### PR TITLE
feat: Added the new api: Tag

### DIFF
--- a/lib/models/Tag/index.ts
+++ b/lib/models/Tag/index.ts
@@ -3,19 +3,19 @@ import mongoose from 'mongoose';
 const TagSchema = new mongoose.Schema({
   parent_id: {
     type: mongoose.Types.ObjectId,
-    require: false,
+    required: false,
   },
   tag: {
-    Type: String,
+    type: String,
     required: true,
   },
   title_id: {
     type: mongoose.Types.ObjectId,
-    require: true,
+    required: false,
   },
   user_id: {
     type: mongoose.Types.ObjectId,
-    require: true,
+    required: true,
   },
 });
 TagSchema.index({ parent_id: 1, title_id: 1, user_id: -1 }, { unique: true });

--- a/lib/models/todo/TodoItems.ts
+++ b/lib/models/todo/TodoItems.ts
@@ -40,7 +40,7 @@ const TodoItemSchema = new mongoose.Schema({
   },
   user_id: {
     type: mongoose.Types.ObjectId,
-    require: true,
+    required: true,
   },
 });
 TodoItemSchema.index({ _id: 1, user_id: -1 }, { unique: true });

--- a/lib/models/todo/TodoNotes.ts
+++ b/lib/models/todo/TodoNotes.ts
@@ -9,11 +9,11 @@ const TodoNoteSchema = new mongoose.Schema({
   },
   title_id: {
     type: mongoose.Types.ObjectId,
-    require: true,
+    required: true,
   },
   user_id: {
     type: mongoose.Types.ObjectId,
-    require: true,
+    required: true,
   },
 });
 

--- a/pages/api/v1/tags/index.tsx
+++ b/pages/api/v1/tags/index.tsx
@@ -1,0 +1,42 @@
+import { databaseConnect } from '@lib/dataConnections/databaseConnection';
+import Tag from '@lib/models/Tag';
+import { TypesQuery } from '@lib/types';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { userInfo } from 'userInfo';
+
+const Tags = async (req: NextApiRequest, res: NextApiResponse) => {
+  await databaseConnect();
+
+  const { method, body } = req;
+
+  const filter = () => {
+    const query: TypesQuery = {};
+    query.user_id = userInfo._id;
+
+    return query;
+  };
+
+  switch (method) {
+    case 'GET':
+      try {
+        const getTags = await Tag.find(filter())
+          .select({ _id: 1, tag: 1, parent_id: 1, title_id: 1 })
+          .lean();
+        res.status(200).json({ success: true, data: getTags });
+      } catch (error) {
+        res.status(400).json({ success: false });
+      }
+      break;
+    case 'POST':
+      try {
+        const createTag = await Tag.create(body);
+        res.status(201).json({ success: true, data: createTag });
+      } catch (error) {
+        res.status(400).json({ success: false });
+      }
+      break;
+    default:
+      res.status(400).json({ success: false });
+  }
+};
+export default Tags;


### PR DESCRIPTION
Added the basic api for Tag for basic GET and POST api request. Due to the api structure, the schema model has been altered to set the `required` to false to `title_id`. There is a situation that user could create a tag without assigning the title so `title_id` should not be required.

Other minor changes:
Fixed the typo that triggers or will trigger the error from `TodoItems` and `TodoNotes` schema.