### PR TITLE
feat: Added the `queryTags` for requesting tag api

### DIFF
--- a/lib/queries/queryTags.ts
+++ b/lib/queries/queryTags.ts
@@ -1,0 +1,41 @@
+import { Tags } from '@lib/types';
+
+export const getDataTags = async () => {
+  const response = await fetch(`/api/v1/tags`);
+  if (!response.ok) throw new Error(response.statusText);
+  return await response.json();
+};
+
+export const getDataTagItem = async (_id: Tags['_id']) => {
+  const response = await fetch(`/api/v1/tags/${_id}`);
+  if (!response.ok) throw new Error(response.statusText);
+  return await response.json();
+};
+
+export const createDataTagItem = async (inputValue: Tags) => {
+  const response = await fetch(`/api/v1/tags`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(inputValue),
+  });
+  if (!response.ok) throw new Error(response.statusText);
+  return await response.json();
+};
+
+export const updateDataTagItem = async (_id: Tags['_id'], inputValue: Tags) => {
+  const response = await fetch(`/api/v1/tags/${_id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(inputValue),
+  });
+  if (!response.ok) throw new Error(response.statusText);
+  return await response.json();
+};
+
+export const deleteDataTagItem = async (_id: Tags['_id']) => {
+  const response = await fetch(`/api/v1/tags/${_id}`, {
+    method: 'DELETE',
+  });
+  if (!response.ok) throw new Error(response.statusText);
+  return await response.json();
+};

--- a/lib/queries/queryTodos.ts
+++ b/lib/queries/queryTodos.ts
@@ -11,15 +11,16 @@ export const getDataTodoIds = async ({
       queries(
         'model=' + model,
         typeof completed !== 'undefined' && 'completed=' + completed,
-        typeof completedFromToday !== 'undefined' &&
-          'completedFromToday=' + completedFromToday,
+        typeof completedFromToday !== 'undefined' && 'completedFromToday=' + completedFromToday,
       ),
   );
+  if (!response.ok) throw new Error(response.statusText);
   return await response.json();
 };
 
 export const getDataTodoItem = async ({ _id }: Pick<Types, '_id'>) => {
   const response = await fetch(`/api/v1/todos/${_id}`);
+  if (!response.ok) throw new Error(response.statusText);
   return await response.json();
 };
 

--- a/lib/queries/queryUsers/querySettings/index.ts
+++ b/lib/queries/queryUsers/querySettings/index.ts
@@ -2,6 +2,7 @@ import { Settings, Users } from '@lib/types';
 
 export const getDataSetting = async (_id: Users['_id']) => {
   const response = await fetch(`/api/v1/users/settings?userId=${_id}`);
+  if (!response.ok) throw new Error(response.statusText);
   return await response.json();
 };
 

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -49,7 +49,7 @@ export interface TypesEditor {
  */
 type CollectTypesArrayObject = Todos & TypesTodo & Settings;
 
-//* Todos
+// Todos
 export interface Todos extends TodosEditors, TodosIds {
   createdDate: Date;
   dueDate: Date | null;
@@ -76,7 +76,18 @@ export interface TypesTodo {
   model: SCHEMA_TODO;
 }
 
-//* Users
+// Tags
+export interface Tags extends TagsIds {
+  parent_id?: OBJECT_ID;
+  title_id?: OBJECT_ID;
+  tag: string;
+}
+
+export interface TagsIds {
+  _id?: OBJECT_ID;
+}
+
+// Users
 export interface Users extends UsersIds {
   email: 'string';
 }


### PR DESCRIPTION
Added the `queryTags` to manage the api call for the `Tags` data schema from the remote database. These consist of create, delete, update, getList, and getItem. Although getItem, which is getting an individual item of the data from `MongoDB` collections, may not be useful due to the nature of the tag module, It may still be necessary to fetch individual tag items.

Added the new type of `Tags` for type checking on `queryTags`.