### PR TITLE
feat: Added `TagList` component with remote and local database

### DIFF
--- a/components/layouts/layoutApp/layoutSideBar/layoutFooter/__test__/footerSidebar.test.tsx
+++ b/components/layouts/layoutApp/layoutSideBar/layoutFooter/__test__/footerSidebar.test.tsx
@@ -1,6 +1,6 @@
 import { renderWithRecoilRoot } from '@lib/utils';
 import { fireEvent, screen } from '@testing-library/react';
-import { FooterSidebar } from '../footerSidebar';
+import { FooterSidebar } from '../footerSideBar';
 
 jest.mock('@components/layouts/layoutApp/layoutLogo', () => ({
   LayoutLogo: () => <div data-testid='layoutLogo' />,

--- a/components/layouts/layoutApp/layoutSideBar/layoutFooter/footerSideBar.tsx
+++ b/components/layouts/layoutApp/layoutSideBar/layoutFooter/footerSideBar.tsx
@@ -1,6 +1,7 @@
 import { DisableButton } from '@buttons/disableButton';
 import { IconButton } from '@buttons/iconButton';
 import { SvgIcon } from '@components/icons/svgIcon';
+import { TagList } from '@components/tags/taglist';
 import { dataButtonCreateTodo } from '@data/dataObjects';
 import {
   ICON_ADD_TASK,
@@ -12,14 +13,14 @@ import {
 } from '@data/materialSymbols';
 import { Transition } from '@headlessui/react';
 import { classNames } from '@lib/utils';
-import { useModalStateOpen } from '@states/modalStates';
 import { atomSidebarOpenMobile, useSidebarOpen } from '@states/layoutStates';
+import { useModalStateOpen } from '@states/modalStates';
 import {
   forwardRef,
-  Fragment,
+  Fragment as BackdropFragment,
   Fragment as CreateTodoFragment,
   Fragment as FooterSidebarFragment,
-  Fragment as BackdropFragment,
+  Fragment,
   Fragment as LayoutLogoFragment,
 } from 'react';
 import { useRecoilCallback } from 'recoil';
@@ -32,7 +33,7 @@ const navigation = [
   { name: 'Reports', href: '#', icon: ICON_EVENT_AVAILABLE, current: false },
 ];
 
-export const FooterSidebar = forwardRef<HTMLDivElement>((Props, ref) => {
+export const FooterSidebar = forwardRef<HTMLDivElement>((_, ref) => {
   const openModal = useModalStateOpen(undefined);
   const setSidebarOpen = useSidebarOpen();
   const isSidebarMobileOpen = useRecoilCallback(({ snapshot }) => () => {
@@ -119,6 +120,7 @@ export const FooterSidebar = forwardRef<HTMLDivElement>((Props, ref) => {
                   {item.name}
                 </a>
               ))}
+              <TagList />
             </nav>
           </div>
         </div>

--- a/components/layouts/layoutApp/layoutSideBar/layoutFooter/index.tsx
+++ b/components/layouts/layoutApp/layoutSideBar/layoutFooter/index.tsx
@@ -5,7 +5,7 @@ import { classNames } from '@lib/utils';
 import { selectorSidebarOpen } from '@states/layoutStates';
 import { Fragment as FooterBodyFragment, Fragment, Fragment as LayoutFooterFragment } from 'react';
 import { useRecoilValue } from 'recoil';
-import { FooterSidebar } from './footerSidebar';
+import { FooterSidebar } from './footerSideBar';
 
 export const LayoutFooter = ({ children }: Pick<Types, 'children'>) => {
   const isSidebarOpen = useRecoilValue(selectorSidebarOpen);

--- a/components/tags/taglist.tsx
+++ b/components/tags/taglist.tsx
@@ -1,0 +1,17 @@
+import { atomQueryTags } from '@states/atomQuries';
+import { Fragment } from 'react';
+import { useRecoilValue } from 'recoil';
+
+export const TagList = () => {
+  const tagList = useRecoilValue(atomQueryTags);
+
+  return (
+    <Fragment>
+      <ul>
+        {tagList.map((tag) => (
+          <li key={tag._id}>{tag.name}</li>
+        ))}
+      </ul>
+    </Fragment>
+  );
+};

--- a/lib/data/stateArrayObjects.tsx
+++ b/lib/data/stateArrayObjects.tsx
@@ -1,3 +1,4 @@
+import { getDataTags } from '@lib/queries/queryTags';
 import { getDataTodoIds } from '@lib/queries/queryTodos';
 import { TypesIDB, TypesNotification } from 'lib/types';
 import {
@@ -74,6 +75,10 @@ export const DATA_IDB: TypesIDB[] = [
     store: IDB_STORE['todos'],
   },
   {
+    name: IDB['Tags'],
+    store: IDB_STORE['tags'],
+  },
+  {
     name: IDB['Users'],
     store: IDB_STORE['users'],
   },
@@ -89,6 +94,11 @@ export const cachedData = () => {
       key: CACHED_DATA['getDataTodoIds'],
       cachedTimer: new Date().getTime(),
       data: getDataTodoIds({ model: SCHEMA_TODO['todoItem'] }),
+    },
+    {
+      key: CACHED_DATA['getDataTags'],
+      cachedTimer: new Date().getTime(),
+      data: getDataTags(),
     },
   ];
 };

--- a/lib/data/stateObjects.tsx
+++ b/lib/data/stateObjects.tsx
@@ -71,6 +71,7 @@ export const CONDITION = {
 export type IDB = typeof IDB[keyof typeof IDB];
 export const IDB = {
   Todos: 'Todos',
+  Tags: 'Tags',
   Users: 'Users',
   Cache: 'Cache',
 } as const;
@@ -78,6 +79,7 @@ export const IDB = {
 export type IDB_STORE = typeof IDB_STORE[keyof typeof IDB_STORE];
 export const IDB_STORE = {
   todos: 'todos',
+  tags: 'tags',
   users: 'users',
   settings: 'settings',
   cache: 'cache',
@@ -104,4 +106,5 @@ export const SCHEMA_TODO = {
 export type CACHED_DATA = typeof CACHED_DATA[keyof typeof CACHED_DATA];
 export const CACHED_DATA = {
   getDataTodoIds: 'getDataTodoIds',
+  getDataTags: 'getDataTags',
 } as const;

--- a/lib/models/Tag/index.ts
+++ b/lib/models/Tag/index.ts
@@ -5,7 +5,7 @@ const TagSchema = new mongoose.Schema({
     type: mongoose.Types.ObjectId,
     required: false,
   },
-  tag: {
+  name: {
     type: String,
     required: true,
   },

--- a/lib/states/Effects/prefetchQueryEffect.tsx
+++ b/lib/states/Effects/prefetchQueryEffect.tsx
@@ -1,4 +1,4 @@
-import { atomQueryTodoIdsCompleted, atomQueryTodoIds } from '@states/atomQuries';
+import { atomQueryTags, atomQueryTodoIds, atomQueryTodoIdsCompleted } from '@states/atomQuries';
 import { atomSelectorTodoIdsCompleted } from '@states/todoStates';
 import { useEffect } from 'react';
 import { useRecoilCallback, waitForAll } from 'recoil';
@@ -6,7 +6,7 @@ import { useRecoilCallback, waitForAll } from 'recoil';
 export const PrefetchQueryEffect = () => {
   const prefetchQuery = useRecoilCallback(({ snapshot, set }) => async () => {
     const [todoIdsCompleted] = await snapshot.getPromise(
-      waitForAll([atomQueryTodoIdsCompleted, atomQueryTodoIds]),
+      waitForAll([atomQueryTodoIdsCompleted, atomQueryTodoIds, atomQueryTags]),
     );
     set(atomSelectorTodoIdsCompleted, todoIdsCompleted);
   });

--- a/lib/states/atomQuries/index.tsx
+++ b/lib/states/atomQuries/index.tsx
@@ -1,14 +1,15 @@
 import { getCachedData } from '@data/cachedApiRequest';
 import { CACHED_DATA, IDB_STORE, SCHEMA_TODO } from '@data/stateObjects';
 import { queryEffect } from '@effects/atomEffects/queryEffect';
+import { getDataTags } from '@lib/queries/queryTags';
 import { getDataTodoIds, getDataTodoItem } from '@lib/queries/queryTodos';
 import { getDataUserId } from '@lib/queries/queryUsers';
 import { getDataSetting } from '@lib/queries/queryUsers/querySettings';
-import { Settings, Todos, TodosIds, Users } from '@lib/types';
+import { Settings, Tags, Todos, TodosIds, Users } from '@lib/types';
 import { atom, atomFamily } from 'recoil';
 
 /**
- * * Query Todos
+ * Query Todos
  * Defining `storeName` will automatically apply the predefined IndexedDB name.
  */
 
@@ -52,6 +53,22 @@ export const atomQueryTodoItem = atomFamily<Todos, Todos['_id']>({
       queryKey: todoId!.toString(),
       queryFunction: () => getDataTodoItem({ _id: todoId }),
       refetchOnMutation: true,
+    }),
+  ],
+});
+
+/**
+ * Query Tags
+ */
+export const atomQueryTags = atom<Tags[]>({
+  key: 'atomQueryTags',
+  effects: [
+    queryEffect({
+      storeName: IDB_STORE['tags'],
+      queryKey: 'tags',
+      queryFunction: () => getDataTags(),
+      cachedQueryFunction: () => getCachedData(CACHED_DATA['getDataTags']),
+      refetchOnMutation: false, // fetching the list of tags is too expensive.
     }),
   ],
 });

--- a/lib/states/layoutStates.tsx
+++ b/lib/states/layoutStates.tsx
@@ -2,7 +2,6 @@ import { BREAKPOINT } from '@data/stateObjects';
 import { atom, RecoilValue, selector, useRecoilCallback } from 'recoil';
 import { mediaQueryEffect } from './effects/atomEffects';
 import { atomMediaQuery } from './miscStates';
-
 /**
  * Atoms
  **/
@@ -56,7 +55,7 @@ export const selectorSidebarOpen = selector({
 export const useSidebarOpen = () => {
   return useRecoilCallback(({ snapshot, set }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
-    // Under the mediaQuery meidum ('md') will return false and will return true over mediaQuery
+    // Under the mediaQuery medium ('md') will return false and will return true over mediaQuery
     if (!get(atomMediaQuery(BREAKPOINT['md'])))
       return set(atomSidebarOpenMobile, (event) => !event);
     set(atomSidebarOpenSetting, (event) => !event);

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -80,7 +80,7 @@ export interface TypesTodo {
 export interface Tags extends TagsIds {
   parent_id?: OBJECT_ID;
   title_id?: OBJECT_ID;
-  tag: string;
+  name: string;
 }
 
 export interface TagsIds {

--- a/pages/api/v1/tags/index.tsx
+++ b/pages/api/v1/tags/index.tsx
@@ -20,7 +20,7 @@ const Tags = async (req: NextApiRequest, res: NextApiResponse) => {
     case 'GET':
       try {
         const getTags = await Tag.find(filter())
-          .select({ _id: 1, tag: 1, parent_id: 1, title_id: 1 })
+          .select({ _id: 1, name: 1, parent_id: 1, title_id: 1 })
           .lean();
         res.status(200).json({ success: true, data: getTags });
       } catch (error) {


### PR DESCRIPTION
Created `TagList` component, which renders the list of tags. For state management `atom`, `atomQueryTags`, is created. As the name of atom suggested, this atom can query the data from the database and integrate fetched data into indexedDB.

Unlike `atomTodoIds`, the tag's atom will fetch all the data at once from the database. This might cause the performance drawback as data gets bigger, and to improve it, the atomQueryTags will be prefetched with `PrefetchQueryEffect` component. The component will prefetch any data within the list prior to the component rendering (or mounting).

Prefetching items may cause multiple fetches with the same data set. To prevent that, option for `getCachedData` is used within the `queryEffect` of aftereffect.

Other minor changes:
1. Added the tag types
2. Updated TagSchema.