### PR TITLE
fix: Fixed the typescript naming issues due to old file names

### DIFF
--- a/components/layouts/layoutApp/layoutSideBar/layoutFooter/__test__/footerSidebar.test.tsx
+++ b/components/layouts/layoutApp/layoutSideBar/layoutFooter/__test__/footerSidebar.test.tsx
@@ -1,6 +1,6 @@
 import { renderWithRecoilRoot } from '@lib/utils';
 import { fireEvent, screen } from '@testing-library/react';
-import { FooterSidebar } from '../footerSideBar';
+import { FooterSidebar } from '../footerSidebar';
 
 jest.mock('@components/layouts/layoutApp/layoutLogo', () => ({
   LayoutLogo: () => <div data-testid='layoutLogo' />,

--- a/components/layouts/layoutApp/layoutSideBar/layoutFooter/footerSideBar.tsx
+++ b/components/layouts/layoutApp/layoutSideBar/layoutFooter/footerSideBar.tsx
@@ -1,7 +1,7 @@
 import { DisableButton } from '@buttons/disableButton';
 import { IconButton } from '@buttons/iconButton';
 import { SvgIcon } from '@components/icons/svgIcon';
-import { TagList } from '@components/tags/taglist';
+import { TagList } from '@components/tags/tagList';
 import { dataButtonCreateTodo } from '@data/dataObjects';
 import {
   ICON_ADD_TASK,

--- a/components/layouts/layoutApp/layoutSideBar/layoutFooter/index.tsx
+++ b/components/layouts/layoutApp/layoutSideBar/layoutFooter/index.tsx
@@ -5,7 +5,7 @@ import { classNames } from '@lib/utils';
 import { selectorSidebarOpen } from '@states/layoutStates';
 import { Fragment as FooterBodyFragment, Fragment, Fragment as LayoutFooterFragment } from 'react';
 import { useRecoilValue } from 'recoil';
-import { FooterSidebar } from './footerSideBar';
+import { FooterSidebar } from './footerSidebar';
 
 export const LayoutFooter = ({ children }: Pick<Types, 'children'>) => {
   const isSidebarOpen = useRecoilValue(selectorSidebarOpen);


### PR DESCRIPTION
While Typescript compiles, the old file names were still existing and cause the mismatched naming error. With the command `tsc --build --clean`, the Typescript cleans the intermediate files while compiling. It wipes off all the `.js` files generated by `Typescript Compiler`.