### PR TITLE
fix: Fixed the typescript's filename path casing issue

### DIFF
--- a/components/layouts/layoutApp/layoutSideBar/layoutFooter/__test__/footerSidebar.test.tsx
+++ b/components/layouts/layoutApp/layoutSideBar/layoutFooter/__test__/footerSidebar.test.tsx
@@ -2,7 +2,7 @@ import { renderWithRecoilRoot } from '@lib/utils';
 import { fireEvent, screen } from '@testing-library/react';
 import { FooterSidebar } from '../footerSidebar';
 
-jest.mock('@components/layouts/layoutApp/layoutLogo', () => ({
+jest.mock('@layouts/layoutApp/layoutLogo', () => ({
   LayoutLogo: () => <div data-testid='layoutLogo' />,
 }));
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,6 +26,7 @@ const customJestConfig = {
     '^@data/(.*)$': ['<rootDir>/lib/data/$1'],
     '^@types/(.*)$': ['<rootDir>/lib/types/$1'],
     '^@lib/(.*)$': ['<rootDir>/lib/$1'],
+    '^@layouts/(.*)$': ['<rootDir>/components/layouts/$1'],
     '^@buttons/(.*)$': ['<rootDir>/components/ui/buttons/$1'],
     '^@dropdowns/(.*)$': ['<rootDir>/components/ui/dropdowns/$1'],
     '^@inputs/(.*)$': ['<rootDir>/components/ui/inputs/$1'],

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,5 @@
-import { LayoutHome } from '@components/layouts/layoutHome';
 import { PrefetchQueryEffect } from '@effects/prefetchQueryEffect';
+import { LayoutHome } from '@layouts/layoutHome';
 import type { AppProps } from 'next/app';
 import { RecoilRoot } from 'recoil';
 import '../styles/globals.css';

--- a/pages/app.tsx
+++ b/pages/app.tsx
@@ -1,7 +1,7 @@
-import { LayoutApp } from '@components/layouts/layoutApp';
 import { ErrorState } from '@components/loadable/errorState';
 import { LoadingState } from '@components/loadable/loadingStates';
 import { dataLoadingTodos } from '@data/dataObjects';
+import { LayoutApp } from '@layouts/layoutApp';
 import dynamic from 'next/dynamic';
 import { ErrorBoundary } from 'react-error-boundary';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
       "@states/*": ["lib/states/*"],
       "@data/*": ["lib/data/*"],
       "@lib/*": ["lib/*"],
+      "@layouts/*": ["components/layouts/*"],
       "@buttons/*": ["components/ui/buttons/*"],
       "@dropdowns/*": ["components/ui/dropdowns/*"],
       "@inputs/*": ["components/ui/inputs/*"],


### PR DESCRIPTION
> The origin error message kept occurring due to the casing issue:
'File name differs from already included file name only in casing' on the relative path with the same casing.'

Although changing the filename and reverting to the original name seems temporarily fixed the issue, the same issues keep emerging as a language server is restarted.

> Example of issue:
File path is `path/file/name`
Typescript forcing the path as `path/file/Name` by triggering an error

> Steps to resolve the issues:
1. Restart the typescript-language-server (does not fix)
2. Delete node cache (does not fix)
3. set `forceConsistentCasingInFileNames` to false then set it to true (fixed the issue)

> Although it seems to have fixed the issue, it is unclear which is
fundamentally fixed, and the issue might reappear shortly.

Minor other changes:
1. Added the `@layouts` path alias to `jest.config` and `tsconfig`
2. Updated `@layouts` alias path