### PR TITLE
fix: Fixed the missing unique key on the repeating component

### DIFF
--- a/components/loadable/loadingStates/index.tsx
+++ b/components/loadable/loadingStates/index.tsx
@@ -9,7 +9,12 @@ export const LoadingState = ({
 }) => {
   return (
     <Fragment>
-      <div className={classNames(margin, space)}>{Array(repeatingCount).fill(loadingSkeleton)}</div>
+      <div className={classNames(margin, space)}>
+        {/* It is reasonable to use index as unique key as this component is static once prop is set */}
+        {[...Array(repeatingCount)].map((_, index) => (
+          <ul key={index}>{loadingSkeleton}</ul>
+        ))}
+      </div>
     </Fragment>
   );
 };


### PR DESCRIPTION
Rewrote the `loadingStates` component to fix the error that is occurred with the missing unique key.

The method to apply is to use `Array.map` with the unique key of index. In the normal situation, using the index as the unique key is not recommended way as it negatively impacts the performance whenever the list is updated or changed. Since the repeating component here only repeats without any update (after the prop is set), using the index as the unique key will not negatively impact the performance.