### PR TITLE
fix: Fixed the double fetches issues and others

### DIFF
--- a/lib/states/utilsStates.tsx
+++ b/lib/states/utilsStates.tsx
@@ -1,10 +1,10 @@
 import { CATCH_MODAL, CONDITION } from '@data/stateObjects';
 import { Todos } from '@lib/types';
 import equal from 'fast-deep-equal/react';
-import { atomFamily, RecoilValue, useRecoilCallback, useRecoilSnapshot } from 'recoil';
+import { atomFamily, RecoilValue, useRecoilCallback, useRecoilValue } from 'recoil';
 import { atomQueryTodoItem } from './atomQueries';
 import { atomTodoModalMini, atomTodoModalOpen } from './modalStates';
-import { atomSelectorTodoItem, atomTodoNew } from './todoStates';
+import { atomTodoNew } from './todoStates';
 
 /**
  * Atoms
@@ -30,22 +30,21 @@ export const useGetWithRecoilCallback = () => {
 // useRecoilSnap is the right hook to check the state of atom.
 
 export const useConditionCheckCreateModalOpen = () => {
-  const snapshot = useRecoilSnapshot();
-  const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
-  return get(atomTodoModalOpen(undefined)) || get(atomTodoModalMini(undefined));
+  const todoModalOpen = useRecoilValue(atomTodoModalOpen(undefined));
+  const todoModalMiniOpen = useRecoilValue(atomTodoModalMini(undefined));
+  return todoModalOpen || todoModalMiniOpen;
 };
 
 export const useConditionCheckTodoTitleEmpty = () => {
-  const snapshot = useRecoilSnapshot();
-  const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
-  return typeof get(atomTodoNew).title === 'undefined' || get(atomTodoNew).title.trim() === '';
+  const newTodo = useRecoilValue(atomTodoNew);
+  return typeof newTodo.title === 'undefined' || newTodo.title.trim() === '';
 };
 
 export const useConditionCompareTodoItemsEqual = (_id: Todos['_id']) => {
-  const snapshot = useRecoilSnapshot();
-  const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
   if (typeof _id === 'undefined') return;
-  return equal(get(atomQueryTodoItem(_id)), get(atomSelectorTodoItem(_id)));
+  const todoItem = useRecoilValue(atomQueryTodoItem(_id));
+  const selectorTodoItem = useRecoilValue(atomQueryTodoItem(_id));
+  return equal(todoItem, selectorTodoItem);
 };
 
 export const useConditionalCheckState = (_id: Todos['_id']) => {


### PR DESCRIPTION
Recoil `atomQueryTodoItem` fetches data twice for every initial fetch. The cause was the use of Recoil's hook called `useRecoilSnapshot`. As warned in the document, this hook will trigger the component re-render for all Recoil's state changes. Therefore, the `atomQueryTodoItem` is re-triggered as the initial fetch happens.

The issue has been fixed by using `useRecoilValue` instead of `useRecoilSnapshot`.

Other minor changes:
Updated the hooks that are using `useRecoilSnapshot` with `useRecoilValue`.

More info on `useRecoilSnapshot`:
https://recoiljs.org/docs/api-reference/core/useRecoilSnapshot