### PR TITLE
fix: Fixed the todoItem comparing issue

### DIFF
--- a/lib/states/atomQueries/index.tsx
+++ b/lib/states/atomQueries/index.tsx
@@ -5,7 +5,7 @@ import { getDataTags } from '@lib/queries/queryTags';
 import { getDataTodoIds, getDataTodoItem } from '@lib/queries/queryTodos';
 import { getDataUserId } from '@lib/queries/queryUsers';
 import { getDataSetting } from '@lib/queries/queryUsers/querySettings';
-import { Settings, Tags, Todos, TodosIds, Users } from '@lib/types';
+import { Settings, Tags, Todos, TodoIds, Users } from '@lib/types';
 import { atom, atomFamily } from 'recoil';
 
 /**
@@ -13,7 +13,7 @@ import { atom, atomFamily } from 'recoil';
  * Defining `storeName` will automatically apply the predefined IndexedDB name.
  */
 
-export const atomQueryTodoIds = atom<TodosIds[]>({
+export const atomQueryTodoIds = atom<TodoIds[]>({
   key: 'atomQueryTodoIds',
   effects: [
     queryEffect({
@@ -26,7 +26,7 @@ export const atomQueryTodoIds = atom<TodosIds[]>({
   ],
 });
 
-export const atomQueryTodoIdsCompleted = atom<TodosIds[]>({
+export const atomQueryTodoIdsCompleted = atom<TodoIds[]>({
   key: 'atomQueryTodoIdsCompleted',
   effects: [
     queryEffect({

--- a/lib/states/todoStates.tsx
+++ b/lib/states/todoStates.tsx
@@ -1,6 +1,6 @@
 import { NOTIFICATION, CATCH_MODAL } from '@data/stateObjects';
 import { createDataNewTodo, updateDataTodo, deleteDataTodo, completeDataTodo } from '@lib/queries/queryTodos';
-import { Todos, TodosIds } from '@lib/types';
+import { Todos, TodoIds } from '@lib/types';
 import { atom, atomFamily, selectorFamily, selector, useRecoilCallback, RecoilValue } from 'recoil';
 import { atomQueryTodoItem, atomQueryTodoIdsCompleted, atomQueryTodoIds } from './atomQueries';
 import { atomNetworkStatusEffect } from './miscStates';
@@ -56,7 +56,7 @@ export const selectorTaskCompleteCapacity = selector({
   },
 });
 
-export const atomSelectorTodoIdsCompleted = atom<TodosIds[]>({
+export const atomSelectorTodoIdsCompleted = atom<TodoIds[]>({
   key: 'atomSelectorTodoIdsCompleted',
   default: selector({
     key: 'selectorTodoIdsCompleted',

--- a/lib/states/utilsStates.tsx
+++ b/lib/states/utilsStates.tsx
@@ -4,7 +4,7 @@ import equal from 'fast-deep-equal/react';
 import { atomFamily, RecoilValue, useRecoilCallback, useRecoilValue } from 'recoil';
 import { atomQueryTodoItem } from './atomQueries';
 import { atomTodoModalMini, atomTodoModalOpen } from './modalStates';
-import { atomTodoNew } from './todoStates';
+import { atomSelectorTodoItem, atomTodoNew } from './todoStates';
 
 /**
  * Atoms
@@ -43,7 +43,7 @@ export const useConditionCheckTodoTitleEmpty = () => {
 export const useConditionCompareTodoItemsEqual = (_id: Todos['_id']) => {
   if (typeof _id === 'undefined') return;
   const todoItem = useRecoilValue(atomQueryTodoItem(_id));
-  const selectorTodoItem = useRecoilValue(atomQueryTodoItem(_id));
+  const selectorTodoItem = useRecoilValue(atomSelectorTodoItem(_id));
   return equal(todoItem, selectorTodoItem);
 };
 

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -50,7 +50,7 @@ export interface TypesEditor {
 type CollectTypesArrayObject = Todos & TypesTodo & Settings;
 
 // Todos
-export interface Todos extends TodosEditors, TodosIds {
+export interface Todos extends TodosEditors, TodoIds {
   createdDate: Date;
   dueDate: Date | null;
   completedDate: Date | null;
@@ -59,7 +59,7 @@ export interface Todos extends TodosEditors, TodosIds {
   priorityRankScore: number;
 }
 
-export interface TodosIds {
+export interface TodoIds {
   _id?: OBJECT_ID;
 }
 
@@ -70,7 +70,7 @@ export interface TodosEditors {
 
 export interface TypesTodo {
   todoItem: Todos;
-  todo: TodosIds;
+  todo: TodoIds;
   index: number;
   completedFromToday: number;
   model: SCHEMA_TODO;


### PR DESCRIPTION
There was issue caused from the previous commit: tpAtalas@1cd026b9b58280fcd1cd034d4c73713389b88aa9 Comparing todoItems must be composed of `atomQueryTodoItem` and `atomSelectorTodoItem`. The previous commit mistakenly added the comparing of the same `atomQueryTodoItem`

By changing the `atomQueryTodoItem` to `atomSelectorTodoItem` fixed the issue.