### PR TITLE
feat: Added the delay to the LoadingState

### DIFF
--- a/components/loadable/loadingStates/index.tsx
+++ b/components/loadable/loadingStates/index.tsx
@@ -1,20 +1,31 @@
 import { TypesDataLoadingState } from '@lib/types/typesData';
 import { classNames } from '@lib/utils';
-import { Fragment } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 
 export const LoadingState = ({
-  data: { margin, space, loadingSkeleton, repeatingCount },
+  data: { margin, space, loadingSkeleton, repeatingCount, delay = 150 },
 }: {
   data: TypesDataLoadingState;
 }) => {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setShow(true), delay);
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [delay]);
+
   return (
     <Fragment>
-      <div className={classNames(margin, space)}>
-        {/* It is reasonable to use index as unique key as this component is static once prop is set */}
-        {[...Array(repeatingCount)].map((_, index) => (
-          <ul key={index}>{loadingSkeleton}</ul>
-        ))}
-      </div>
+      {show && (
+        <div className={classNames(margin, space)}>
+          {/* It is reasonable to use index as unique key as this component is static once prop is set */}
+          {[...Array(repeatingCount)].map((_, index) => (
+            <ul key={index}>{loadingSkeleton}</ul>
+          ))}
+        </div>
+      )}
     </Fragment>
   );
 };

--- a/lib/data/stateArrayObjects.tsx
+++ b/lib/data/stateArrayObjects.tsx
@@ -115,7 +115,7 @@ export const DATA_SIDEBAR_MENU = [
     tooltip: 'Important todos',
     icon: ICON_LABEL_IMPORTANT,
     iconActive: ICON_LABEL_IMPORTANT_FILL,
-    iconColor: 'fill-yellow-600',
+    iconColor: 'fill-yellow-500',
     path: '/app/important',
   },
   {

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -201,6 +201,7 @@ export interface TypesUi {
 export interface TypesLoadings {
   loadingSkeleton: Types['children'];
   repeatingCount: number;
+  delay: number;
 }
 
 export interface TypesStyleAttributes {

--- a/lib/types/typesData.ts
+++ b/lib/types/typesData.ts
@@ -52,7 +52,5 @@ export type TypesDataMinimizedModalTransition = Partial<
   Pick<Types, 'positionX' | 'positionY' | 'minimizedModalPadding'>
 >;
 
-export type TypesDataLoadingState = Pick<
-  Types,
-  'loadingSkeleton' | 'repeatingCount' | 'margin' | 'space'
->;
+export type TypesDataLoadingState = Partial<Pick<Types, 'delay'>> &
+  Pick<Types, 'loadingSkeleton' | 'repeatingCount' | 'margin' | 'space'>;


### PR DESCRIPTION
Due to the fact that cached data is available as soon as possible the suspense only briefly runs that leads to the flickering of suspense. This is not the best UX, and delaying the suspense to prevent the flickering issue. There is still a shaky behavior (very minor but still existing) that can be fixed near future by implementing useTransition with another LoadingState.

Other minor change:
There was minor color adjustment on iconColor of DATA_SIDEBAR_MENU