### PR TITLE
feat: Disabled the Update button upon completing todoItem

### DIFF
--- a/lib/states/utilsStates.tsx
+++ b/lib/states/utilsStates.tsx
@@ -44,7 +44,9 @@ export const useConditionCompareTodoItemsEqual = (_id: Todos['_id']) => {
   if (typeof _id === 'undefined') return;
   const todoItem = useRecoilValue(atomQueryTodoItem(_id));
   const selectorTodoItem = useRecoilValue(atomSelectorTodoItem(_id));
-  return equal(todoItem, selectorTodoItem);
+  const todoItemCompletedEqual = equal(todoItem.completed, selectorTodoItem.completed);
+  // Disable update button if completed
+  return !todoItemCompletedEqual ? true : equal(todoItem, selectorTodoItem);
 };
 
 export const useConditionalCheckState = (_id: Todos['_id']) => {


### PR DESCRIPTION
Added the additional condition to disable the updateButton on todoItemModal whenever the todoItem is marked as completed. This behavior is necessary due to the fact that completing todo does not take draft-editing-mode.

*draft-editing-mode: Whenever user edit in this mode, no update is actually made until user clicks the button, update. So user can anytime change his/her mind or cancel the update.