### PR TITLE
fix: Fixed the issue that Note is not updated if not exist

### DIFF
--- a/pages/api/v1/todos/[todoId].tsx
+++ b/pages/api/v1/todos/[todoId].tsx
@@ -76,6 +76,7 @@ const TodosById = async (req: NextApiRequest, res: NextApiResponse) => {
         todoItem,
         {
           session: session,
+          upsert: true,
           new: true,
           runValidators: true,
         },
@@ -85,6 +86,7 @@ const TodosById = async (req: NextApiRequest, res: NextApiResponse) => {
         todoNote,
         {
           session: session,
+          upsert: true,
           new: true,
           runValidators: true,
         },


### PR DESCRIPTION
In previous commits, the database structure had been changed in MongoDB by separating todoItem and todoNote into different collections. The purpose was to clearly distinguish the size of each document. (todoNote is the one of item that can't be predicted).

Due to the separation of collections, there is situation that only todoItem's title exists but todoNote is not. The problem occurs whenever the todo only has a title without note, and could not proceed to create document within todoNote collection into MongoDB. This happens because API could not create another document with `findByIdAndUpdate`.

The resolution is to give `upsert: true` to the `findByIdAndUpdate`, which option enables the updating to create new document if it does not exist.