### PR TITLE
fix: Fixed the wrong place of cursor position

### DIFF
--- a/lib/states/Effects/editorAutoFocusEffect.tsx
+++ b/lib/states/Effects/editorAutoFocusEffect.tsx
@@ -1,10 +1,11 @@
-import { CATCH_MODAL } from '@data/stateObjects';
+import { CATCH_MODAL, PATHNAME } from '@data/stateObjects';
 import { CustomEditor } from '@lib/types/typesSlate';
 import { atomCatch } from '@states/utilsStates';
 import { Types } from 'lib/types';
+import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
-import { Path, Transforms } from 'slate';
+import { Editor, Transforms } from 'slate';
 import { ReactEditor } from 'slate-react';
 
 export const EditorAutoFocusEffect = ({
@@ -14,18 +15,20 @@ export const EditorAutoFocusEffect = ({
   autoFocus: Types['autoFocus'];
   editor: CustomEditor;
 }) => {
+  const router = useRouter();
+  const completedPath = router.asPath === PATHNAME['completed'];
   const isCatchConfirmModal = useRecoilValue(atomCatch(CATCH_MODAL.confirmModal));
 
   useEffect(() => {
     ReactEditor.blur(editor);
 
-    if (!autoFocus || isCatchConfirmModal) return;
+    if (!autoFocus || isCatchConfirmModal || completedPath) return;
 
     setTimeout(() => {
       ReactEditor.focus(editor);
-      Transforms.select(editor, { path: Path.next([0, 0]), offset: 0 });
+      Transforms.select(editor, Editor.end(editor, []));
     }, 100);
-  }, [autoFocus, editor, isCatchConfirmModal]);
+  }, [autoFocus, completedPath, editor, isCatchConfirmModal]);
 
   return null;
 };


### PR DESCRIPTION
Fixed the cursor position of wrong position whenever the todoItemModal is open to edit the text. The initial position of the cursor was before the text. Now the cursor is positioned to the after the text.

Before: | example text
After: example text |