### PR TITLE
feat: Added the itemLabelModal and its logics

### DIFF
--- a/components/labels/labelItem.tsx
+++ b/components/labels/labelItem.tsx
@@ -1,0 +1,26 @@
+import { IconButton } from '@buttons/iconButton';
+import { ICON_MORE_VERT } from '@data/materialSymbols';
+import { Types } from '@lib/types';
+import { ItemLabelModal } from '@modals/labelModals/labelModal/itemLabelModal';
+import { atomLabelModalOpen } from '@states/modalStates';
+import { Fragment, Fragment as LabelModalFragment } from 'react';
+import { useSetRecoilState } from 'recoil';
+
+export const LabelItem = ({ label }: Pick<Types, 'label'>) => {
+  const setLabelModal = useSetRecoilState(atomLabelModalOpen(label._id));
+
+  return (
+    <Fragment>
+      <div className='item-center flex flex-row justify-between'>
+        <div className='py-2'>{label.name}</div>
+        <IconButton
+          data={{ path: ICON_MORE_VERT }}
+          onClick={() => setLabelModal(true)}
+        />
+      </div>
+      <LabelModalFragment>
+        <ItemLabelModal label={label} />
+      </LabelModalFragment>
+    </Fragment>
+  );
+};

--- a/components/labels/labelList.tsx
+++ b/components/labels/labelList.tsx
@@ -4,6 +4,7 @@ import { ICON_ADD } from '@data/materialSymbols';
 import { useLabelModalStateOpen } from '@states/modalStates';
 import { Fragment } from 'react';
 import { useRecoilValue } from 'recoil';
+import { LabelItem } from './labelItem';
 
 export const LabelList = () => {
   const labelList = useRecoilValue(atomQueryLabels);
@@ -21,7 +22,9 @@ export const LabelList = () => {
         </div>
         <ul>
           {labelList.map((label) => (
-            <li key={label._id}>{label.name}</li>
+            <li key={label._id?.toString()}>
+              <LabelItem label={label} />
+            </li>
           ))}
         </ul>
       </div>

--- a/components/ui/buttons/disableButton.tsx
+++ b/components/ui/buttons/disableButton.tsx
@@ -1,14 +1,17 @@
 import { TypesDataButton } from '@lib/types/typesData';
-import { useConditionalCheckState } from '@states/utilsStates';
+import { useLabelConditionalCheckState, useTodoConditionalCheckState } from '@states/utilsStates';
 import { Types } from 'lib/types';
 import { Button } from './button';
 
 type Props = { data: TypesDataButton } & Partial<
-  Pick<Types, 'className' | 'onClick' | 'condition' | 'children' | 'todo'>
+  Pick<Types, 'className' | 'onClick' | 'condition' | 'children' | 'todo' | 'label'>
 >;
 
-export const DisableButton = ({ todo, data, onClick, children = data.name }: Props) => {
-  const condition = useConditionalCheckState(todo?._id);
+export const DisableButton = ({ todo, label, data, onClick, children = data.name }: Props) => {
+  const condition =
+    typeof label === 'undefined'
+      ? useTodoConditionalCheckState(todo?._id)
+      : useLabelConditionalCheckState(label._id);
   const conditionalRendering = typeof data.condition !== 'undefined' && condition(data.condition);
 
   return (

--- a/components/ui/modals/labelModals/labelModal/index.tsx
+++ b/components/ui/modals/labelModals/labelModal/index.tsx
@@ -6,31 +6,39 @@ import {
   dataButtonTodoModalClose,
 } from '@data/dataObjects';
 import { classNames } from '@lib/utils';
-import { atomLabelNew, useLabelStateAdd } from '@states/labelStates';
+import {
+  atomLabelNew,
+  atomSelectorLabelItem,
+  useLabelStateAdd,
+  useLabelValueUpdate,
+} from '@states/labelStates';
 import { atomLabelModalOpen, useLabelModalStateClose } from '@states/modalStates';
-import ObjectID from 'bson-objectid';
 import { Types } from 'lib/types';
 import { Fragment as LabelModalFragment, useRef } from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import { Button as CancelButton } from '../../../buttons/button';
 import { Divider as PlainLineDivider } from '../../../dividers/divider';
 import { ModalTransitionChild } from '../../modal/modalTransition/modalTransitionChild';
 import { ModalTransitionRoot } from '../../modal/modalTransition/modalTransitionRoot';
 
 type Props = Partial<
-  Pick<Types, 'todo' | 'children' | 'headerContents' | 'footerButtons' | 'headerButtons'>
+  Pick<Types, 'label' | 'children' | 'headerContents' | 'footerButtons' | 'headerButtons'>
 >;
 
 export const LabelModal = ({
-  headerContents = 'Create New Label',
+  label,
   footerButtons,
   children,
+  headerContents = 'Create New Label',
 }: Props) => {
-  const isLabelModalOpen = useRecoilValue(atomLabelModalOpen(undefined));
-  const closeModal = useLabelModalStateClose(undefined);
+  const isLabelModalOpen = useRecoilValue(atomLabelModalOpen(label?._id));
+  const closeModal = useLabelModalStateClose(label?._id);
   const initialFocusDiv = useRef<HTMLInputElement>(null);
-  const labelItem = useRecoilValue(atomLabelNew);
-  const setLabelItem = useSetRecoilState(atomLabelNew);
+  const labelItem =
+    typeof label === 'undefined'
+      ? useRecoilValue(atomLabelNew)
+      : useRecoilValue(atomSelectorLabelItem(label._id));
+  const updateLabelItem = useLabelValueUpdate(label);
   const addLabel = useLabelStateAdd();
 
   return (
@@ -59,13 +67,7 @@ export const LabelModal = ({
               type='text'
               name='label'
               value={labelItem.name}
-              onChange={(event) =>
-                setLabelItem({
-                  ...labelItem,
-                  name: event.target.value,
-                  _id: ObjectID().toHexString(),
-                })
-              }
+              onChange={(event) => updateLabelItem(event.target.value)}
               ref={initialFocusDiv}
             />
           </div>

--- a/components/ui/modals/labelModals/labelModal/itemLabelModal.tsx
+++ b/components/ui/modals/labelModals/labelModal/itemLabelModal.tsx
@@ -1,0 +1,26 @@
+import { DisableButton } from '@buttons/disableButton';
+import { dataButtonLabelModalUpdateLabel } from '@data/dataObjects';
+import { Types } from '@lib/types';
+import { useLabelStateUpdate } from '@states/labelStates';
+import { Fragment } from 'react';
+import { LabelModal } from '.';
+
+export const ItemLabelModal = ({ label }: Pick<Types, 'label'>) => {
+  const updateLabel = useLabelStateUpdate(label);
+
+  return (
+    <Fragment>
+      <LabelModal
+        label={label}
+        headerContents='Update label'
+        footerButtons={
+          <DisableButton
+            data={dataButtonLabelModalUpdateLabel}
+            onClick={() => updateLabel()}>
+            Update
+          </DisableButton>
+        }
+      />
+    </Fragment>
+  );
+};

--- a/lib/data/dataObjects.tsx
+++ b/lib/data/dataObjects.tsx
@@ -213,6 +213,11 @@ export const dataButtonLabelModalAddLabel: TypesDataButton = {
   condition: CONDITION['checkLabelTitleEmpty'],
 };
 
+export const dataButtonLabelModalUpdateLabel: TypesDataButton = {
+  tooltip: 'Update Label',
+  className: classNames(STYLE_BUTTON_NORMAL_BLUE, 'mx-2'),
+  condition: CONDITION['compareLabelItemsEqual'],
+};
 /**
  * * TypesDataPriority
  */

--- a/lib/data/stateArrayObjects.tsx
+++ b/lib/data/stateArrayObjects.tsx
@@ -79,6 +79,12 @@ export const DATA_NOTIFICATION: TypesNotification[] = [
     iconPath: ICON_TASK_ALT,
     iconPresetStyle: 'h-6 w-6 fill-green-500',
   },
+  {
+    _id: NOTIFICATION['updatedLabel'],
+    message: 'label updated',
+    iconPath: ICON_TASK_ALT,
+    iconPresetStyle: 'h-6 w-6 fill-blue-500',
+  },
 ];
 
 export const DATA_IDB: TypesIDB[] = [

--- a/lib/data/stateObjects.tsx
+++ b/lib/data/stateObjects.tsx
@@ -19,6 +19,8 @@ export const FOCUS = {
 export type NOTIFICATION = typeof NOTIFICATION[keyof typeof NOTIFICATION];
 export const NOTIFICATION = {
   offline: 'offline',
+  actionUndone: 'actionUndone',
+  //todo
   completeTodo: 'completeTodo',
   unCompleteTodo: 'unCompleteTodo',
   deleteTodo: 'deleteTodo',
@@ -26,8 +28,9 @@ export const NOTIFICATION = {
   createdTodo: 'createdTodo',
   updatedDueDate: `updatedDueDate`,
   removedDueDate: `removedDueDate`,
-  actionUndone: 'actionUndone',
+  //label
   createdLabel: 'createdLabel',
+  updatedLabel: 'updatedLabel',
 } as const;
 
 export type OBJECT_ID = typeof OBJECT_ID[keyof typeof OBJECT_ID];
@@ -69,6 +72,7 @@ export const CONDITION = {
   checkTodoTitleEmpty: 'checkTodoTitleEmpty',
   checkLabelTitleEmpty: 'checkLabelTitleEmpty',
   checkCreateModalOpen: 'checkCreateModalOpen',
+  compareLabelItemsEqual: 'compareLabelItemsEqual',
 } as const;
 
 export type IDB = typeof IDB[keyof typeof IDB];

--- a/lib/states/labelStates.tsx
+++ b/lib/states/labelStates.tsx
@@ -1,7 +1,8 @@
 import { NOTIFICATION } from '@data/stateObjects';
-import { createDataNewLabel } from '@lib/queries/queryLabels';
-import { Labels } from '@lib/types';
-import { atom, atomFamily, RecoilValue, useRecoilCallback } from 'recoil';
+import { createDataNewLabel, updateDataLabelItem } from '@lib/queries/queryLabels';
+import { Labels, Types } from '@lib/types';
+import ObjectID from 'bson-objectid';
+import { atom, atomFamily, RecoilValue, useRecoilCallback, selectorFamily } from 'recoil';
 import { atomQueryLabels } from './atomQueries';
 import { atomLabelModalOpen } from './modalStates';
 import { useNotificationState } from './notificationStates';
@@ -19,13 +20,33 @@ export const atomLabelNew = atom<Labels>({
   } as Labels,
 });
 
-export const atomLabelItem = atomFamily<Labels, Labels['_id']>({
-  key: 'atomLabelItem',
+export const atomSelectorLabelItem = atomFamily<Labels, Labels['_id']>({
+  key: 'atomSelectorLabelItem',
+  default: selectorFamily({
+    key: 'selectorLabelItem',
+    get:
+      (label_id) =>
+      ({ get }) =>
+        get(atomQueryLabels).find((label) => label._id === label_id)!,
+  }),
 });
 
 /**
  * Hooks
  **/
+export const useLabelValueUpdate = (label?: Types['label']) => {
+  return useRecoilCallback(({ set }) => (content: string) => {
+    typeof label !== 'undefined'
+      ? set(atomSelectorLabelItem(label._id), {
+          name: content,
+        })
+      : set(atomLabelNew, {
+          name: content,
+          _id: ObjectID().toHexString(),
+        });
+  });
+};
+
 export const useLabelStateAdd = () => {
   const setNotification = useNotificationState();
 
@@ -40,5 +61,24 @@ export const useLabelStateAdd = () => {
     reset(atomLabelNew);
     reset(atomLabelModalOpen(undefined));
     setNotification(NOTIFICATION['createdLabel']);
+  });
+};
+
+export const useLabelStateUpdate = (label: Types['label']) => {
+  const setNotification = useNotificationState();
+
+  return useRecoilCallback(({ snapshot, set, reset }) => () => {
+    const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
+
+    const updateLabels = get(atomQueryLabels).map((labelItem) => ({
+      ...labelItem,
+      name:
+        labelItem._id === label._id ? get(atomSelectorLabelItem(label._id)).name : labelItem.name,
+    }));
+
+    set(atomQueryLabels, updateLabels);
+    updateDataLabelItem(label._id, get(atomSelectorLabelItem(label._id)));
+    reset(atomLabelModalOpen(label._id));
+    setNotification(NOTIFICATION['updatedLabel']);
   });
 };

--- a/lib/states/modalStates.tsx
+++ b/lib/states/modalStates.tsx
@@ -2,6 +2,7 @@ import { CATCH_MODAL } from '@data/stateObjects';
 import { Labels, Todos } from '@lib/types';
 import { atomFamily, RecoilValue, useRecoilCallback } from 'recoil';
 import { useCalResetDateItemOnly } from './calendarStates';
+import { atomSelectorLabelItem } from './labelStates';
 import { atomSelectorTodoItem, atomTodoNew, useTodoStateRemove } from './todoStates';
 import {
   atomCatch,
@@ -222,6 +223,7 @@ export const useLabelModalStateClose = (_id: Labels['_id']) => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
 
     reset(atomLabelModalOpen(_id));
+    reset(atomSelectorLabelItem(_id));
     get(atomCatch(CATCH_MODAL.labelModal)) && reset(atomCatch(CATCH_MODAL.labelModal));
   });
 };

--- a/lib/states/utilsStates.tsx
+++ b/lib/states/utilsStates.tsx
@@ -2,8 +2,8 @@ import { CATCH_MODAL, CONDITION } from '@data/stateObjects';
 import { Labels, Todos } from '@lib/types';
 import equal from 'fast-deep-equal/react';
 import { atomFamily, RecoilValue, useRecoilCallback, useRecoilValue } from 'recoil';
-import { atomQueryTodoItem } from './atomQueries';
-import { atomLabelNew } from './labelStates';
+import { atomQueryLabels, atomQueryTodoItem } from './atomQueries';
+import { atomLabelNew, atomSelectorLabelItem } from './labelStates';
 import { atomTodoModalMini, atomTodoModalOpen } from './modalStates';
 import { atomSelectorTodoItem, atomTodoNew } from './todoStates';
 
@@ -55,10 +55,30 @@ export const useConditionCompareTodoItemsEqual = (_id: Todos['_id']) => {
   return !todoItemCompletedEqual ? true : equal(todoItem, selectorTodoItem);
 };
 
-export const useConditionalCheckState = (_id: Todos['_id'] | Labels['_id']) => {
+export const useConditionCompareLabelItemsEqual = (_id: Labels['_id']) => {
+  if (typeof _id === 'undefined') return;
+  const labels = useRecoilValue(atomQueryLabels);
+  const labelItem = labels.find((label) => label._id === _id);
+  const labelItemCompare = useRecoilValue(atomSelectorLabelItem(_id));
+  return equal(labelItem, labelItemCompare);
+};
+
+export const useLabelConditionalCheckState = (_id: Labels['_id']) => {
+  const checkLabelTitleEmpty = useConditionCheckLabelTitleEmpty();
+  const compareLabelItemsEqual = useConditionCompareLabelItemsEqual(_id);
+  return (state: CONDITION) => {
+    switch (state) {
+      case CONDITION['checkLabelTitleEmpty']:
+        return checkLabelTitleEmpty;
+      case CONDITION['compareLabelItemsEqual']:
+        return compareLabelItemsEqual;
+    }
+  };
+};
+
+export const useTodoConditionalCheckState = (_id: Todos['_id']) => {
   const checkCreateModalOpen = useConditionCheckCreateModalOpen();
   const checkTodoTitleEmpty = useConditionCheckTodoTitleEmpty();
-  const checkLabelTitleEmpty = useConditionCheckLabelTitleEmpty();
   const compareTodoItemsEqual = useConditionCompareTodoItemsEqual(_id);
   return (state: CONDITION) => {
     switch (state) {
@@ -66,8 +86,6 @@ export const useConditionalCheckState = (_id: Todos['_id'] | Labels['_id']) => {
         return checkCreateModalOpen;
       case CONDITION['checkTodoTitleEmpty']:
         return checkTodoTitleEmpty;
-      case CONDITION['checkLabelTitleEmpty']:
-        return checkLabelTitleEmpty;
       case CONDITION['compareTodoItemsEqual']:
         return compareTodoItemsEqual;
     }

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -47,7 +47,7 @@ export interface TypesEditor {
 /**
  * Types Array Object
  */
-type CollectTypesArrayObject = Todos & TypesTodo & Settings;
+type CollectTypesArrayObject = Todos & TypesTodo & Labels & TypesLabel & Settings;
 
 // Todos
 export interface Todos extends TodosEditors, TodoIds {
@@ -88,6 +88,9 @@ export interface LabelIds {
   _id?: OBJECT_ID;
 }
 
+export interface TypesLabel {
+  label: Labels;
+}
 // Users
 export interface Users extends UsersIds {
   email: 'string';


### PR DESCRIPTION
Now clicking `ICON_MORE_VERT` icon next to the item of labels will enable the `itemLabelModal` to edit label along with updating database, giving the notification feedback, and updating localData including indexedDB.

Other minor update:
Now closing labelModal will reset the state of labelModal and label state.