### PR TITLE
fix: Fixed the updating label with `Enter` key

### DIFF
--- a/lib/states/keybindStates.tsx
+++ b/lib/states/keybindStates.tsx
@@ -134,7 +134,7 @@ export const useKeyWithLabelModal = (_id: Labels['_id']) => {
     switch (event.key) {
       case 'Enter':
         event.preventDefault();
-        if (typeof _id !== 'undefined') return updateLabel();
+        if (get(atomLabelModalOpen(_id)) && typeof _id !== 'undefined') return updateLabel();
         get(atomLabelModalOpen(undefined)) && addLabel();
         return;
       default:


### PR DESCRIPTION
When button is disabled with the condition in DisableButton, the `Enter` key was not updating the label. Given specific condition to the `updateLabel` fixed the issue.