### PR TITLE
feat: Improved the `footerSidebar` UI

### DIFF
--- a/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/index.tsx
+++ b/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/index.tsx
@@ -6,8 +6,10 @@ import { dataButtonCreateTodo, dataLoadingLabels } from '@data/dataObjects';
 import { ICON_ADD_TASK, ICON_MENU } from '@data/materialSymbols';
 import { Transition } from '@headlessui/react';
 import { LayoutLogo } from '@layouts/layoutApp/layoutLogo';
+import { classNames } from '@lib/utils';
 import { atomSidebarOpenMobile, useSidebarOpen } from '@states/layoutStates';
 import { useTodoModalStateOpen } from '@states/modalStates';
+import { atomDisableScroll } from '@states/utilsStates';
 import dynamic from 'next/dynamic';
 import {
   forwardRef,
@@ -17,7 +19,7 @@ import {
   Fragment,
   Fragment as LayoutLogoFragment,
 } from 'react';
-import { useRecoilCallback } from 'recoil';
+import { useRecoilCallback, useRecoilValue } from 'recoil';
 import { FooterSidebarMenu } from './footerSidebarMenu';
 
 const LabelList = dynamic(
@@ -28,6 +30,7 @@ const LabelList = dynamic(
 );
 
 export const FooterSidebar = forwardRef<HTMLDivElement>((_, ref) => {
+  const isScrollDisabled = useRecoilValue(atomDisableScroll);
   const openModal = useTodoModalStateOpen(undefined);
   const setSidebarOpen = useSidebarOpen();
   const isSidebarMobileOpen = useRecoilCallback(({ snapshot }) => () => {
@@ -56,9 +59,9 @@ export const FooterSidebar = forwardRef<HTMLDivElement>((_, ref) => {
       </BackdropFragment>
       <div
         ref={ref}
-        className='fixed left-0 top-0 z-20 h-full w-72 bg-white px-3 pt-3 md:top-[4.6rem] md:flex md:w-full md:max-w-3xs md:flex-col md:bg-transparent md:pt-0 md:pl-3 md:pr-0'>
+        className='fixed left-0 top-0 z-20 w-72 bg-white pl-3 pr-0 pt-3 md:top-[4.6rem] md:z-auto md:flex md:w-full md:max-w-[16.5rem] md:flex-col md:bg-transparent md:pt-0 md:pl-3 md:pr-0'>
         <LayoutLogoFragment>
-          <div className='mb-4 mt-0 flex flex-row items-center justify-between md:hidden'>
+          <div className='mb-4 mt-0 flex flex-row items-center justify-between pr-3 md:hidden'>
             <IconButton
               data={{
                 path: ICON_MENU,
@@ -73,7 +76,7 @@ export const FooterSidebar = forwardRef<HTMLDivElement>((_, ref) => {
           </div>
         </LayoutLogoFragment>
         <CreateTodoFragment>
-          <div className='mb-4 flex w-full flex-row justify-center bg-transparent'>
+          <div className='mb-4 flex w-full flex-row justify-center bg-transparent pr-3'>
             <DisableButton
               data={dataButtonCreateTodo}
               onClick={() => openModal()}>
@@ -89,7 +92,11 @@ export const FooterSidebar = forwardRef<HTMLDivElement>((_, ref) => {
             </DisableButton>
           </div>
         </CreateTodoFragment>
-        <div className='flex h-full flex-grow flex-col bg-transparent'>
+        <div
+          className={classNames(
+            'flex h-[calc(100vh-7.8rem)] w-full flex-grow flex-col bg-transparent pr-3 md:h-[calc(100vh-8.5rem)]',
+            isScrollDisabled ? 'overflow-y-hidden' : 'overflow-y-auto',
+          )}>
           <div className='flex flex-grow flex-col'>
             <nav className='flex-1 space-y-1 pb-4'>
               <FooterSidebarMenu />

--- a/components/layouts/layoutApp/layout/layoutFooter/index.tsx
+++ b/components/layouts/layoutApp/layout/layoutFooter/index.tsx
@@ -3,12 +3,14 @@ import { Transition } from '@headlessui/react';
 import { Types } from '@lib/types';
 import { classNames } from '@lib/utils';
 import { selectorSidebarOpen } from '@states/layoutStates';
+import { atomDisableScroll } from '@states/utilsStates';
 import { Fragment as FooterBodyFragment, Fragment, Fragment as LayoutFooterFragment } from 'react';
 import { useRecoilValue } from 'recoil';
 import { FooterSidebar } from './footerSidebar';
 
 export const LayoutFooter = ({ children }: Pick<Types, 'children'>) => {
   const isSidebarOpen = useRecoilValue(selectorSidebarOpen);
+  const isScrollDisabled = useRecoilValue(atomDisableScroll);
 
   return (
     <LayoutFooterFragment>
@@ -32,10 +34,14 @@ export const LayoutFooter = ({ children }: Pick<Types, 'children'>) => {
         <FooterBodyFragment>
           <div
             className={classNames(
-              'relative mr-3 mb-3 flex w-full flex-row justify-between overflow-y-auto rounded-md bg-white shadow-md shadow-slate-200 transition-[margin-left] duration-200 ease-in-out ',
+              'relative mr-3 mb-3 flex w-full flex-row justify-between rounded-md bg-white shadow-md shadow-slate-200 transition-[margin-left] duration-200 ease-in-out ',
               isSidebarOpen ? 'ml-3 md:ml-[266px]' : 'ml-3',
             )}>
-            <main className='absolute h-full w-full'>
+            <main
+              className={classNames(
+                'absolute h-[calc(100vh-4.3rem)] w-full lg:h-full',
+                isScrollDisabled ? 'overflow-y-hidden' : 'overflow-y-auto',
+              )}>
               <div className='flex max-w-7xl justify-start pb-64'>{children}</div>
             </main>
           </div>

--- a/components/layouts/layoutApp/layoutLogo.tsx
+++ b/components/layouts/layoutApp/layoutLogo.tsx
@@ -14,7 +14,9 @@ export const LayoutLogo = () => {
           </LogoFragment>
         </PrefetchRouterButton>
       </LogoContainerFragment>
-      <NetworkStatus />
+      <div className='ml-4'>
+        <NetworkStatus />
+      </div>
     </nav>
   );
 };

--- a/components/ui/dropdowns/dropdown/index.tsx
+++ b/components/ui/dropdowns/dropdown/index.tsx
@@ -1,10 +1,11 @@
-import { Menu, Transition } from '@headlessui/react';
+import { DisableScrollEffect } from '@effects/disableScrollEffect';
+import { Menu, Portal, Transition } from '@headlessui/react';
 import { TypesDataDropdown } from '@lib/types/typesData';
 import { classNames } from '@lib/utils';
 import { SvgIcon } from 'components/icons/svgIcon';
 import { Types } from 'lib/types';
 import dynamic from 'next/dynamic';
-import { useState } from 'react';
+import { Fragment as MenuFragment, useState } from 'react';
 import { usePopper } from 'react-popper';
 const Tooltip = dynamic(() => import('@tooltips/tooltips').then((mod) => mod.Tooltip));
 
@@ -37,72 +38,83 @@ export const Dropdown = ({
   const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
     placement: placement,
-    modifiers: [{ name: 'offset', options: { offset: [0, 10] } }],
+    modifiers: [{ name: 'offset', options: { offset: [0, 5] } }],
   });
+
+  const visibility = (initialVisible: boolean, open: boolean) => {
+    if (initialVisible || open) return 'visible';
+    return 'invisible group-focus-within:visible group-hover:visible';
+  };
 
   return (
     <span>
-      <Tooltip
-        tooltip={isClicked ? undefined : tooltip}
-        kbd={isClicked ? undefined : kbd}>
-        <Menu
-          as='div'
-          className={classNames('relative inline-block text-left', menuWidth)}>
-          <Menu.Button
-            className={classNames(
-              group,
-              'inline-flex w-full items-center text-gray-400 ease-in hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-0',
-              padding,
-              hoverBg,
-              initialVisible
-                ? 'visible'
-                : 'invisible group-focus-within:visible group-hover:visible',
-              borderRadius,
-              !borderRadius && headerContents ? 'rounded-lg' : 'rounded-full',
-            )}
-            ref={setReferenceElement}
-            onMouseDown={() => setClick(true)}
-            onMouseEnter={() => setClick(false)}
-            onMouseLeave={() => setClick(true)}>
-            <SvgIcon
-              data={{
-                path: path,
-                className: classNames(size, color),
-              }}
-            />
-            {headerContents && (
-              <span
+      <Menu
+        as='div'
+        className={classNames('relative inline-block text-left', menuWidth)}>
+        {({ open }) => (
+          <Tooltip
+            tooltip={isClicked || open ? undefined : tooltip}
+            kbd={isClicked || open ? undefined : kbd}>
+            <MenuFragment>
+              <Menu.Button
                 className={classNames(
-                  'flex flex-row items-start justify-start pl-3 text-sm font-normal text-gray-500',
-                  text,
-                )}>
-                {headerContents}
-              </span>
-            )}
-          </Menu.Button>
-
-          <Transition
-            as='div'
-            className='relative z-20 '
-            enter='transition ease-out duration-100'
-            enterFrom='transform opacity-0 scale-95'
-            enterTo='transform opacity-100 scale-100'
-            leave='transition ease-in duration-75'
-            leaveFrom='transform opacity-100 scale-100'
-            leaveTo='transform opacity-0 scale-95'>
-            <Menu.Items
-              className={classNames(
-                'absolute right-0 origin-top-right rounded-lg bg-white shadow-xl ring-1 ring-black ring-opacity-5 focus:outline-none',
-                contentWidth,
-              )}
-              ref={setPopperElement}
-              style={styles.popper}
-              {...attributes.popper}>
-              <div className={classNames(divider && 'divide-y divide-gray-100')}>{children}</div>
-            </Menu.Items>
-          </Transition>
-        </Menu>
-      </Tooltip>
+                  group,
+                  'inline-flex w-full items-center text-gray-400 ease-in hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-0',
+                  padding,
+                  hoverBg,
+                  borderRadius,
+                  !borderRadius && headerContents ? 'rounded-lg' : 'rounded-full',
+                  visibility(initialVisible, open),
+                )}
+                ref={setReferenceElement}
+                onMouseDown={() => setClick(true)}
+                onMouseEnter={() => setClick(false)}
+                onMouseLeave={() => setClick(true)}>
+                <SvgIcon
+                  data={{
+                    path: path,
+                    className: classNames(size, color),
+                  }}
+                />
+                {headerContents && (
+                  <span
+                    className={classNames(
+                      'flex flex-row items-start justify-start pl-3 text-sm font-normal text-gray-500',
+                      text,
+                    )}>
+                    {headerContents}
+                  </span>
+                )}
+              </Menu.Button>
+              <Transition
+                as='div'
+                className='relative z-20 '
+                enter='transition ease-out duration-100'
+                enterFrom='transform opacity-0 scale-95'
+                enterTo='transform opacity-100 scale-100'
+                leave='transition ease-in duration-75'
+                leaveFrom='transform opacity-100 scale-100'
+                leaveTo='transform opacity-0 scale-95'>
+                <Portal>
+                  <DisableScrollEffect open={open} />
+                  <Menu.Items
+                    className={classNames(
+                      'absolute right-0 z-50 origin-top-right rounded-lg bg-white shadow-xl ring-1 ring-black ring-opacity-5 focus:outline-none',
+                      contentWidth,
+                    )}
+                    ref={setPopperElement}
+                    style={styles.popper}
+                    {...attributes.popper}>
+                    <div className={classNames(divider && 'divide-y divide-gray-100')}>
+                      {children}
+                    </div>
+                  </Menu.Items>
+                </Portal>
+              </Transition>
+            </MenuFragment>
+          </Tooltip>
+        )}
+      </Menu>
     </span>
   );
 };

--- a/components/ui/modals/labelModals/labelModal/index.tsx
+++ b/components/ui/modals/labelModals/labelModal/index.tsx
@@ -52,7 +52,7 @@ export const LabelModal = ({
         onClose={() => closeModal()}>
         <ModalTransitionChild className='h-40 px-2 pt-2 pb-4 sm:relative sm:bottom-24 sm:h-40 sm:max-w-lg'>
           <div className='flex flex-row items-center justify-between sm:inline-block'>
-            <div className='flex flex-row items-center justify-between pl-3 text-base font-semibold text-gray-600 sm:mb-1 '>
+            <div className='flex w-full flex-row items-center justify-between pl-3 text-base font-semibold text-gray-600 sm:mb-1 '>
               {headerContents}
               <IconButton
                 data={dataButtonTodoModalClose}

--- a/lib/states/Effects/disableScrollEffect.tsx
+++ b/lib/states/Effects/disableScrollEffect.tsx
@@ -1,0 +1,16 @@
+import { atomDisableScroll } from '@states/utilsStates';
+import { useEffect } from 'react';
+import { useRecoilCallback } from 'recoil';
+
+export const DisableScrollEffect = ({ open }: { open: boolean }) => {
+  const disableScroll = useRecoilCallback(({ set, reset }) => () => {
+    if (open) return set(atomDisableScroll, true);
+    reset(atomDisableScroll);
+  });
+
+  useEffect(() => {
+    disableScroll();
+  }, [disableScroll, open]);
+
+  return null;
+};

--- a/lib/states/utilsStates.tsx
+++ b/lib/states/utilsStates.tsx
@@ -1,7 +1,7 @@
 import { CATCH_MODAL } from '@data/stateObjects';
 import { Labels, Todos } from '@lib/types';
 import equal from 'fast-deep-equal/react';
-import { atomFamily, RecoilValue, useRecoilCallback, useRecoilValue } from 'recoil';
+import { atom, atomFamily, RecoilValue, useRecoilCallback, useRecoilValue } from 'recoil';
 import { atomQueryLabels, atomQueryTodoItem } from './atomQueries';
 import { atomLabelNew, atomSelectorLabelItem } from './labelStates';
 import { atomTodoModalMini, atomTodoModalOpen } from './modalStates';
@@ -12,6 +12,11 @@ import { atomSelectorTodoItem, atomTodoNew } from './todoStates';
  */
 export const atomCatch = atomFamily<boolean, CATCH_MODAL>({
   key: 'atomCatch',
+  default: false,
+});
+
+export const atomDisableScroll = atom<boolean>({
+  key: 'atomDisableScroll',
   default: false,
 });
 
@@ -62,5 +67,3 @@ export const useConditionCompareLabelItemsEqual = (_id: Labels['_id']) => {
   const labelItemCompare = useRecoilValue(atomSelectorLabelItem(_id));
   return equal(labelItem, labelItemCompare);
 };
-
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1171,9 +1171,9 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
     "node_modules/@babel/core/node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -6917,9 +6917,9 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -10811,9 +10811,9 @@
           "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
         },
         "json5": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+          "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
         },
         "semver": {
           "version": "6.3.0",
@@ -14896,9 +14896,9 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -5,7 +5,7 @@ class MyDocument extends Document {
     return (
       <Html>
         <Head></Head>
-        <body className='bg-slate-50 font-roboto'>
+        <body className='overflow-hidden bg-slate-50 font-roboto'>
           <Main />
           <NextScript />
         </body>


### PR DESCRIPTION
Added the `overflow-y-auto` to enable the `footerSidebar`'s scrolls. To improve the user's experience even further, the scrolling behavior is disabled upon opening `MenuItems` or dropdown. Closing the `MenuItems` will re-enable the scrolling behavior again. The height at which the scroll can reach the end is dynamically calculated with the viewHeight. The `DisableScrollEffect` component controls this behavior.

Added the <Portal> to the `Menu` to target the document body as the container instead of scrolled container for better UI.

Other minor changes:
1. Added the missing style to `LabelModal`.
2. Updated the package, json5.
3. Fixed the z-index.