### PR TITLE
feat: Minor fixes and style adjustments

### DIFF
--- a/components/labels/labelList.tsx
+++ b/components/labels/labelList.tsx
@@ -21,7 +21,7 @@ export const LabelList = () => {
               tooltip: 'Add new label',
               hoverBg: 'hover:enabled:bg-gray-200',
               padding: 'p-2',
-              color: 'hover:endabled:bg-fill-700',
+              color: 'hover:enabled:bg-fill-700',
             }}
             onClick={() => labelModalOpen()}
           />

--- a/components/loadable/loadingStates/loadingSkeletons/loadingSkeletonLabels.tsx
+++ b/components/loadable/loadingStates/loadingSkeletons/loadingSkeletonLabels.tsx
@@ -3,7 +3,7 @@ import { Fragment } from 'react';
 export function LoadingSkeletonLabels() {
   return (
     <Fragment>
-      <div className='flex max-w-lg animate-pulse flex-col justify-start space-y-4'>
+      <div className='mt-3 flex max-w-lg animate-pulse flex-col justify-start space-y-4'>
         <div className='h-4 w-[7rem] rounded-md bg-slate-200' />
         <div className='h-4 w-[5rem] rounded-md bg-slate-200' />
         <div className='h-4 w-[8rem] rounded-md bg-slate-200' />

--- a/components/ui/modals/todoModals/todoModal/index.tsx
+++ b/components/ui/modals/todoModals/todoModal/index.tsx
@@ -8,9 +8,7 @@ import { TodoModalHeaderButtons } from '@modals/todoModals/todoModal/todoModalHe
 import { useCalUpdateItem } from '@states/calendarStates';
 import { atomTodoModalMax, atomTodoModalOpen, useTodoModalStateClose } from '@states/modalStates';
 import { useTodoStateAdd } from '@states/todoStates';
-import {
-    useConditionCheckTodoTitleEmpty
-} from '@states/utilsStates';
+import { useConditionCheckTodoTitleEmpty } from '@states/utilsStates';
 import { Types } from 'lib/types';
 import { Fragment as TodoModalFragment, useRef } from 'react';
 import { useRecoilValue } from 'recoil';
@@ -49,7 +47,7 @@ export const TodoModal = ({
           className={classNames(
             'h-80 min-h-[20rem] px-4 pt-2 pb-5 sm:relative',
             isTodoModalMax
-              ? 'sm:bottom-0 sm:h-full sm:max-h-[44rem] sm:max-w-3xl md:max-h-[54rem] md:max-w-5xl lg:max-w-6xl'
+              ? 'sm:bottom-0 sm:h-full sm:max-h-[calc(100vh-10vh)] sm:max-w-[calc(100vw-10vw)]'
               : 'sm:bottom-20 sm:h-[28rem] sm:max-w-2xl',
           )}>
           <div className='flex flex-row items-center justify-between sm:inline-block'>
@@ -95,7 +93,7 @@ export const TodoModal = ({
         </ModalTransitionChild>
       </ModalTransitionRoot>
       {children}
-      <TodoModalWithKeyEffect />
+      <TodoModalWithKeyEffect todo={todo} />
     </TodoModalFragment>
   );
 };

--- a/components/ui/tooltips/tooltips/index.tsx
+++ b/components/ui/tooltips/tooltips/index.tsx
@@ -1,3 +1,4 @@
+import { Portal } from '@headlessui/react';
 import { classNames } from '@lib/utils';
 import { TypesTooltipAttributes, Types } from 'lib/types';
 import React, { Fragment as TooltipFragment, memo } from 'react';
@@ -32,20 +33,24 @@ export const Tooltip = memo(
       <TooltipFragment>
         <span ref={setTriggerRef}>{children}</span>
         {visible && (
-          <div
-            ref={setTooltipRef}
-            {...getTooltipProps()}
-            className={classNames(
-              tooltip && ' z-50 whitespace-nowrap rounded-md bg-gray-700 p-2 text-xs text-white opacity-90',
-            )}>
-            <span>{tooltip}</span>
-            <kbd
+          <Portal>
+            <div
+              ref={setTooltipRef}
+              {...getTooltipProps()}
               className={classNames(
-                kbd && 'ml-2 h-6 rounded border-x border-y py-px px-1.5 font-sans tracking-normal subpixel-antialiased',
+                tooltip &&
+                  'z-50 whitespace-nowrap rounded-md bg-gray-700 p-2 text-xs text-white opacity-90',
               )}>
-              {kbd}
-            </kbd>
-          </div>
+              <span>{tooltip}</span>
+              <kbd
+                className={classNames(
+                  kbd &&
+                    'ml-2 h-6 rounded border-x border-y py-px px-1.5 font-sans tracking-normal subpixel-antialiased',
+                )}>
+                {kbd}
+              </kbd>
+            </div>
+          </Portal>
         )}
       </TooltipFragment>
     );

--- a/lib/states/atomQueries/index.tsx
+++ b/lib/states/atomQueries/index.tsx
@@ -34,7 +34,7 @@ export const atomQueryTodoItem = atomFamily<Todos, Todos['_id']>({
       queryKey: todoId!.toString(),
       queryFunction: () => getDataTodoItem({ _id: todoId }),
       refetchOnMutation: true,
-      refetchDelayOnMutation: 500,
+      refetchDelayOnMutation: 800,
     }),
   ],
 });

--- a/lib/states/priorityStates.tsx
+++ b/lib/states/priorityStates.tsx
@@ -33,8 +33,8 @@ export const selectorDynamicPriority = selectorFamily<Todos['priorityLevel'], To
   },
 });
 
-export const selectorFilterPioirtyRankScore = selector({
-  key: 'selectorFilterPioirtyRankScore',
+export const selectorFilterPriorityRankScore = selector({
+  key: 'selectorFilterPriorityRankScore',
   get: ({ get }) => {
     const taskCapacity = get(selectorTaskCompleteCapacity);
     const prsUrgentFiltered = get(atomQueryTodoIds).filter(

--- a/lib/states/todoStates.tsx
+++ b/lib/states/todoStates.tsx
@@ -20,7 +20,7 @@ import { atomQueryTodoIds, atomQueryTodoItem } from './atomQueries';
 import { atomNetworkStatusEffect } from './miscStates';
 import { atomConfirmModalDelete, useTodoModalStateReset } from './modalStates';
 import { useNotificationState } from './notificationStates';
-import { selectorFilterPioirtyRankScore, usePriorityRankScore } from './priorityStates';
+import { selectorFilterPriorityRankScore, usePriorityRankScore } from './priorityStates';
 import {
   atomCatch,
   useConditionCheckTodoTitleEmpty,
@@ -103,7 +103,7 @@ export const selectorFilterTodoIdsByPathname = selectorFamily<TodoIds[], PATHNAM
     ({ get }) => {
       switch (pathname) {
         case PATHNAME['app']:
-          return get(selectorFilterPioirtyRankScore);
+          return get(selectorFilterPriorityRankScore);
         case PATHNAME['urgent']:
           return get(atomQueryTodoIds).filter(
             (todo) => !todo.completed && todo.priorityLevel === 1,
@@ -283,7 +283,6 @@ export const useTodoIdsWithPathname = () => {
       return app;
   }
 };
-
 
 export const useFilterTodoIdsWithPathname = () => {
   const router = useRouter();


### PR DESCRIPTION
- Increased the `refetchDelayOnMutation` of `atomQueryTodoItem` to 800 from 500. The main purpose of delaying the refetching is when refetching happens on first server started. Due to the fact that fetching happens too fast before item is updated, the server error is triggered. The delaying the refetching mitigate this issue.

- Minor adjustments on styles of `LoadingSkeletonLabels`.

- Added `Portal` to `Tooltip` component to target the document's body instead of targeting a wrong container. When targeting a wrong container, the popper does not render correctly.

- Refactored the Modal's maxSize on Increaseing the size to the max. Previoulsy the size is depended the on the media breakPoint. Now It is calculated by the `100viewSize-10viewSize`.