### PR TITLE
feat: Added new components: `PseudoButtons`

### DIFF
--- a/components/ui/pseudoButtons/pseudoButton/index.tsx
+++ b/components/ui/pseudoButtons/pseudoButton/index.tsx
@@ -1,0 +1,41 @@
+import { TypesDataPseudoButton } from '@lib/types/typesData';
+import { Types } from 'lib/types';
+import dynamic from 'next/dynamic';
+import { forwardRef, useState } from 'react';
+
+const Tooltip = dynamic(() => import('@tooltips/tooltips').then((mod) => mod.Tooltip));
+
+type Props = { data: TypesDataPseudoButton } & Partial<
+  Pick<
+    Types,
+    'onKeyDown' | 'children' | 'onClick' | 'onDoubleClick' | 'onMouseEnter' | 'onMouseOver'
+  >
+>;
+
+export const PseudoButton = forwardRef<HTMLDivElement, Props>(
+  ({ data, onClick, onKeyDown, onDoubleClick, onMouseOver, children = data.name }: Props, ref) => {
+    const [isClicked, setClick] = useState(false);
+
+    return (
+      <Tooltip
+        tooltip={isClicked ? undefined : data.tooltip}
+        kbd={isClicked ? undefined : data.kbd}
+        placement={data.placement}
+        offset={data.offset}>
+        <div
+          className={data.className}
+          onMouseOver={onMouseOver}
+          onMouseDown={() => setClick(true)}
+          onMouseEnter={() => setClick(false)}
+          onMouseLeave={() => setClick(true)}
+          onClick={onClick}
+          onKeyDown={onKeyDown}
+          onDoubleClick={onDoubleClick}
+          ref={ref}>
+          {children}
+        </div>
+      </Tooltip>
+    );
+  },
+);
+PseudoButton.displayName = 'PseudoButton';

--- a/components/ui/pseudoButtons/pseudoIconButton/index.tsx
+++ b/components/ui/pseudoButtons/pseudoIconButton/index.tsx
@@ -1,0 +1,62 @@
+import { Types } from '@lib/types';
+import { TypesDataButton } from '@lib/types/typesData';
+import { classNames } from '@lib/utils';
+import dynamic from 'next/dynamic';
+import { Fragment as HeaderContentsFragment } from 'react';
+
+const SvgIcon = dynamic(() => import('@components/icons/svgIcon').then((mod) => mod.SvgIcon));
+const PseudoButton = dynamic(() => import('../pseudoButton').then((mod) => mod.PseudoButton));
+
+type Props = { data: TypesDataButton } & Partial<
+  Pick<Types, 'headerContents' | 'children' | 'onClick' | 'children'>
+>;
+
+export const PseudoIconButton = ({
+  data,
+  headerContents,
+  onClick,
+  children = data.name,
+}: Props) => {
+  return (
+    <span className={data.containerWidth}>
+      <PseudoButton
+        data={{
+          className: classNames(
+            data.className,
+            'group-pseudoButton border-gray-300 bg-transparent text-gray-500 hover:bg-white focus-visible:ring-blue-500 hover:enabled:text-gray-700',
+            headerContents ? 'rounded-lg' : 'rounded-full',
+            data.padding || 'p-2',
+            data.margin || 'ml-px',
+            data.hoverBg || 'hover:enabled:bg-gray-100',
+            data.display,
+            data.width,
+          ),
+          tooltip: data.tooltip,
+          kbd: data.kbd,
+          offset: data.offset,
+        }}
+        onClick={onClick}>
+        <div className='flex flex-row items-center justify-center'>
+          {children}
+          <SvgIcon
+            data={{
+              path: data.path,
+              className: classNames(
+                data.size || 'h-5 w-5',
+                data.color || 'fill-gray-500',
+                data.color && '[.group-pseudoButton:hover_&]:fill-gray-700',
+              ),
+            }}
+          />
+          <HeaderContentsFragment>
+            {headerContents && (
+              <span className='px-3 text-sm font-normal text-gray-500 [.group-pseudoButton:hover_&]:text-gray-700'>
+                {headerContents}
+              </span>
+            )}
+          </HeaderContentsFragment>
+        </div>
+      </PseudoButton>
+    </span>
+  );
+};

--- a/lib/types/typesData.ts
+++ b/lib/types/typesData.ts
@@ -10,17 +10,18 @@ export type TypesDataSvg = Partial<
 export type TypesDataButton = Partial<
   Pick<
     Types,
-    | 'className'
-    | 'disabled'
-    | 'path'
-    | 'name'
-    | 'tooltip'
-    | 'offset'
-    | 'kbd'
-    | 'placement'
+    'className' | 'disabled' | 'path' | 'name' | 'tooltip' | 'offset' | 'kbd' | 'placement'
   > & {
     type: Extract<TypesElement['type'], 'button' | 'submit' | 'reset'>;
   } & Pick<
+      TypesStyleAttributes,
+      'padding' | 'margin' | 'display' | 'width' | 'size' | 'color' | 'containerWidth' | 'hoverBg'
+    >
+>;
+
+export type TypesDataPseudoButton = Partial<
+  Pick<Types, 'className' | 'path' | 'name' | 'tooltip' | 'offset' | 'kbd' | 'placement'> &
+    Pick<
       TypesStyleAttributes,
       'padding' | 'margin' | 'display' | 'width' | 'size' | 'color' | 'containerWidth' | 'hoverBg'
     >


### PR DESCRIPTION
Added the new components: `PseudoButton` and `PseudoIconButton`, which resemble the regular Button and IconButton components except for parts that it does not consist of `button` element but `div` element. Additionally, `TypesDataPseudoButton` is also added to `TypesData`