### PR TITLE
feat: Updated the Label ComboBox

### DIFF
--- a/components/layouts/layoutApp/index.tsx
+++ b/components/layouts/layoutApp/index.tsx
@@ -1,4 +1,6 @@
+import { CATCH_MODAL } from '@data/stateObjects';
 import { Types } from '@lib/types';
+import { atomCatch } from '@states/utilsStates';
 import dynamic from 'next/dynamic';
 import {
   Fragment as FooterFragment,
@@ -6,6 +8,7 @@ import {
   Fragment as LayoutAppFragment,
   Fragment as ModalActionsFragment,
 } from 'react';
+import { useRecoilValue } from 'recoil';
 const CreateTodoModal = dynamic(() =>
   import('@modals/todoModals/todoModal').then((mod) => mod.TodoModal),
 );
@@ -29,6 +32,8 @@ const Layout = dynamic(() => import('./layout').then((mod) => mod.Layout));
 type Props = Pick<Types, 'children'>;
 
 export const LayoutApp = ({ children }: Props) => {
+  const catchTodoModal = useRecoilValue(atomCatch(CATCH_MODAL.todoModal));
+
   return (
     <LayoutAppFragment>
       <HeaderFragment>
@@ -41,7 +46,7 @@ export const LayoutApp = ({ children }: Props) => {
           <CreateTodoModal />
           <DiscardConfirmModal />
           <MinimizedModal />
-          <LabelModal />
+          {!catchTodoModal && <LabelModal />}
         </ModalActionsFragment>
       </FooterFragment>
     </LayoutAppFragment>

--- a/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/index.tsx
+++ b/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/index.tsx
@@ -8,7 +8,7 @@ import { LayoutLogo } from '@layouts/layoutApp/layoutLogo';
 import { classNames } from '@lib/utils';
 import { atomSidebarOpenMobile, useSidebarOpen } from '@states/layoutStates';
 import { useTodoModalStateOpen } from '@states/modalStates';
-import { atomDisableScroll } from '@states/utilsStates';
+import { atomDisableScroll, useConditionCheckCreateModalOpen } from '@states/utilsStates';
 import dynamic from 'next/dynamic';
 import {
   forwardRef,
@@ -38,6 +38,7 @@ export const FooterSidebar = forwardRef<HTMLDivElement>((_, ref) => {
   const isSidebarMobileOpen = useRecoilCallback(({ snapshot }) => () => {
     return snapshot.getLoadable(atomSidebarOpenMobile).getValue();
   });
+  const condition = useConditionCheckCreateModalOpen();
 
   return (
     <FooterSidebarFragment>
@@ -81,7 +82,8 @@ export const FooterSidebar = forwardRef<HTMLDivElement>((_, ref) => {
           <div className='mb-4 flex w-full flex-row justify-center bg-transparent pr-3'>
             <DisableButton
               data={dataButtonCreateTodo}
-              onClick={() => openModal()}>
+              onClick={() => openModal()}
+              conditionalRendering={condition}>
               <span className='flex flex-row items-center'>
                 <SvgIcon
                   data={{

--- a/components/ui/buttons/iconButton/index.tsx
+++ b/components/ui/buttons/iconButton/index.tsx
@@ -40,7 +40,7 @@ export const IconButton = ({ data, headerContents, onClick, children = data.name
               className: classNames(
                 data.size || 'h-5 w-5',
                 data.color || 'fill-gray-500',
-                data.color && !data.disabled && '[.group-button:hover_&]:fill-gray-700',
+                !data.disabled && '[.group-button:hover_&]:fill-gray-700',
               ),
             }}
           />

--- a/components/ui/comboBoxes/comboBox/index.tsx
+++ b/components/ui/comboBoxes/comboBox/index.tsx
@@ -1,21 +1,57 @@
 import { atomQueryLabels } from '@atomQueries/index';
+import { IconButton } from '@buttons/iconButton';
 import { SvgIcon } from '@components/icons/svgIcon';
 import {
+  ICON_ADD,
   ICON_CHECK_BOX_FILL,
   ICON_CHECK_BOX_OUTLINE_BLANK,
   ICON_UNFOLD_MORE,
 } from '@data/materialSymbols';
 import { Combobox, Transition } from '@headlessui/react';
-import { Labels } from '@lib/types';
+import { Labels, Types } from '@lib/types';
 import { classNames } from '@lib/utils';
+import { useLabelModalStateOpen } from '@states/modalStates';
+import { atomTodoNew } from '@states/todoStates';
 import { PseudoIconButton } from '@ui/pseudoButtons/pseudoIconButton';
-import { Fragment, useState } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useState } from 'react';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
-export const ComboBox = () => {
+type Props = Partial<Pick<Types, 'todo'>>;
+
+export const ComboBox = ({ todo }: Props) => {
   const labels = useRecoilValue(atomQueryLabels);
-  const [selected, setSelected] = useState([]);
+  const todoNew = useRecoilValue(atomTodoNew);
+  const todoId = todo ? todo._id! : todoNew._id!;
+  const selectedLabels = labels.filter(
+    (label) => label.title_id && label.title_id.includes(todoId),
+  );
+  const setSelectedLabels = useSetRecoilState(atomQueryLabels);
   const [query, setQuery] = useState('');
+  const labelModalOpen = useLabelModalStateOpen(undefined);
+
+  const onChangeHandler = (selected: Labels[]) => {
+    const updateChange = labels.map((label) => {
+      const labelId = selected.filter((select) => select._id === label._id)[0]?._id;
+      const isTodoIdExist = label.title_id && label.title_id.includes(todoId);
+      const addOrCreateTodoId = label.title_id ? [...label.title_id, todoId] : [todoId];
+      const updateTitleId = () => {
+        if (!labelId) return label;
+        return {
+          ...label,
+          title_id: !isTodoIdExist ? addOrCreateTodoId : label.title_id,
+        };
+      };
+      const removeTitleId = () => {
+        if (labelId) return label;
+        return {
+          ...label,
+          title_id: label.title_id && label.title_id.filter((titleId) => titleId !== todoId),
+        };
+      };
+      return isTodoIdExist ? removeTitleId() : updateTitleId();
+    });
+    setSelectedLabels(updateChange);
+  };
 
   const filteredLabels =
     query === ''
@@ -31,11 +67,11 @@ export const ComboBox = () => {
     <div className='relative'>
       <div className='fixed top-16 z-10 w-72'>
         <Combobox
-          value={selected}
-          onChange={(value) => setSelected(value)}
+          value={selectedLabels}
+          onChange={onChangeHandler}
           multiple>
-          <div className='group/comboBox relative mt-1 flex flex-col rounded-md outline-none focus-within:shadow-2xl focus-within:shadow-slate-300/40'>
-            <div className='relative w-full cursor-default overflow-hidden rounded-md border border-solid border-slate-200 bg-white py-1 text-left shadow-xl shadow-slate-300/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-teal-300 group-focus-within/comboBox:border-opacity-50 sm:text-sm'>
+          <div className='group/comboBox relative mt-1 flex flex-col rounded-lg outline-none focus-within:shadow-2xl focus-within:shadow-slate-300/40'>
+            <div className='relative w-full cursor-default overflow-hidden rounded-lg border border-solid border-slate-200 bg-white py-1 text-left shadow-xl shadow-slate-300/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-teal-300 group-focus-within/comboBox:border-opacity-50 sm:text-sm'>
               <Combobox.Input
                 className='w-full border-none py-2 pl-4 pr-10 text-sm leading-5 text-gray-900 placeholder:text-gray-400 focus:ring-0'
                 displayValue={(label: Labels) => label.name}
@@ -55,12 +91,13 @@ export const ComboBox = () => {
               </Combobox.Button>
             </div>
             <Transition
-              as={Fragment}
+              as={'div'}
               leave='transition ease-in duration-100'
               leaveFrom='opacity-100'
               leaveTo='opacity-0'
+              className='-mt-[5px] rounded-b-lg border-x border-b border-solid border-slate-200 shadow-xl shadow-slate-300/40 group-focus-within/comboBox:border-opacity-50'
               afterLeave={() => setQuery('')}>
-              <Combobox.Options className='relative -mt-[5px] max-h-60 w-full overflow-auto rounded-b-md border-x border-b border-slate-200 bg-white py-1 text-base shadow-xl shadow-slate-300/40 ring-0 ring-transparent focus:outline-none group-focus-within/comboBox:border-opacity-50 sm:text-sm'>
+              <Combobox.Options className='relative max-h-60 w-full overflow-auto bg-white py-1 text-base ring-0 ring-transparent focus:outline-none sm:text-sm'>
                 {filteredLabels.length === 0 && query !== '' ? (
                   <div className='relative cursor-default select-none py-2 px-4 text-gray-500'>
                     Nothing found!
@@ -112,6 +149,17 @@ export const ComboBox = () => {
                   ))
                 )}
               </Combobox.Options>
+              <div className='px-3 pt-3 pb-2'>
+                <IconButton
+                  data={{
+                    path: ICON_ADD,
+                    size: 'h-6 w-6',
+                    width: 'w-full',
+                  }}
+                  headerContents='Add new label'
+                  onClick={() => labelModalOpen()}
+                />
+              </div>
             </Transition>
           </div>
         </Combobox>

--- a/components/ui/modals/labelModals/labelModal/index.tsx
+++ b/components/ui/modals/labelModals/labelModal/index.tsx
@@ -35,7 +35,7 @@ export const LabelModal = ({
 }: Props) => {
   const isLabelModalOpen = useRecoilValue(atomLabelModalOpen(label?._id));
   const closeModal = useLabelModalStateClose(label?._id);
-  const initialFocusDiv = useRef<HTMLInputElement>(null);
+  const initialFocusInput = useRef<HTMLInputElement>(null);
   const labelItem =
     typeof label === 'undefined'
       ? useRecoilValue(atomLabelNew)
@@ -48,7 +48,7 @@ export const LabelModal = ({
     <LabelModalFragment>
       <ModalTransitionRoot
         show={isLabelModalOpen}
-        initialFocus={initialFocusDiv}
+        initialFocus={initialFocusInput}
         onClose={() => closeModal()}>
         <ModalTransitionChild className='h-40 px-2 pt-2 pb-4 sm:relative sm:bottom-24 sm:h-40 sm:max-w-lg'>
           <div className='flex flex-row items-center justify-between sm:inline-block'>
@@ -71,7 +71,7 @@ export const LabelModal = ({
               name='label'
               value={labelItem.name}
               onChange={(event) => updateLabelItem(event.target.value)}
-              ref={initialFocusDiv}
+              ref={initialFocusInput}
             />
           </div>
           <div className='flex flex-row justify-end pt-4'>
@@ -92,7 +92,7 @@ export const LabelModal = ({
         </ModalTransitionChild>
       </ModalTransitionRoot>
       {children}
-      <LabelModalWithKeyEffect />
+      <LabelModalWithKeyEffect label={label} />
     </LabelModalFragment>
   );
 };

--- a/components/ui/modals/todoModals/todoModal/index.tsx
+++ b/components/ui/modals/todoModals/todoModal/index.tsx
@@ -2,8 +2,10 @@ import { DisableButton } from '@buttons/disableButton';
 import { TodoEditors } from '@components/editors/todoEditor';
 import { dataButtonTodoModalAddTodo, dataButtonTodoModalCancel } from '@data/dataObjects';
 import { CalendarDropdown } from '@dropdowns/calendarDropdown';
+import { DisableScrollEffect } from '@effects/disableScrollEffect';
 import { TodoModalWithKeyEffect } from '@effects/todoModalWithKeyEffect';
 import { classNames } from '@lib/utils';
+import { LabelModal } from '@modals/labelModals/labelModal';
 import { TodoModalHeaderButtons } from '@modals/todoModals/todoModal/todoModalHeaderButtons';
 import { useCalUpdateItem } from '@states/calendarStates';
 import { atomTodoModalMax, atomTodoModalOpen, useTodoModalStateClose } from '@states/modalStates';
@@ -43,6 +45,8 @@ export const TodoModal = ({
         show={isTodoModalOpen}
         initialFocus={initialFocusDiv}
         onClose={() => closeModal()}>
+        {/* nested modal */}
+        <LabelModal label={undefined} />
         <ModalTransitionChild
           className={classNames(
             'h-80 min-h-[20rem] px-4 pt-2 pb-5 sm:relative',
@@ -94,6 +98,7 @@ export const TodoModal = ({
       </ModalTransitionRoot>
       {children}
       <TodoModalWithKeyEffect todo={todo} />
+      <DisableScrollEffect open={isTodoModalOpen} />
     </TodoModalFragment>
   );
 };

--- a/lib/states/effects/navigateWithKeyEffect.tsx
+++ b/lib/states/effects/navigateWithKeyEffect.tsx
@@ -17,6 +17,7 @@ export const NavigateWithKeyEffect = ({ index, divFocus, todo }: Props) => {
   const isOnBlur = useRecoilValue(atomOnBlur);
   const isTodoModalOpen = useRecoilValue(atomCatch(CATCH_MODAL.todoModal));
   const isConfirmModalOpen = useRecoilValue(atomCatch(CATCH_MODAL.confirmModal));
+  const isLabelModalOpen = useRecoilValue(atomCatch(CATCH_MODAL.labelModal));
 
   const navigateCondition = useRecoilCallback(({ snapshot, reset }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
@@ -34,7 +35,7 @@ export const NavigateWithKeyEffect = ({ index, divFocus, todo }: Props) => {
       isOnBlur && reset(atomOnBlur);
       return;
     }
-    if (isTodoModalOpen || isConfirmModalOpen) return; // Cannot use useRecoilCallback with useEffect
+    if (isTodoModalOpen || isConfirmModalOpen || isLabelModalOpen) return; // Cannot use useRecoilCallback with useEffect
     if (currentFocus === index) {
       divFocus.current?.focus();
     }

--- a/lib/states/keybindStates.tsx
+++ b/lib/states/keybindStates.tsx
@@ -148,7 +148,12 @@ export const useKeyWithNavigate = () => {
   const keyDownNavigate = useRecoilCallback(({ set, snapshot }) => (event: KeyboardEvent) => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
 
-    if (get(atomCatch(CATCH_MODAL.todoModal)) || get(atomCatch(CATCH_MODAL.confirmModal))) return;
+    if (
+      get(atomCatch(CATCH_MODAL.todoModal)) ||
+      get(atomCatch(CATCH_MODAL.confirmModal)) ||
+      get(atomCatch(CATCH_MODAL.labelModal))
+    )
+      return;
 
     switch (event.key) {
       case 'ArrowDown':

--- a/lib/states/modalStates.tsx
+++ b/lib/states/modalStates.tsx
@@ -2,7 +2,7 @@ import { CATCH_MODAL } from '@data/stateObjects';
 import { Labels, Todos } from '@lib/types';
 import { atomFamily, RecoilValue, useRecoilCallback } from 'recoil';
 import { useCalResetDateItemOnly } from './calendarStates';
-import { atomSelectorLabelItem, useLabelStateRemove } from './labelStates';
+import { atomLabelNew, atomSelectorLabelItem, useLabelStateRemove } from './labelStates';
 import { atomSelectorTodoItem, atomTodoNew, useTodoStateRemove } from './todoStates';
 import {
   atomCatch,
@@ -200,8 +200,9 @@ export const useTodoModalStateClose = (_id: Todos['_id']) => {
   return useRecoilCallback(({ reset, snapshot }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
 
-    setModalClose();
+    !get(atomCatch(CATCH_MODAL.labelModal)) && setModalClose();
     get(atomCatch(CATCH_MODAL.todoModal)) && reset(atomCatch(CATCH_MODAL.todoModal));
+    get(atomCatch(CATCH_MODAL.minimizedModal)) && reset(atomCatch(CATCH_MODAL.minimizedModal));
   });
 };
 
@@ -228,6 +229,7 @@ export const useLabelModalStateClose = (_id: Labels['_id']) => {
 
     reset(atomLabelModalOpen(_id));
     reset(atomSelectorLabelItem(_id));
+    get(atomLabelModalOpen(undefined)) && reset(atomLabelNew);
     get(atomCatch(CATCH_MODAL.labelModal)) && reset(atomCatch(CATCH_MODAL.labelModal));
   });
 };

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -183,6 +183,7 @@ export interface TypesReactChildren {
   headerButtons: Types['children'];
   headerIcons: Types['children'];
   headerContents: Types['children'];
+  nestedModal: Types['children'];
 }
 
 export interface TypesUi {


### PR DESCRIPTION
Now Label ComboBox can create new label by opening the `createLabelModal` from ComboBox. Due to the modal prioritization, 'labelModal' is nested into `todoModal`. Headless UI's dialog requires the nested modal if it is desired to close from the latest open modal.

Other minor changes:
1. Updated the comboBox's style
2. Added the additional condition to useKeyWithFocus to blur the focus if labelModal is open
3. Added the missing CATCH_MODAL.minimizedModal to useTodoModalStateClose
4. Added the condition to useTodoMOdalStateClose
5. Added the missing condition in FooterSidebar