### PR TITLE
feat: Updated the effects of `keybinds` states

### DIFF
--- a/components/todos/todo/todoItemFocuser.tsx
+++ b/components/todos/todo/todoItemFocuser.tsx
@@ -1,6 +1,6 @@
 import { useFocusOnClick } from '@states/focus/hooks';
 import { useKeyWithFocus } from '@states/keybinds/hooks';
-import { NavigateWithKeyEffect } from '@states/keybinds/navigateWithKeyEffect';
+import { KeysWithNavigationEffect } from '@states/keybinds/KeysWithNavigateEffect';
 import { Types, TypesTodo } from 'lib/types';
 import { useRef } from 'react';
 
@@ -18,7 +18,7 @@ export const TodoItemFocuser = ({ todo, index, children }: Props) => {
       ref={divFocus}
       onKeyDown={focusKeyHandler}
       onClick={() => focusOnClick()}>
-      <NavigateWithKeyEffect
+      <KeysWithNavigationEffect
         index={index}
         divFocus={divFocus}
         todo={todo}

--- a/components/ui/modals/labelModals/labelModal/index.tsx
+++ b/components/ui/modals/labelModals/labelModal/index.tsx
@@ -5,7 +5,7 @@ import {
   dataButtonTodoModalCancel,
   dataButtonTodoModalClose,
 } from '@data/dataObjects';
-import { LabelModalWithKeyEffect } from '@states/keybinds/labelModalWithKeyEffect';
+import { KeysWithLabelModalEffect } from '@states/keybinds/KeysWithLabelModalEffect';
 import { atomLabelNew, atomSelectorLabelItem } from '@states/labels';
 import { useLabelValueUpdate, useLabelStateAdd } from '@states/labels/hooks';
 import { atomLabelModalOpen } from '@states/modals';
@@ -91,7 +91,7 @@ export const LabelModal = ({
         </ModalTransitionChild>
       </ModalTransitionRoot>
       {children}
-      <LabelModalWithKeyEffect label={label} />
+      <KeysWithLabelModalEffect label={label} />
     </LabelModalFragment>
   );
 };

--- a/components/ui/modals/labelModals/labelModal/itemLabelModal.tsx
+++ b/components/ui/modals/labelModals/labelModal/itemLabelModal.tsx
@@ -1,7 +1,7 @@
 import { DisableButton } from '@buttons/disableButton';
 import { dataButtonLabelModalUpdateLabel } from '@data/dataObjects';
 import { Types } from '@lib/types';
-import { LabelModalWithKeyEffect } from '@states/keybinds/labelModalWithKeyEffect';
+import { KeysWithLabelModalEffect } from '@states/keybinds/KeysWithLabelModalEffect';
 import { useLabelStateUpdate } from '@states/labels/hooks';
 import { useConditionCompareLabelItemsEqual } from '@states/utils/hooks';
 import { Fragment } from 'react';
@@ -24,7 +24,7 @@ export const ItemLabelModal = ({ label }: Pick<Types, 'label'>) => {
             Update
           </DisableButton>
         }>
-        <LabelModalWithKeyEffect label={label} />
+        <KeysWithLabelModalEffect label={label} />
       </LabelModal>
     </Fragment>
   );

--- a/components/ui/modals/todoModals/itemTodoModal.tsx
+++ b/components/ui/modals/todoModals/itemTodoModal.tsx
@@ -3,7 +3,7 @@ import { dataButtonItemModalUpdate } from '@data/dataObjects';
 import { PRIORITY_LEVEL } from '@data/stateObjects';
 import { CheckBox as CompleteTodoCheckBox } from '@inputs/checkbox';
 import { Types } from '@lib/types';
-import { TodoModalWithKeyEffect } from '@states/keybinds/todoModalWithKeyEffect';
+import { KeysWithTodoModalEffect } from '@states/keybinds/keysWithTodoModalEffect';
 import { atomPriority } from '@states/priorities';
 import { atomQueryTodoItem } from '@states/todos/atomQueries';
 import { useTodoStateUpdate, useTodoStateComplete } from '@states/todos/hooks';
@@ -52,7 +52,7 @@ export const ItemTodoModal = ({ todo }: Pick<Types, 'todo'>) => {
           </DisableButton>
         </FooterButtonsFragment>
       }>
-      <TodoModalWithKeyEffect todo={todo} />
+      <KeysWithTodoModalEffect todo={todo} />
     </TodoModal>
   );
 };

--- a/components/ui/modals/todoModals/todoModal/index.tsx
+++ b/components/ui/modals/todoModals/todoModal/index.tsx
@@ -6,9 +6,9 @@ import { LabelComboBoxDropdown } from '@dropdowns/labelComboBoxDropdown';
 import { LabelModal } from '@modals/labelModals/labelModal';
 import { TodoModalHeaderButtons } from '@modals/todoModals/todoModal/todoModalHeaderButtons';
 import { useCalUpdateItem } from '@states/calendars/hooks';
-import { TodoModalWithKeyEffect } from '@states/keybinds/todoModalWithKeyEffect';
+import { KeysWithTodoModalEffect } from '@states/keybinds/keysWithTodoModalEffect';
 import { DisableScrollEffect } from '@states/misc/disableScrollEffect';
-import { atomTodoModalOpen, atomTodoModalMax } from '@states/modals';
+import { atomTodoModalMax, atomTodoModalOpen } from '@states/modals';
 import { useTodoModalStateClose } from '@states/modals/hooks';
 import { useTodoStateAdd } from '@states/todos/hooks';
 import { classNames } from '@states/utils';
@@ -100,7 +100,7 @@ export const TodoModal = ({
         </ModalTransitionChild>
       </ModalTransitionRoot>
       {children}
-      <TodoModalWithKeyEffect todo={todo} />
+      <KeysWithTodoModalEffect todo={todo} />
       <DisableScrollEffect open={isTodoModalOpen} />
     </TodoModalFragment>
   );

--- a/lib/states/keybinds/KeysWithItemModalEffect.tsx
+++ b/lib/states/keybinds/KeysWithItemModalEffect.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 
 type Props = Pick<TypesTodo, 'todo'>;
 
-export const ItemModalWithKeyEffect = ({ todo }: Props) => {
+export const KeysWithItemModalEffect = ({ todo }: Props) => {
   const todoItemKeyHandler = useItemModalWithKey(todo._id);
 
   useEffect(() => {

--- a/lib/states/keybinds/KeysWithLabelModalEffect.tsx
+++ b/lib/states/keybinds/KeysWithLabelModalEffect.tsx
@@ -2,7 +2,7 @@ import { Types } from '@lib/types';
 import { useKeyWithLabelModal } from '@states/keybinds/hooks';
 import { useEffect } from 'react';
 
-export const LabelModalWithKeyEffect = ({ label }: Partial<Pick<Types, 'label'>>) => {
+export const KeysWithLabelModalEffect = ({ label }: Partial<Pick<Types, 'label'>>) => {
   const labelModalWithKey = useKeyWithLabelModal(label?._id);
 
   useEffect(() => {

--- a/lib/states/keybinds/KeysWithNavigateEffect.tsx
+++ b/lib/states/keybinds/KeysWithNavigateEffect.tsx
@@ -11,7 +11,7 @@ import { RecoilValue, useRecoilCallback, useRecoilValue } from 'recoil';
 
 type Props = Pick<Types, 'index' | 'divFocus' | 'todo'>;
 
-export const NavigateWithKeyEffect = ({ index, divFocus, todo }: Props) => {
+export const KeysWithNavigationEffect = ({ index, divFocus, todo }: Props) => {
   const setFocus = useFocusState(todo._id);
   const keyDownNavigate = useKeyWithNavigate();
   const currentFocus = useRecoilValue(atomCurrentFocus);

--- a/lib/states/keybinds/keysWithTodoModalEffect.tsx
+++ b/lib/states/keybinds/keysWithTodoModalEffect.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 
 type Props = Partial<Pick<TypesTodo, 'todo'>>;
 
-export const TodoModalWithKeyEffect = ({ todo }: Props) => {
+export const KeysWithTodoModalEffect = ({ todo }: Props) => {
   const windowCreateModalKeydownHandler = useKeyWithTodoModal(todo?._id);
 
   useEffect(() => {


### PR DESCRIPTION
Updated the name of effect components in `keybinds` state:

- `TodoModalWithKeyEffect`  > `KeysWithTodoModalEffect`
- `ItemModalWithKeyEffect`  > `KeysWithItemModalEffect`
- `NavigationWithKeyEffect` > `KeysWithNavigationEffect`
- `LabelModalWithKeyEffect` > `KeysWithLabelModalEffect`