### PR TITLE
feat: Now label adds a random color to Label's color field

### DIFF
--- a/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/index.tsx
+++ b/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/index.tsx
@@ -103,7 +103,7 @@ export const FooterSidebar = forwardRef<HTMLDivElement>((_, ref) => {
             isScrollDisabled ? 'overflow-y-hidden' : 'overflow-y-auto',
           )}>
           <div className='flex flex-grow flex-col'>
-            <nav className='flex-1 space-y-1 pb-24'>
+            <nav className='flex-1 space-y-1 pb-20'>
               <FooterSidebarMenu />
               <LabelList />
             </nav>

--- a/lib/data/stylePreset.tsx
+++ b/lib/data/stylePreset.tsx
@@ -67,3 +67,21 @@ export const STYLE_CALENDAR_COL_START = [
   'col-start-6',
   'col-start-7',
 ];
+
+/**
+ * Color palette
+ **/
+// background color
+export const STYLE_COLORS_BG = [
+  'bg-stone-400 hover:bg-stone-700',
+  'bg-orange-400 hover:bg-orange-700',
+  'bg-amber-400 hover:bg-amber-700',
+  'bg-lime-400 hover:bg-lime-700',
+  'bg-green-400 hover:bg-green-700',
+  'bg-teal-400 hover:bg-teal-700',
+  'bg-cyan-400 hover:bg-cyan-700',
+  'bg-blue-400 hover:bg-blue-700',
+  'bg-indigo-400 hover:bg-indigo-700',
+  'bg-purple-400 hover:bg-purple-700',
+  'bg-rose-400 hover:bg-rose-700',
+];

--- a/lib/models/Label/index.ts
+++ b/lib/models/Label/index.ts
@@ -13,6 +13,10 @@ const LabelSchema = new mongoose.Schema({
     type: String,
     required: true,
   },
+  color: {
+    type: String,
+    required: false,
+  },
   title_id: [
     {
       type: mongoose.Types.ObjectId,

--- a/lib/states/keybinds/hooks.tsx
+++ b/lib/states/keybinds/hooks.tsx
@@ -81,7 +81,7 @@ export const useKeyWithFocus = (_id: Todos['_id']) => {
             break;
           case event.key === 'Escape':
             event.preventDefault();
-            if (get(atomQueryTodoItem(_id)).isCompleted && get(atomTodoModalOpen(_id))) return;
+            if (get(atomQueryTodoItem(_id)).completed && get(atomTodoModalOpen(_id))) return;
             !get(atomTodoModalMini(_id)) && reset(atomOnFocus);
             reset(atomCurrentFocus);
             set(atomOnBlur, true);

--- a/lib/states/labels/hooks.tsx
+++ b/lib/states/labels/hooks.tsx
@@ -1,8 +1,9 @@
 import { CATCH_MODAL, NOTIFICATION } from '@data/stateObjects';
+import { STYLE_COLORS_BG } from '@data/stylePreset';
 import {
-    createDataNewLabel,
-    deleteDataLabelItem,
-    updateDataLabelItem
+  createDataNewLabel,
+  deleteDataLabelItem,
+  updateDataLabelItem,
 } from '@lib/queries/queryLabels';
 import { Labels, Todos, Types } from '@lib/types';
 import { atomConfirmModalDelete, atomLabelModalOpen } from '@states/modals';
@@ -18,6 +19,7 @@ import { atomLabelNew, atomQueryLabels, atomSelectorLabelItem } from '.';
  **/
 export const useLabelValueUpdate = (label?: Types['label']) => {
   return useRecoilCallback(({ set }) => (content: string) => {
+    const randomBgColor = STYLE_COLORS_BG[Math.floor(Math.random() * STYLE_COLORS_BG.length)];
     typeof label !== 'undefined'
       ? set(atomSelectorLabelItem(label._id), {
           name: content,
@@ -25,6 +27,7 @@ export const useLabelValueUpdate = (label?: Types['label']) => {
       : set(atomLabelNew, {
           name: content,
           _id: ObjectID().toHexString(),
+          color: randomBgColor,
         });
   });
 };
@@ -37,7 +40,7 @@ export const useLabelStateAdd = () => {
 
     set(atomQueryLabels, [
       ...get(atomQueryLabels),
-      { _id: get(atomLabelNew)._id, name: get(atomLabelNew).name },
+      { _id: get(atomLabelNew)._id, name: get(atomLabelNew).name, color: get(atomLabelNew).color },
     ]);
     createDataNewLabel(get(atomLabelNew));
     reset(atomLabelNew);

--- a/lib/states/labels/index.tsx
+++ b/lib/states/labels/index.tsx
@@ -29,6 +29,7 @@ export const atomLabelNew = atom<Labels>({
   default: {
     _id: undefined,
     name: '',
+    color: '',
     title_id: undefined,
     parent_id: undefined,
   } as Labels,

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -85,6 +85,7 @@ export interface Labels extends LabelIds {
   parent_id?: OBJECT_ID;
   title_id?: OBJECT_ID[];
   name: string;
+  color?: string;
 }
 
 export interface LabelIds {


### PR DESCRIPTION
Now label add random color from `STYLE_COLORS_PALETTE` to its color field. This random color can be used to add label's background color upon selection. Therefore, the modification of Label's Model, or Mongoose's schema, has been made by adding `color` field to the model.

Gotcha: The random color pick is literally random pick therefore there is a chance that the same color is picked twice. However, the improvement may not be necessary as a lining of the same color of labels may occur repeatedly.