### PR TITLE
feat: Added the `labelColor` and label to render in todoModal

### DIFF
--- a/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/footerSidebarMenu.tsx
+++ b/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/footerSidebarMenu.tsx
@@ -1,6 +1,6 @@
 import { PrefetchRouterButton } from '@buttons/button/prefetchRouterButton';
 import { SvgIcon } from '@components/icons/svgIcon';
-import { DATA_SIDEBAR_MENU } from '@data/stateArrayObjects';
+import { DATA_SIDEBAR_MENU } from '@data/dataArrayObjects';
 import { classNames } from '@states/utils';
 import { useRouter } from 'next/router';
 import { Fragment as FooterSidebarMenuFragment, Fragment as TotalNumberTodos } from 'react';

--- a/components/ui/buttons/button/index.tsx
+++ b/components/ui/buttons/button/index.tsx
@@ -14,12 +14,12 @@ type Props = { data: TypesDataButton } & Partial<
 
 export const Button = forwardRef<HTMLButtonElement, Props>(
   ({ data, onClick, onKeyDown, onDoubleClick, onMouseOver, children = data.name }: Props, ref) => {
-    const [isClicked, setClick] = useState(false);
+    const [hasTooltip, setTooltip] = useState(false);
 
     return (
       <Tooltip
-        tooltip={isClicked || data.isDisabled ? undefined : data.tooltip}
-        kbd={isClicked || data.isDisabled ? undefined : data.kbd}
+        tooltip={hasTooltip || data.isDisabled ? undefined : data.tooltip}
+        kbd={hasTooltip || data.isDisabled ? undefined : data.kbd}
         placement={data.placement}
         offset={data.offset}>
         <button
@@ -27,9 +27,9 @@ export const Button = forwardRef<HTMLButtonElement, Props>(
           className={data.className}
           disabled={data.isDisabled}
           onMouseOver={onMouseOver}
-          onMouseDown={() => !data.isDisabled && setClick(true)}
-          onMouseEnter={() => !data.isDisabled && setClick(false)}
-          onMouseLeave={() => !data.isDisabled && setClick(true)}
+          onMouseDown={() => !data.isDisabled && setTooltip(true)}
+          onMouseEnter={() => !data.isDisabled && setTooltip(false)}
+          onMouseLeave={() => !data.isDisabled && setTooltip(true)}
           onClick={onClick}
           onKeyDown={onKeyDown}
           onDoubleClick={onDoubleClick}

--- a/components/ui/dropdowns/calendarDropdown.tsx
+++ b/components/ui/dropdowns/calendarDropdown.tsx
@@ -28,7 +28,7 @@ type Props = { data: TypesDataDropdown } & Partial<Pick<Types, 'todo'>> &
 export const CalendarDropdown = ({
   todo,
   onClickConfirm,
-  data: { borderRadius, menuWidth, tooltip, padding = 'px-3 py-2' },
+  data: { borderRadius, tooltip, padding = 'px-3 py-2' },
 }: Props) => {
   const resetCalendar = useCalResetDayUpdater(todo?._id);
   const resetDateItemOnly = useCalResetDateItemOnly(todo?._id);
@@ -45,7 +45,6 @@ export const CalendarDropdown = ({
         tooltip: tooltip,
         padding: padding,
         borderRadius: borderRadius,
-        menuWidth: menuWidth,
         color: noDaySelected
           ? 'fill-gray-500 [.group-calendarDropdown:hover_&]:fill-gray-700'
           : 'fill-blue-500 [.group-calendarDropdown:hover_&]:fill-blue-700',

--- a/components/ui/dropdowns/dropdown/index.tsx
+++ b/components/ui/dropdowns/dropdown/index.tsx
@@ -81,7 +81,7 @@ export const Dropdown = ({
                 {headerContents && (
                   <span
                     className={classNames(
-                      'flex flex-row items-start justify-start pl-3 text-sm font-normal text-gray-500',
+                      'flex flex-row items-start justify-start whitespace-nowrap pl-3 text-sm font-normal text-gray-500',
                       text,
                     )}>
                     {headerContents}

--- a/components/ui/dropdowns/labelComboBoxDropdown.tsx
+++ b/components/ui/dropdowns/labelComboBoxDropdown.tsx
@@ -1,22 +1,63 @@
+import { IconButton } from '@buttons/iconButton';
 import { dataDropdownComboBox } from '@data/dataObjects';
+import { ICON_CLOSE } from '@data/materialSymbols';
 import { Types } from '@lib/types';
+import { selectorSelectedLabels } from '@states/labels';
+import { useRemoveTitleId } from '@states/labels/hooks';
+import { classNames } from '@states/utils';
 import { LabelComboBox } from '@ui/comboBoxes/labelComboBox';
-import {
-  Fragment as HeaderContentFragment,
-  Fragment as LabelComboBoxDropdownFragment,
-} from 'react';
+import { PseudoButton } from '@ui/pseudoButtons/pseudoButton';
+import { Fragment as LabelComboBoxDropdownFragment } from 'react';
+import { useRecoilValue } from 'recoil';
 import { Dropdown } from './dropdown';
 
 type Props = Partial<Pick<Types, 'todo'>>;
 
 export const LabelComboBoxDropdown = ({ todo }: Props) => {
+  const selectedLabels = useRecoilValue(selectorSelectedLabels(todo?._id));
+  const removeTitleId = useRemoveTitleId(todo?._id);
+
   return (
     <LabelComboBoxDropdownFragment>
-      <Dropdown
-        data={dataDropdownComboBox}
-        headerContents={<HeaderContentFragment>Label</HeaderContentFragment>}>
-        <LabelComboBox todo={todo} />
-      </Dropdown>
+      <div className='flex flex-row items-center justify-start overflow-x-auto px-1 pt-1 pb-2'>
+        <Dropdown
+          data={dataDropdownComboBox}
+          headerContents={selectedLabels.length === 0 && 'Label'}>
+          <LabelComboBox todo={todo} />
+        </Dropdown>
+        <ul className='flex flex-row items-center justify-center'>
+          {selectedLabels.map((label) => (
+            <li key={label._id}>
+              <div
+                className={classNames(
+                  'mr-1 flex cursor-pointer flex-row items-center justify-center rounded-lg py-[3px] pl-2 pr-1 text-sm text-gray-700',
+                  label.color && label.color,
+                  'bg-opacity-40 hover:bg-opacity-60',
+                )}>
+                <PseudoButton
+                  data={{
+                    className: 'max-w-[5.3rem] truncate pr-1',
+                    tooltip: label.name,
+                    offset: [10, 15],
+                  }}>
+                  {label.name}
+                </PseudoButton>
+                <IconButton
+                  data={{
+                    path: ICON_CLOSE,
+                    padding: 'p-[2px]',
+                    hoverBg: 'bg-opacity-0 hover:bg-opacity-30',
+                    size: 'h-4 w-4',
+                    color: 'fill-gray-700 hover:fill-gray-900',
+                    container: 'h-5',
+                  }}
+                  onClick={() => removeTitleId(label._id)}
+                />
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
     </LabelComboBoxDropdownFragment>
   );
 };

--- a/components/ui/modals/todoModals/todoModal/index.tsx
+++ b/components/ui/modals/todoModals/todoModal/index.tsx
@@ -69,7 +69,7 @@ export const TodoModal = ({
             <div className='hidden sm:mb-2 sm:block'>
               <PlainLineDivider />
             </div>
-            <div className='m-1 sm:flex sm:flex-row'>
+            <div className='m-1 items-center sm:flex sm:flex-row '>
               <CalendarDropdown
                 data={{ tooltip: 'Due date' }}
                 todo={todo}

--- a/components/ui/pseudoButtons/pseudoButton/index.tsx
+++ b/components/ui/pseudoButtons/pseudoButton/index.tsx
@@ -14,20 +14,21 @@ type Props = { data: TypesDataPseudoButton } & Partial<
 
 export const PseudoButton = forwardRef<HTMLDivElement, Props>(
   ({ data, onClick, onKeyDown, onDoubleClick, onMouseOver, children = data.name }: Props, ref) => {
-    const [isClicked, setClick] = useState(false);
+    const [hasTooltip, setTooltip] = useState(false);
 
     return (
       <Tooltip
-        tooltip={isClicked ? undefined : data.tooltip}
-        kbd={isClicked ? undefined : data.kbd}
+        tooltip={hasTooltip ? undefined : data.tooltip}
+        kbd={hasTooltip ? undefined : data.kbd}
         placement={data.placement}
         offset={data.offset}>
         <div
           className={data.className}
           onMouseOver={onMouseOver}
-          onMouseDown={() => setClick(true)}
-          onMouseEnter={() => setClick(false)}
-          onMouseLeave={() => setClick(true)}
+          onMouseDown={() => setTooltip(true)}
+          onMouseEnter={() => setTooltip(false)}
+          onMouseLeave={() => setTooltip(true)}
+          onWheel={() => setTooltip(true)}
           onClick={onClick}
           onKeyDown={onKeyDown}
           onDoubleClick={onDoubleClick}

--- a/lib/data/dataArrayObjects.tsx
+++ b/lib/data/dataArrayObjects.tsx
@@ -139,7 +139,7 @@ export const DATA_SIDEBAR_MENU = [
   },
   {
     name: 'Show All',
-    tooltip: 'Show all incompleted todos',
+    tooltip: 'Show all incomplete todos',
     icon: ICON_LIST,
     iconActive: ICON_LIST,
     iconColor: 'fill-purple-600',

--- a/lib/data/dataObjects.tsx
+++ b/lib/data/dataObjects.tsx
@@ -272,7 +272,7 @@ export const dataDropdownComboBox: TypesDataDropdown = {
   tooltip: 'Add label',
   hasDivider: false,
   contentWidth: 'w-72',
-  menuWidth: 'ml-2',
+  menuWidth: 'ml-1',
   padding: 'px-3 py-2',
 };
 

--- a/lib/data/stylePreset.tsx
+++ b/lib/data/stylePreset.tsx
@@ -72,16 +72,16 @@ export const STYLE_CALENDAR_COL_START = [
  * Color palette
  **/
 // background color
-export const STYLE_COLORS_BG = [
-  'bg-stone-400 hover:bg-stone-700',
-  'bg-orange-400 hover:bg-orange-700',
-  'bg-amber-400 hover:bg-amber-700',
-  'bg-lime-400 hover:bg-lime-700',
-  'bg-green-400 hover:bg-green-700',
-  'bg-teal-400 hover:bg-teal-700',
-  'bg-cyan-400 hover:bg-cyan-700',
-  'bg-blue-400 hover:bg-blue-700',
-  'bg-indigo-400 hover:bg-indigo-700',
-  'bg-purple-400 hover:bg-purple-700',
-  'bg-rose-400 hover:bg-rose-700',
+export const STYLE_COLORS = [
+  'bg-stone-400',
+  'bg-orange-400',
+  'bg-amber-400',
+  'bg-lime-400',
+  'bg-green-400',
+  'bg-teal-400',
+  'bg-cyan-400',
+  'bg-blue-400',
+  'bg-indigo-400',
+  'bg-purple-400',
+  'bg-rose-400',
 ];

--- a/lib/dataConnections/indexedDB.ts
+++ b/lib/dataConnections/indexedDB.ts
@@ -1,4 +1,4 @@
-import { DATA_IDB } from '@data/stateArrayObjects';
+import { DATA_IDB } from '@data/dataArrayObjects';
 import { IDB } from '@data/stateObjects';
 import { Types, TypesIDB } from '@lib/types';
 import { openDB } from 'idb';

--- a/lib/states/notifications/index.tsx
+++ b/lib/states/notifications/index.tsx
@@ -1,4 +1,4 @@
-import { DATA_NOTIFICATION } from '@data/stateArrayObjects';
+import { DATA_NOTIFICATION } from '@data/dataArrayObjects';
 import { TypesNotification } from '@lib/types';
 import { atom, atomFamily, selectorFamily, selector } from 'recoil';
 

--- a/lib/states/utils/hooks.tsx
+++ b/lib/states/utils/hooks.tsx
@@ -1,11 +1,11 @@
-import { Todos, Labels, Types } from '@lib/types';
+import { Labels, Todos, Types } from '@lib/types';
 import { atomLabelNew, atomQueryLabels, atomSelectorLabelItem } from '@states/labels';
-import { atomTodoModalOpen, atomTodoModalMini } from '@states/modals';
-import { atomTodoNew, atomSelectorTodoItem } from '@states/todos';
+import { atomTodoModalMini, atomTodoModalOpen } from '@states/modals';
+import { atomSelectorTodoItem, atomTodoNew } from '@states/todos';
 import { atomQueryTodoItem } from '@states/todos/atomQueries';
 import equal from 'fast-deep-equal/react';
 import { useEffect } from 'react';
-import { useRecoilCallback, RecoilValue, useRecoilValue, RecoilState } from 'recoil';
+import { RecoilState, RecoilValue, useRecoilCallback, useRecoilValue } from 'recoil';
 
 /**
  * Hooks


### PR DESCRIPTION
Now label has a new field in the schema model, `color`. At the moment new label is created, the label will pick random `bg-color` from STYLE_COLORS to add a color to label. The color of the label can be used to display the label's color in the todoModal.

Now selecting any label will display to todoModal. Each rendered label can be removed individually by clicking `close` icon.

Minor other changes:
1. Fixed the typos
2. Removed the unused hook
3. Updated the styles of components
4. Implemented onWheel to disable tooltip on Button and PseudoButton components.