### PR TITLE
feat: Update the layout structure to `per-page`

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,17 +1,26 @@
 import { LayoutHome } from '@layouts/layoutHome';
+import { NextPage } from 'next';
 import type { AppProps } from 'next/app';
+import { ReactElement, ReactNode } from 'react';
 import { RecoilRoot } from 'recoil';
 import '../styles/globals.css';
 
-const MyApp = ({ Component, pageProps }: AppProps) => {
+export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
+  getLayout?: (page: ReactElement) => ReactNode;
+};
+
+type AppPropsWithLayout = AppProps & {
+  Component: NextPageWithLayout;
+};
+
+const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
+  const getLayout = Component.getLayout ?? ((page) => page);
+
   return (
     <RecoilRoot>
-      <LayoutHome>
-        <Component {...pageProps} />
-      </LayoutHome>
+      <LayoutHome>{getLayout(<Component {...pageProps} />)}</LayoutHome>
     </RecoilRoot>
   );
 };
 
 export default MyApp;
-

--- a/pages/app/[...app].tsx
+++ b/pages/app/[...app].tsx
@@ -1,13 +1,14 @@
 import dynamic from 'next/dynamic';
-import { Fragment } from 'react';
+import { Fragment, ReactElement } from 'react';
 
 const LayoutApp = dynamic(() => import('@layouts/layoutApp').then((mod) => mod.LayoutApp));
 
 const CatchAllApp = () => {
-  return (
-    <LayoutApp>
-      <Fragment />
-    </LayoutApp>
-  );
+  return <Fragment />;
 };
+
+CatchAllApp.getLayout = function getLayout(page: ReactElement) {
+  return <LayoutApp>{page}</LayoutApp>;
+};
+
 export default CatchAllApp;

--- a/pages/app/[appId].tsx
+++ b/pages/app/[appId].tsx
@@ -1,7 +1,7 @@
 import { ErrorState } from '@components/loadable/errorState';
 import { LayoutApp } from '@layouts/layoutApp';
 import dynamic from 'next/dynamic';
-import { Fragment as AppByIdFragment } from 'react';
+import { Fragment as AppByIdFragment, ReactElement } from 'react';
 
 const LoadingTodos = dynamic(() =>
   import('@components/loadable/loadingStates/loadingTodos').then((mod) => mod.LoadingTodos),
@@ -20,12 +20,15 @@ const AppById = () => {
   return (
     <AppByIdFragment>
       <FilterTodoIdsEffect />
-      <LayoutApp>
         <ErrorBoundary fallback={<ErrorState />}>
           <TodoList />
         </ErrorBoundary>
-      </LayoutApp>
     </AppByIdFragment>
   );
 };
+
+AppById.getLayout = function getLayout(page: ReactElement) {
+  return <LayoutApp>{page}</LayoutApp>;
+};
+
 export default AppById;

--- a/pages/app/index.tsx
+++ b/pages/app/index.tsx
@@ -1,7 +1,7 @@
 import { ErrorState } from '@components/loadable/errorState';
 import { LayoutApp } from '@layouts/layoutApp';
 import dynamic from 'next/dynamic';
-import { Fragment as AppFragment } from 'react';
+import { Fragment as AppFragment, ReactElement } from 'react';
 
 const LoadingTodos = dynamic(() =>
   import('@components/loadable/loadingStates/loadingTodos').then((mod) => mod.LoadingTodos),
@@ -20,12 +20,15 @@ const App = () => {
   return (
     <AppFragment>
       <FilterTodoIdsEffect />
-      <LayoutApp>
-        <ErrorBoundary fallback={<ErrorState />}>
-          <TodoList />
-        </ErrorBoundary>
-      </LayoutApp>
+      <ErrorBoundary fallback={<ErrorState />}>
+        <TodoList />
+      </ErrorBoundary>
     </AppFragment>
   );
 };
+
+App.getLayout = function getLayout(page: ReactElement) {
+  return <LayoutApp>{page}</LayoutApp>;
+};
+
 export default App;


### PR DESCRIPTION
Implemented the `per-page` layout to leverage the per-page layout structure. This update will be changed in the future as Next.js version 13's `app/` directory become out of beta. The `app/` directory supports for layouts, nested routes, and uses Server Components by default according to Next.js: however, this feature is currently under the beta.