### PR TITLE
feat: Added the label routing

### DIFF
--- a/components/labels/labelItem.tsx
+++ b/components/labels/labelItem.tsx
@@ -1,6 +1,10 @@
+import { PrefetchRouterButton } from '@buttons/button/prefetchRouterButton';
 import { SvgIcon } from '@components/icons/svgIcon';
-import { ICON_LABEL } from '@data/materialSymbols';
+import { ICON_LABEL, ICON_LABEL_FILL } from '@data/materialSymbols';
+import { TodosCount } from '@layouts/layoutApp/layout/layoutFooter/footerSidebar/todosCount';
 import { Types } from '@lib/types';
+import { classNames, paths } from '@states/utils';
+import { useNextQuerySlug } from '@states/utils/hooks';
 import dynamic from 'next/dynamic';
 import { Fragment, Fragment as LabelModalFragment } from 'react';
 
@@ -17,22 +21,48 @@ const DeleteLabelConfirmModal = dynamic(() =>
 );
 
 export const LabelItem = ({ label }: Pick<Types, 'label'>) => {
+  const slug = useNextQuerySlug('/app/label');
+  const matchedSlug = slug === label._id;
+
   return (
     <Fragment>
-      <div className='item-center group relative -mb-1 flex cursor-pointer flex-row justify-between'>
-        <div className='flex w-full flex-row rounded-lg py-2 px-2 hover:bg-gray-200 hover:bg-opacity-80'>
-          <SvgIcon
-            data={{
-              path: ICON_LABEL,
-              className: 'h-5 w-5 fill-gray-500 group-hover:fill-gray-700',
-            }}
-          />
-          <div className='pl-2 text-gray-600 group-hover:text-gray-900'>{label.name}</div>
+      <div className='group relative -mb-0 flex w-full cursor-pointer flex-row items-center justify-between'>
+        <div className='mr-[0.5rem] inline-block w-full'>
+          <PrefetchRouterButton
+            tooltip={label.name}
+            offset={[0, 10]}
+            path={paths('/app/label/', label._id)}
+            className={classNames(
+              'w-full rounded-lg hover:bg-gray-200 hover:bg-opacity-80 focus:outline-none focus:ring-0 focus:ring-offset-0',
+              matchedSlug && 'bg-blue-100 font-semibold',
+            )}>
+            <div className='flex w-full flex-row py-2 px-2'>
+              {matchedSlug ? (
+                <SvgIcon
+                  data={{
+                    path: ICON_LABEL_FILL,
+                    className: 'h-5 w-5 fill-yellow-500',
+                  }}
+                />
+              ) : (
+                <SvgIcon
+                  data={{
+                    path: ICON_LABEL,
+                    className: 'h-5 w-5 fill-gray-500 group-hover:fill-yellow-500 ',
+                  }}
+                />
+              )}
+              <div className='pl-2 text-gray-600 group-hover:text-gray-900'>{label.name}</div>
+            </div>
+          </PrefetchRouterButton>
         </div>
         <LabelItemDropdown
           label={label}
           data={{ isInitiallyVisible: false }}
         />
+        <span className='absolute right-3 top-1/2 -translate-y-2/4 select-none text-xs tracking-tighter text-slate-400'>
+          <TodosCount label={label} />
+        </span>
       </div>
       <LabelModalFragment>
         <ItemLabelModal label={label} />

--- a/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/footerSidebarMenu.tsx
+++ b/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/footerSidebarMenu.tsx
@@ -19,12 +19,12 @@ export const FooterSidebarMenu = () => {
             <PrefetchRouterButton
               tooltip={item.tooltip}
               offset={[0, 5]}
-              pathName={item.path}
+              path={item.path}
               className={classNames(
                 router.asPath === item.path
                   ? 'cursor-default bg-blue-100 text-gray-900'
                   : 'text-gray-600 hover:bg-gray-200 hover:bg-opacity-80 hover:text-gray-900',
-                'group flex w-full items-center rounded-md px-2 py-2 text-sm font-medium',
+                'group ml-[0.05rem] mt-[0.05rem] flex w-full items-center rounded-md px-2 py-2 text-sm font-medium focus:outline-none focus:ring-0 focus:ring-offset-0',
               )}>
               <span className='pr-3'>
                 <SvgIcon

--- a/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/todosCount.tsx
+++ b/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/todosCount.tsx
@@ -1,11 +1,14 @@
-import { PATHNAME } from '@data/stateObjects';
-import { selectorFilterTodoIdsByPathname } from '@states/todos';
+import { Types } from '@lib/types';
+import { selectorTodosCount } from '@states/todos';
 import { Fragment } from 'react';
 import { useRecoilValue } from 'recoil';
 
-export const TodosCount = ({ pathname }: { pathname: PATHNAME }) => {
-  const todoIdsByPathName = useRecoilValue(selectorFilterTodoIdsByPathname(pathname));
-  const todoCounts = todoIdsByPathName.length;
+type Props = Partial<Pick<Types, 'label' | 'pathname'>>;
 
-  return <Fragment>{todoCounts}</Fragment>;
+export const TodosCount = ({ pathname, label }: Props) => {
+  const todosCount = useRecoilValue(
+    selectorTodosCount({ pathname: pathname, labelId: label?._id }),
+  );
+
+  return <Fragment>{todosCount > 0 ? todosCount : undefined}</Fragment>;
 };

--- a/components/layouts/layoutApp/layoutLogo.tsx
+++ b/components/layouts/layoutApp/layoutLogo.tsx
@@ -7,7 +7,7 @@ export const LayoutLogo = () => {
     <nav className='flex h-0 flex-row items-center'>
       <LogoContainerFragment>
         <PrefetchRouterButton
-          pathName='/'
+          path='/'
           className='cursor-pointer'>
           <LogoFragment>
             <div>I am a LOGO</div>

--- a/components/ui/buttons/button/prefetchRouterButton.tsx
+++ b/components/ui/buttons/button/prefetchRouterButton.tsx
@@ -4,7 +4,7 @@ import { Fragment, useEffect } from 'react';
 import { Button } from '.';
 
 export const PrefetchRouterButton = ({
-  pathName,
+  path,
   children,
   className,
   isPrefetchingOnHover,
@@ -13,7 +13,7 @@ export const PrefetchRouterButton = ({
   kbd,
   offset,
   placement,
-}: Pick<Types, 'pathName' | 'children'> &
+}: Pick<Types, 'path' | 'children'> &
   Partial<
     Pick<
       Types,
@@ -24,9 +24,9 @@ export const PrefetchRouterButton = ({
 
   useEffect(() => {
     if (!isPrefetchingOnHover || typeof isPrefetchingOnHover === 'undefined') {
-      router.prefetch(pathName);
+      router.prefetch(path);
     }
-  }, [pathName, isPrefetchingOnHover, router]);
+  }, [path, isPrefetchingOnHover, router]);
 
   return (
     <Fragment>
@@ -38,11 +38,11 @@ export const PrefetchRouterButton = ({
           placement: placement,
           offset: offset,
         }}
-        onMouseOver={() => isPrefetchingOnHover && router.prefetch(pathName)}
+        onMouseOver={() => isPrefetchingOnHover && router.prefetch(path)}
         onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
           event.preventDefault();
-          router.push(pathName);
-          onClick;
+          router.push(path);
+          onClick && onClick(event);
         }}>
         {children}
       </Button>

--- a/components/ui/dropdowns/calendarDropdown.tsx
+++ b/components/ui/dropdowns/calendarDropdown.tsx
@@ -51,6 +51,7 @@ export const CalendarDropdown = ({
         path: noDaySelected ? ICON_EVENT_AVAILABLE : ICON_EVENT_AVAILABLE_FILL,
         group: 'group-calendarDropdown',
         contentWidth: 'w-[21rem]',
+        menuWidth: 'w-full',
         text: classNames('[.group-calendarDropdown:hover_&]:text-gray-700'),
       }}
       headerContents={

--- a/components/ui/dropdowns/labelComboBoxDropdown.tsx
+++ b/components/ui/dropdowns/labelComboBoxDropdown.tsx
@@ -1,12 +1,13 @@
+import { PrefetchRouterButton } from '@buttons/button/prefetchRouterButton';
 import { IconButton } from '@buttons/iconButton';
 import { dataDropdownComboBox } from '@data/dataObjects';
 import { ICON_CLOSE } from '@data/materialSymbols';
 import { Types } from '@lib/types';
 import { selectorSelectedLabels } from '@states/labels';
 import { useRemoveTitleId } from '@states/labels/hooks';
-import { classNames } from '@states/utils';
+import { useTodoModalStateClose } from '@states/modals/hooks';
+import { classNames, paths } from '@states/utils';
 import { LabelComboBox } from '@ui/comboBoxes/labelComboBox';
-import { PseudoButton } from '@ui/pseudoButtons/pseudoButton';
 import { Fragment as LabelComboBoxDropdownFragment } from 'react';
 import { useRecoilValue } from 'recoil';
 import { Dropdown } from './dropdown';
@@ -16,6 +17,7 @@ type Props = Partial<Pick<Types, 'todo'>>;
 export const LabelComboBoxDropdown = ({ todo }: Props) => {
   const selectedLabels = useRecoilValue(selectorSelectedLabels(todo?._id));
   const removeTitleId = useRemoveTitleId(todo?._id);
+  const closeTodoModal = useTodoModalStateClose(todo?._id);
 
   return (
     <LabelComboBoxDropdownFragment>
@@ -34,14 +36,14 @@ export const LabelComboBoxDropdown = ({ todo }: Props) => {
                   label.color && label.color,
                   'bg-opacity-40 hover:bg-opacity-60',
                 )}>
-                <PseudoButton
-                  data={{
-                    className: 'max-w-[5.3rem] truncate pr-1',
-                    tooltip: label.name,
-                    offset: [10, 15],
-                  }}>
+                <PrefetchRouterButton
+                  path={paths('/app/label/', label._id)}
+                  className='max-w-[5.3rem] truncate pr-1'
+                  tooltip={label.name}
+                  offset={[10, 15]}
+                  onClick={() => closeTodoModal()}>
                   {label.name}
-                </PseudoButton>
+                </PrefetchRouterButton>
                 <IconButton
                   data={{
                     path: ICON_CLOSE,

--- a/lib/data/stateObjects.tsx
+++ b/lib/data/stateObjects.tsx
@@ -1,6 +1,6 @@
 import ObjectID from 'bson-objectid';
 
-export type CATCH_MODAL = typeof CATCH_MODAL[keyof typeof CATCH_MODAL];
+export type CATCH_MODAL = (typeof CATCH_MODAL)[keyof typeof CATCH_MODAL];
 export const CATCH_MODAL = {
   todoModal: 'todoModal',
   labelModal: 'labelModal',
@@ -8,7 +8,7 @@ export const CATCH_MODAL = {
   minimizedModal: 'minimizedModal',
 } as const;
 
-export type FOCUS = typeof FOCUS[keyof typeof FOCUS];
+export type FOCUS = (typeof FOCUS)[keyof typeof FOCUS];
 export const FOCUS = {
   openTodoModalOnFocus: 'openTodoModalOnFocus',
   returnOnNoFocus: 'returnOnNoFocus',
@@ -16,7 +16,7 @@ export const FOCUS = {
   resetCurrentFocus: 'resetCurrentFocus',
 } as const;
 
-export type NOTIFICATION = typeof NOTIFICATION[keyof typeof NOTIFICATION];
+export type NOTIFICATION = (typeof NOTIFICATION)[keyof typeof NOTIFICATION];
 export const NOTIFICATION = {
   offline: 'offline',
   actionUndone: 'actionUndone',
@@ -34,13 +34,13 @@ export const NOTIFICATION = {
   deleteLabel: 'deleteLabel',
 } as const;
 
-export type OBJECT_ID = typeof OBJECT_ID[keyof typeof OBJECT_ID];
+export type OBJECT_ID = (typeof OBJECT_ID)[keyof typeof OBJECT_ID];
 export const OBJECT_ID = {
   objectID: ObjectID().toHexString(),
 } as const;
 
-export type POSITION_X = typeof POSITION_X[keyof typeof POSITION_X];
-export type POSITION_Y = typeof POSITION_Y[keyof typeof POSITION_Y];
+export type POSITION_X = (typeof POSITION_X)[keyof typeof POSITION_X];
+export type POSITION_Y = (typeof POSITION_Y)[keyof typeof POSITION_Y];
 export const POSITION_X = {
   left: 'sm:items-start',
   right: 'sm:items-end',
@@ -52,14 +52,14 @@ export const POSITION_Y = {
   center: 'sm:items-center',
 } as const;
 
-export type PRIORITY_LEVEL = typeof PRIORITY_LEVEL[keyof typeof PRIORITY_LEVEL];
+export type PRIORITY_LEVEL = (typeof PRIORITY_LEVEL)[keyof typeof PRIORITY_LEVEL];
 export const PRIORITY_LEVEL = {
   urgent: 1,
   important: 2,
   normal: 3,
 } as const;
 
-export type CALENDAR = typeof CALENDAR[keyof typeof CALENDAR];
+export type CALENDAR = (typeof CALENDAR)[keyof typeof CALENDAR];
 export const CALENDAR = {
   today: 'today',
   nextMonth: 'nextMonth',
@@ -67,7 +67,7 @@ export const CALENDAR = {
   days: 'days',
 } as const;
 
-export type IDB = typeof IDB[keyof typeof IDB];
+export type IDB = (typeof IDB)[keyof typeof IDB];
 export const IDB = {
   Todos: 'Todos',
   Labels: 'Labels',
@@ -75,7 +75,7 @@ export const IDB = {
   Cache: 'Cache',
 } as const;
 
-export type IDB_STORE = typeof IDB_STORE[keyof typeof IDB_STORE];
+export type IDB_STORE = (typeof IDB_STORE)[keyof typeof IDB_STORE];
 export const IDB_STORE = {
   todos: 'todos',
   labels: 'labels',
@@ -84,7 +84,7 @@ export const IDB_STORE = {
   cache: 'cache',
 } as const;
 
-export type BREAKPOINT = typeof BREAKPOINT[keyof typeof BREAKPOINT];
+export type BREAKPOINT = (typeof BREAKPOINT)[keyof typeof BREAKPOINT];
 export const BREAKPOINT = {
   sm: 640,
   md: 768,
@@ -96,13 +96,13 @@ export const BREAKPOINT = {
   '5xl': 2304,
 } as const;
 
-export type SCHEMA_TODO = typeof SCHEMA_TODO[keyof typeof SCHEMA_TODO];
+export type SCHEMA_TODO = (typeof SCHEMA_TODO)[keyof typeof SCHEMA_TODO];
 export const SCHEMA_TODO = {
   todoItem: 'todoItem',
   todoNote: 'todoNote',
 } as const;
 
-export type FITLER_TODOIDS = typeof FILTER_TODOIDS[keyof typeof FILTER_TODOIDS];
+export type FITLER_TODOIDS = (typeof FILTER_TODOIDS)[keyof typeof FILTER_TODOIDS];
 export const FILTER_TODOIDS = {
   focus: 'focus',
   showAll: 'showAll',
@@ -111,11 +111,12 @@ export const FILTER_TODOIDS = {
   completed: 'completed',
 } as const;
 
-export type PATHNAME = typeof PATHNAME[keyof typeof PATHNAME];
+export type PATHNAME = (typeof PATHNAME)[keyof typeof PATHNAME];
 export const PATHNAME = {
   app: '/app',
   urgent: '/app/urgent',
   important: '/app/important',
   showAll: '/app/showall',
   completed: '/app/completed',
+  label: '/app/label/(.*)$',
 } as const;

--- a/lib/states/labels/index.tsx
+++ b/lib/states/labels/index.tsx
@@ -46,6 +46,11 @@ export const atomSelectorLabelItem = atomFamily<Labels, Labels['_id']>({
   }),
 });
 
+export const atomLabelId = atom<Labels['_id']>({
+  key: 'atomLabelId',
+  default: undefined,
+});
+
 /**
  * Selectors
  **/

--- a/lib/states/todos/filterTodoIdsEffect.tsx
+++ b/lib/states/todos/filterTodoIdsEffect.tsx
@@ -1,30 +1,25 @@
 import { PATHNAME } from '@data/stateObjects';
+import { atomLabelId } from '@states/labels';
+import { useNextQuerySlug } from '@states/utils/hooks';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { useRecoilCallback } from 'recoil';
 import { atomFilterTodoIds } from '.';
 
 export const FilterTodoIdsEffect = () => {
-  const router = useRouter();
+  const labelId = useNextQuerySlug('/app/label');
+  const { asPath } = useRouter();
+
   const filterTodoIds = useRecoilCallback(({ set }) => () => {
-    switch (router.asPath) {
-      case PATHNAME['app']:
-        set(atomFilterTodoIds, 'focus');
-        break;
-      case PATHNAME['urgent']:
-        set(atomFilterTodoIds, 'urgent');
-        break;
-      case PATHNAME['important']:
-        set(atomFilterTodoIds, 'important');
-        break;
-      case PATHNAME['showAll']:
-        set(atomFilterTodoIds, 'showAll');
-        break;
-      case PATHNAME['completed']:
-        set(atomFilterTodoIds, 'completed');
-        break;
-      default:
-        break;
+    if (asPath === PATHNAME['app']) return set(atomFilterTodoIds, 'focus');
+    if (asPath === PATHNAME['urgent']) return set(atomFilterTodoIds, 'urgent');
+    if (asPath === PATHNAME['important']) return set(atomFilterTodoIds, 'important');
+    if (asPath === PATHNAME['showAll']) return set(atomFilterTodoIds, 'showAll');
+    if (asPath === PATHNAME['completed']) return set(atomFilterTodoIds, 'completed');
+    if (asPath.match(new RegExp(PATHNAME['label']))) {
+      set(atomFilterTodoIds, 'label');
+      set(atomLabelId, labelId);
+      return;
     }
   });
 

--- a/lib/states/todos/hooks.tsx
+++ b/lib/states/todos/hooks.tsx
@@ -162,26 +162,6 @@ export const useTodoStateComplete = (todoId: Todos['_id']) => {
       : setNotification(NOTIFICATION['unCompleteTodo']);
   };
 };
-export const useTodoIdsWithPathname = () => {
-  const router = useRouter();
-  const app = useRecoilValue(selectorFilterTodoIdsByPathname(PATHNAME['app']));
-  const urgent = useRecoilValue(selectorFilterTodoIdsByPathname(PATHNAME['urgent']));
-  const important = useRecoilValue(selectorFilterTodoIdsByPathname(PATHNAME['important']));
-  const completed = useRecoilValue(selectorFilterTodoIdsByPathname(PATHNAME['completed']));
-
-  switch (router.asPath) {
-    case PATHNAME['app']:
-      return app;
-    case PATHNAME['urgent']:
-      return urgent;
-    case PATHNAME['important']:
-      return important;
-    case PATHNAME['completed']:
-      return completed;
-    default:
-      return app;
-  }
-};
 
 export const useFilterTodoIdsWithPathname = () => {
   const router = useRouter();

--- a/lib/states/utils/hooks.tsx
+++ b/lib/states/utils/hooks.tsx
@@ -4,7 +4,8 @@ import { atomTodoModalMini, atomTodoModalOpen } from '@states/modals';
 import { atomSelectorTodoItem, atomTodoNew } from '@states/todos';
 import { atomQueryTodoItem } from '@states/todos/atomQueries';
 import equal from 'fast-deep-equal/react';
-import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { useEffect, useMemo } from 'react';
 import { RecoilState, RecoilValue, useRecoilCallback, useRecoilValue } from 'recoil';
 
 /**
@@ -65,4 +66,16 @@ export const RecoilObserver = <T,>({
   const value = useRecoilValue(node);
   useEffect(() => onChange(value), [onChange, value]);
   return null;
+};
+
+export const useNextQuerySlug = (path: string): string | undefined => {
+  const router = useRouter();
+
+  const value = useMemo(() => {
+    const match = router.asPath.match(new RegExp(`${path}/(.*)(&|$)`));
+    if (!match) return undefined;
+    return decodeURIComponent(match[1]);
+  }, [path, router]);
+
+  return value;
 };

--- a/lib/states/utils/index.tsx
+++ b/lib/states/utils/index.tsx
@@ -1,8 +1,7 @@
 import { CATCH_MODAL } from '@data/stateObjects';
-import { atomFamily, atom } from 'recoil';
 import { render, RenderOptions } from '@testing-library/react';
 import React, { FC, ReactElement } from 'react';
-import { RecoilRoot } from 'recoil';
+import { atom, atomFamily, RecoilRoot } from 'recoil';
 
 /**
  * Atoms
@@ -25,14 +24,13 @@ export const atomDisableScroll = atom<boolean>({
 export const dayInSecond = 60 * 60 * 24;
 
 // tailwind classNames
-export const classNames = (...classes: unknown[]) => {
-  return classes.filter(Boolean).join(' ') || undefined;
-};
+export const classNames = (...classes: unknown[]) => classes.filter(Boolean).join(' ') || undefined;
 
 // Query Joins
-export const queries = (...queries: unknown[]) => {
-  return queries.filter(Boolean).join('&') || '';
-};
+export const queries = (...queries: unknown[]) => queries.filter(Boolean).join('&') || '';
+
+// path joins
+export const paths = (...paths: unknown[]) => paths.filter(Boolean).join('') || '';
 
 // test-utils for custom render
 const RecoilRootProvider: FC<{ children: React.ReactNode }> = ({ children }) => {

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -4,6 +4,7 @@ import {
   IDB_STORE,
   NOTIFICATION,
   OBJECT_ID,
+  PATHNAME,
   POSITION_X,
   POSITION_Y,
   PRIORITY_LEVEL,
@@ -164,7 +165,8 @@ type CollectTypesMISC = TypesIndexedDB &
   TypesStyleAttributes;
 
 export interface TypesRouter {
-  pathName: string;
+  path: string;
+  pathname: PATHNAME;
   isPrefetchingOnHover: boolean;
 }
 

--- a/pages/app/[...app].tsx
+++ b/pages/app/[...app].tsx
@@ -4,7 +4,7 @@ import { Fragment, ReactElement } from 'react';
 const LayoutApp = dynamic(() => import('@layouts/layoutApp').then((mod) => mod.LayoutApp));
 
 const CatchAllApp = () => {
-  return <Fragment />;
+  return <Fragment>Nothing to show you</Fragment>;
 };
 
 CatchAllApp.getLayout = function getLayout(page: ReactElement) {

--- a/pages/app/label/[...label].tsx
+++ b/pages/app/label/[...label].tsx
@@ -1,0 +1,12 @@
+import { LayoutApp } from '@layouts/layoutApp';
+import { ReactElement } from 'react';
+
+const CatchAllLabels = () => {
+  return;
+};
+
+CatchAllLabels.getLayout = function getLayout(page: ReactElement) {
+  return <LayoutApp>{page}</LayoutApp>;
+};
+
+export default CatchAllLabels;

--- a/pages/app/label/[labelId].tsx
+++ b/pages/app/label/[labelId].tsx
@@ -1,0 +1,34 @@
+import { ErrorState } from '@components/loadable/errorState';
+import { LayoutApp } from '@layouts/layoutApp';
+import dynamic from 'next/dynamic';
+import { Fragment, ReactElement } from 'react';
+
+const LoadingTodos = dynamic(() =>
+  import('@components/loadable/loadingStates/loadingTodos').then((mod) => mod.LoadingTodos),
+);
+const TodoList = dynamic(() => import('components/todos/todoList').then((mod) => mod.TodoList), {
+  loading: () => <LoadingTodos />,
+});
+const FilterTodoIdsEffect = dynamic(() =>
+  import('@states/todos/filterTodoIdsEffect').then((mod) => mod.FilterTodoIdsEffect),
+);
+const ErrorBoundary = dynamic(() =>
+  import('react-error-boundary').then((mod) => mod.ErrorBoundary),
+);
+
+const LabelById = () => {
+  return (
+    <Fragment>
+      <FilterTodoIdsEffect />
+      <ErrorBoundary fallback={<ErrorState />}>
+        <TodoList />
+      </ErrorBoundary>
+    </Fragment>
+  );
+};
+
+LabelById.getLayout = function getLayout(page: ReactElement) {
+  return <LayoutApp>{page}</LayoutApp>;
+};
+
+export default LabelById;

--- a/pages/app/label/index.tsx
+++ b/pages/app/label/index.tsx
@@ -1,0 +1,12 @@
+import { LayoutApp } from '@layouts/layoutApp';
+import { ReactElement } from 'react';
+
+const Label = () => {
+  return;
+};
+
+Label.getLayout = function getLayout(page: ReactElement) {
+  return <LayoutApp>{page}</LayoutApp>;
+};
+
+export default Label;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,7 +11,7 @@ const Home = () => {
     <div className='flex w-full flex-row justify-center'>
       <PrefetchRouterButton
         className={STYLE_BUTTON_NORMAL_BLUE}
-        pathName={PATHNAME['app']}>
+        path={PATHNAME['app']}>
         Go to App
       </PrefetchRouterButton>
     </div>


### PR DESCRIPTION
Added the per-page layout featured by Next.js for each page while adding label pages.

Clicking the label will route to the label's dynamic page. The dynamic page is taken based on the ObjectId of label. Also clicking label on todoModal will re-direct to the label's dynamic page while closing the todoModal. This logic must be improved as updating the labelQuery.

Additionally, updating label will update the total number of todos within the label. TodosCount component is refactored with the selectorTodosCount to render the total number of todos of label. The selector is responsible for computing the value.

other minor changes:
1. Removed the unused codes.
2. Refactored the CSS.