### PR TITLE
feat: Improved the UI of labelItemDropdown

### DIFF
--- a/components/labels/labelItem.tsx
+++ b/components/labels/labelItem.tsx
@@ -26,16 +26,18 @@ export const LabelItem = ({ label }: Pick<Types, 'label'>) => {
 
   return (
     <Fragment>
-      <div className='group relative -mb-0 flex w-full cursor-pointer flex-row items-center justify-between'>
+      <div
+        className={classNames(
+          'group relative flex w-full cursor-pointer flex-row items-center justify-between rounded-md pr-[0.20rem]',
+          matchedSlug
+            ? 'bg-blue-100 font-semibold text-opacity-80'
+            : 'hover:bg-gray-200 hover:bg-opacity-80 ',
+        )}>
         <div className='mr-[0.5rem] inline-block w-full'>
           <PrefetchRouterButton
             tooltip={label.name}
-            offset={[0, 10]}
             path={paths('/app/label/', label._id)}
-            className={classNames(
-              'w-full rounded-lg hover:bg-gray-200 hover:bg-opacity-80 focus:outline-none focus:ring-0 focus:ring-offset-0',
-              matchedSlug && 'bg-blue-100 font-semibold',
-            )}>
+            className={classNames('w-full focus:outline-none focus:ring-0 focus:ring-offset-0')}>
             <div className='flex w-full flex-row py-2 px-2'>
               {matchedSlug ? (
                 <SvgIcon
@@ -58,11 +60,18 @@ export const LabelItem = ({ label }: Pick<Types, 'label'>) => {
         </div>
         <LabelItemDropdown
           label={label}
-          data={{ isInitiallyVisible: false }}
+          data={{
+            isInitiallyVisible: false,
+            hoverBg: matchedSlug
+              ? 'hover:bg-blue-900 hover:bg-opacity-[0.07]'
+              : 'hover:bg-gray-900 hover:bg-opacity-[0.07]',
+          }}
+          headerContentsOnClose={
+            <span className='absolute right-[0.73rem] top-1/2 -translate-y-2/4 select-none text-xs tracking-tighter text-slate-400 group-hover:invisible'>
+              <TodosCount label={label} />
+            </span>
+          }
         />
-        <span className='absolute right-3 top-1/2 -translate-y-2/4 select-none text-xs tracking-tighter text-slate-400'>
-          <TodosCount label={label} />
-        </span>
       </div>
       <LabelModalFragment>
         <ItemLabelModal label={label} />

--- a/components/labels/labelList.tsx
+++ b/components/labels/labelList.tsx
@@ -14,7 +14,7 @@ export const LabelList = () => {
     <Fragment>
       <div className='text-sm text-gray-900'>
         <div className='item-center flex flex-row justify-between fill-gray-500 pb-1 text-base opacity-90'>
-          <div className='py-2 pl-1'>Labels</div>
+          <div className='py-2 pl-2'>Labels</div>
           <IconButton
             data={{
               path: ICON_NEW_LABEL,

--- a/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/footerSidebarMenu.tsx
+++ b/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/footerSidebarMenu.tsx
@@ -15,16 +15,15 @@ export const FooterSidebarMenu = () => {
         {DATA_SIDEBAR_MENU.map((item) => (
           <ul
             key={item.name}
-            className='relative pb-1'>
+            className='relative'>
             <PrefetchRouterButton
               tooltip={item.tooltip}
-              offset={[0, 5]}
               path={item.path}
               className={classNames(
                 router.asPath === item.path
-                  ? 'cursor-default bg-blue-100 text-gray-900'
-                  : 'text-gray-600 hover:bg-gray-200 hover:bg-opacity-80 hover:text-gray-900',
-                'group ml-[0.05rem] mt-[0.05rem] flex w-full items-center rounded-md px-2 py-2 text-sm font-medium focus:outline-none focus:ring-0 focus:ring-offset-0',
+                  ? 'cursor-default bg-blue-100 font-semibold text-gray-900 text-opacity-80'
+                  : 'font-medium text-gray-600 hover:bg-gray-200 hover:bg-opacity-80 hover:text-gray-900',
+                'group flex w-full items-center rounded-md px-2 py-2 text-sm focus:outline-none focus:ring-0 focus:ring-offset-0',
               )}>
               <span className='pr-3'>
                 <SvgIcon
@@ -36,7 +35,7 @@ export const FooterSidebarMenu = () => {
               </span>
               {item.name}
               <TotalNumberTodos>
-                <span className='absolute right-3 top-1/2 -translate-y-2/4 select-none text-xs tracking-tighter text-slate-400'>
+                <span className='absolute right-[0.87rem] top-1/2 -translate-y-2/4 select-none text-xs tracking-tighter text-slate-400'>
                   <TodosCount pathname={item.path} />
                 </span>
               </TotalNumberTodos>

--- a/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/index.tsx
+++ b/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/index.tsx
@@ -63,7 +63,7 @@ export const FooterSidebar = forwardRef<HTMLDivElement>((_, ref) => {
       </BackdropFragment>
       <div
         ref={ref}
-        className='fixed left-0 top-0 z-20 w-72 bg-white pl-3 pr-0 pt-3 md:top-[4.6rem] md:z-auto md:flex md:w-full md:max-w-[16.5rem] md:flex-col md:bg-transparent md:pt-0 md:pl-3 md:pr-0'>
+        className='fixed left-0 top-0 z-20 w-72 bg-white pl-2 pr-0 pt-3 md:top-[4.6rem] md:z-auto md:flex md:w-full md:max-w-[16.5rem] md:flex-col md:bg-transparent md:pt-0 md:pl-2 md:pr-0'>
         <LayoutLogoFragment>
           <div className='mb-4 mt-0 flex flex-row items-center justify-between pr-3 md:hidden'>
             <IconButton
@@ -80,7 +80,7 @@ export const FooterSidebar = forwardRef<HTMLDivElement>((_, ref) => {
           </div>
         </LayoutLogoFragment>
         <CreateTodoFragment>
-          <div className='mb-4 flex w-full flex-row justify-center bg-transparent pr-3'>
+          <div className='mb-4 flex w-full flex-row justify-center bg-transparent px-2'>
             <DisableButton
               data={dataButtonCreateTodo}
               onClick={() => openModal()}
@@ -99,7 +99,7 @@ export const FooterSidebar = forwardRef<HTMLDivElement>((_, ref) => {
         </CreateTodoFragment>
         <div
           className={classNames(
-            'flex h-[calc(100vh-7.8rem)] w-full flex-grow flex-col bg-transparent pr-3 md:h-[calc(100vh-8.5rem)]',
+            'flex h-[calc(100vh-7.8rem)] w-full flex-grow flex-col bg-transparent pr-2 md:h-[calc(100vh-8.5rem)]',
             isScrollDisabled ? 'overflow-y-hidden' : 'overflow-y-auto',
           )}>
           <div className='flex flex-grow flex-col'>

--- a/components/layouts/layoutApp/layout/layoutFooter/index.tsx
+++ b/components/layouts/layoutApp/layout/layoutFooter/index.tsx
@@ -13,22 +13,22 @@ export const LayoutFooter = ({ children }: Pick<Types, 'children'>) => {
 
   return (
     <LayoutFooterFragment>
-      <SidebarMobileResetEffect />
       <div className='flex h-full flex-row'>
         <Transition.Root
           show={isSidebarOpen}
-          as={Fragment}>
+          as='div'>
           <Transition.Child
             appear={true}
             as={Fragment}
-            enter='transition transform ease-in-out duration-200'
-            enterFrom='transform -translate-x-40 opacity-0'
+            enter='transition transform ease-in-out duration-350'
+            enterFrom='transform -translate-x-24 opacity-0'
             enterTo='transform translate-x-0 opacity-100'
-            leave='transition ease-in-out duration-200'
+            leave='transition ease-in-out duration-350'
             leaveFrom='transform translate-x-0 opacity-100'
-            leaveTo='transform -translate-x-40 opacity-0'>
+            leaveTo='transform -translate-x-24 opacity-0'>
             <FooterSidebar />
           </Transition.Child>
+          <SidebarMobileResetEffect />
         </Transition.Root>
         <FooterBodyFragment>
           <div

--- a/components/ui/buttons/iconButton/index.tsx
+++ b/components/ui/buttons/iconButton/index.tsx
@@ -18,7 +18,7 @@ export const IconButton = ({ data, headerContents, onClick, children = data.name
         data={{
           className: classNames(
             data.className,
-            'group-button border-gray-300 bg-transparent text-gray-500 hover:bg-white focus-visible:ring-blue-500 hover:enabled:text-gray-700 hover:disabled:cursor-not-allowed',
+            'group-button border-gray-300 bg-transparent text-gray-500 focus-visible:ring-blue-500 hover:enabled:text-gray-700 hover:disabled:cursor-not-allowed',
             headerContents ? 'rounded-lg' : 'rounded-full',
             data.padding || 'p-2',
             data.margin || 'ml-px',

--- a/components/ui/dropdowns/dropdown/index.tsx
+++ b/components/ui/dropdowns/dropdown/index.tsx
@@ -9,11 +9,14 @@ import { Fragment as MenuFragment, useState } from 'react';
 import { usePopper } from 'react-popper';
 const Tooltip = dynamic(() => import('@tooltips/tooltips').then((mod) => mod.Tooltip));
 
-type Props = { data: TypesDataDropdown } & Partial<Pick<Types, 'headerContents' | 'show'>> &
+type Props = { data: TypesDataDropdown } & Partial<
+  Pick<Types, 'headerContents' | 'show' | 'headerContentsOnClose'>
+> &
   Pick<Types, 'children'>;
 
 export const Dropdown = ({
   headerContents,
+  headerContentsOnClose,
   children,
   show,
   data: {
@@ -45,7 +48,7 @@ export const Dropdown = ({
 
   const visibility = (initialVisible: boolean, open: boolean) => {
     if (initialVisible || open) return 'visible';
-    return 'invisible group-focus-within:visible group-hover:visible';
+    return 'invisible group-hover:visible';
   };
 
   return (
@@ -88,6 +91,7 @@ export const Dropdown = ({
                   </span>
                 )}
               </Menu.Button>
+              {!open && headerContentsOnClose}
               <Transition
                 as='div'
                 show={show ? show : open}
@@ -99,7 +103,7 @@ export const Dropdown = ({
                 leaveFrom='transform opacity-100 scale-100'
                 leaveTo='transform opacity-0 scale-95'>
                 <Portal>
-                  <DisableScrollEffect open={open} />
+                  {open && <DisableScrollEffect open={open} />}
                   <Menu.Items
                     className={classNames(
                       'absolute right-0 z-50 origin-top-right focus:outline-none',

--- a/components/ui/dropdowns/labelComboBoxDropdown.tsx
+++ b/components/ui/dropdowns/labelComboBoxDropdown.tsx
@@ -32,7 +32,7 @@ export const LabelComboBoxDropdown = ({ todo }: Props) => {
             <li key={label._id}>
               <div
                 className={classNames(
-                  'mr-1 flex cursor-pointer flex-row items-center justify-center rounded-lg py-[3px] pl-2 pr-1 text-sm text-gray-700',
+                  'ml-1 flex cursor-pointer flex-row items-center justify-center rounded-lg py-[3px] pl-2 pr-1 text-sm text-gray-700',
                   label.color && label.color,
                   'bg-opacity-40 hover:bg-opacity-60',
                 )}>
@@ -40,7 +40,6 @@ export const LabelComboBoxDropdown = ({ todo }: Props) => {
                   path={paths('/app/label/', label._id)}
                   className='max-w-[5.3rem] truncate pr-1'
                   tooltip={label.name}
-                  offset={[10, 15]}
                   onClick={() => closeTodoModal()}>
                   {label.name}
                 </PrefetchRouterButton>
@@ -48,7 +47,7 @@ export const LabelComboBoxDropdown = ({ todo }: Props) => {
                   data={{
                     path: ICON_CLOSE,
                     padding: 'p-[2px]',
-                    hoverBg: 'bg-opacity-0 hover:bg-opacity-30',
+                    hoverBg: 'hover:bg-gray-900 hover:bg-opacity-10',
                     size: 'h-4 w-4',
                     color: 'fill-gray-700 hover:fill-gray-900',
                     container: 'h-5',

--- a/components/ui/dropdowns/labelItemDropdown.tsx
+++ b/components/ui/dropdowns/labelItemDropdown.tsx
@@ -7,9 +7,14 @@ import { Types } from 'lib/types';
 import { Dropdown } from './dropdown';
 import { DropdownMenuItem } from './dropdown/dropdownMenuItem';
 
-type Props = { data: TypesDataDropdown } & Pick<Types, 'label'>;
+type Props = { data: TypesDataDropdown } & Pick<Types, 'label'> &
+  Partial<Pick<Types, 'headerContentsOnClose'>>;
 
-export const LabelItemDropdown = ({ label, data: { isInitiallyVisible } }: Props) => {
+export const LabelItemDropdown = ({
+  label,
+  data: { isInitiallyVisible, hoverBg },
+  headerContentsOnClose,
+}: Props) => {
   const openModal = useLabelModalStateOpen(label?._id);
   const removeLabel = useLabelStateRemove(label._id);
 
@@ -18,11 +23,12 @@ export const LabelItemDropdown = ({ label, data: { isInitiallyVisible } }: Props
       data={{
         tooltip: 'Menu',
         path: ICON_MORE_VERT,
-        padding: 'p-2',
+        padding: 'p-[0.3rem]',
         color: 'fill-gray-500 group-hover:fill-gray-700',
-        hoverBg: 'hover:bg-gray-200',
+        hoverBg: hoverBg,
         isInitiallyVisible: isInitiallyVisible,
-      }}>
+      }}
+      headerContentsOnClose={headerContentsOnClose}>
       <ActiveDropdownMenuItemEffect menuItemId={null} />
       {/* give menuItemId any ID: string to activate the keyboard navigation */}
       <div className='py-1'>

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -264,6 +264,7 @@ export interface TypesComboboxAttributes {
 
 export interface TypesDropdownAttributes {
   hasDropdownBoardStyle: boolean;
+  headerContentsOnClose: Types['children'];
 }
 
 export interface TypesInputAttributes {


### PR DESCRIPTION
Now hover, or opening labelItemDropdown will hide the `TodosCount` component. To equip with better UI, selecting the label will not hide the `TodosCount`, but it will be hidden only when the dropdown is open and hovering with the cursor. This is not only limited to TodosCount. Any item in the `headerContentsOnClose` will display and hide interactively based on the hovering and closing state of labelItemDropdown.

Other minor changes:
- Updated the CSS.