### PR TITLE
fix: Fixed the `Portal` issue on `Dropdown` component

### DIFF
--- a/components/ui/dropdowns/dropdown/conditionalPortal.tsx
+++ b/components/ui/dropdowns/dropdown/conditionalPortal.tsx
@@ -1,0 +1,13 @@
+import { Portal } from '@headlessui/react';
+import { Types } from '@lib/types';
+import { Fragment as ConditionalPortalFragment } from 'react';
+
+type Props = Pick<Types, 'children'> & Partial<Pick<Types, 'isPortal'>>;
+
+export const ConditionalPortal = ({ children, isPortal }: Props) => {
+  return (
+    <ConditionalPortalFragment>
+      {isPortal ? <Portal>{children}</Portal> : children}
+    </ConditionalPortalFragment>
+  );
+};

--- a/components/ui/dropdowns/dropdown/index.tsx
+++ b/components/ui/dropdowns/dropdown/index.tsx
@@ -1,4 +1,4 @@
-import { Menu, Portal, Transition } from '@headlessui/react';
+import { Menu, Transition } from '@headlessui/react';
 import { TypesDataDropdown } from '@lib/types/typesData';
 import { DisableScrollEffect } from '@states/misc/disableScrollEffect';
 import { classNames } from '@states/utils';
@@ -7,6 +7,7 @@ import { Types } from 'lib/types';
 import dynamic from 'next/dynamic';
 import { Fragment as MenuFragment, useState } from 'react';
 import { usePopper } from 'react-popper';
+import { ConditionalPortal } from './conditionalPortal';
 const Tooltip = dynamic(() => import('@tooltips/tooltips').then((mod) => mod.Tooltip));
 
 type Props = { data: TypesDataDropdown } & Partial<
@@ -36,6 +37,7 @@ export const Dropdown = ({
     color = 'fill-gray-500 group-hover:fill-gray-700',
     text = 'group-hover:text-gray-700',
     contentWidth = 'w-60',
+    isPortal = false,
   },
 }: Props) => {
   const [isClicked, setClick] = useState(false);
@@ -102,7 +104,7 @@ export const Dropdown = ({
                 leave='transition ease-in duration-75'
                 leaveFrom='transform opacity-100 scale-100'
                 leaveTo='transform opacity-0 scale-95'>
-                <Portal>
+                <ConditionalPortal isPortal={isPortal}>
                   {open && <DisableScrollEffect open={open} />}
                   <Menu.Items
                     className={classNames(
@@ -119,7 +121,7 @@ export const Dropdown = ({
                       {children}
                     </div>
                   </Menu.Items>
-                </Portal>
+                </ConditionalPortal>
               </Transition>
             </MenuFragment>
           </Tooltip>

--- a/components/ui/dropdowns/labelItemDropdown.tsx
+++ b/components/ui/dropdowns/labelItemDropdown.tsx
@@ -27,6 +27,7 @@ export const LabelItemDropdown = ({
         color: 'fill-gray-500 group-hover:fill-gray-700',
         hoverBg: hoverBg,
         isInitiallyVisible: isInitiallyVisible,
+        isPortal: true,
       }}
       headerContentsOnClose={headerContentsOnClose}>
       <ActiveDropdownMenuItemEffect menuItemId={null} />

--- a/lib/data/dataObjects.tsx
+++ b/lib/data/dataObjects.tsx
@@ -27,6 +27,7 @@ import {
   ICON_WARNING,
 } from './materialSymbols';
 import {
+  STYLE_BUTTON_KEY_ONLY_RING,
   STYLE_BUTTON_NORMAL_BLUE,
   STYLE_BUTTON_NORMAL_RED,
   STYLE_BUTTON_NORMAL_WHITE,
@@ -260,7 +261,7 @@ export const dataPriorityDropdownUrgent: TypesDataPriority = {
  */
 // Calendar
 export const dataDropdownCalendar: TypesDataDropdown = {
-  borderRadius: 'rounded-none',
+  borderRadius: classNames('rounded-none focus-visible:rounded-lg', STYLE_BUTTON_KEY_ONLY_RING),
   padding: 'px-4 py-2',
   menuWidth: 'w-full',
   tooltip: 'Due Date',

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -212,6 +212,7 @@ export interface TypesUi {
   isConditionalRendering: boolean;
   enterDuration: DURATION;
   leaveDuration: DURATION;
+  isPortal: boolean;
 }
 
 export interface TypesLoadings {

--- a/lib/types/typesData.ts
+++ b/lib/types/typesData.ts
@@ -43,6 +43,7 @@ export type TypesDataDropdown = Partial<
     | 'path'
     | 'isInitiallyVisible'
     | 'hasDropdownBoardStyle'
+    | 'isPortal'
   > &
     Pick<
       TypesStyleAttributes,


### PR DESCRIPTION
The dropdown component has Portal component provided by Headless UI library that allows us to set the components to target different DOM. This is useful if Dropdown component needs to target different DOM with Popper.js library, rendering engine library.

The issue was unexpected behavior of one of dropdown component that closes upon clicking item inside the dropdown. This should happen, but should stay open.

solution: Added the conditional wrapper component as `ConditionalPortal` component to resolve the issue because not all dropdown components require `Portal`.

Minor Changes:
- update the CSS on calendarMenuItem.