### PR TITLE
fix: Fixed the ConditionalPortal rendering issue

### DIFF
--- a/lib/data/dataObjects.tsx
+++ b/lib/data/dataObjects.tsx
@@ -273,6 +273,7 @@ export const dataDropdownComboBox: TypesDataDropdown = {
   tooltip: 'Add label',
   hasDivider: false,
   contentWidth: 'w-72',
+  isPortal: true,
 };
 
 /**


### PR DESCRIPTION
As `LabelComboBoxDropdown` requires the `Portal` components provided by Headless UI library as well as used in the `ConditionalPortal` component, It is set to true to use ConditionalPortal to in `LabelComboBoxDropdown`.