### PR TITLE
refactor: Refactored the `loadingStateTodos`

### DIFF
--- a/components/loadable/loadingStates/loadingSkeletons/loadingSkeletonTodos.tsx
+++ b/components/loadable/loadingStates/loadingSkeletons/loadingSkeletonTodos.tsx
@@ -1,21 +1,24 @@
+import { RepeatingElements } from '@ui/repeatings/repeatingElements';
 import { Fragment as LoadingSkeletonFragment } from 'react';
 
 export const LoadingSkeletonTodos = () => {
   return (
     <LoadingSkeletonFragment>
-      <div className='flex max-w-7xl animate-pulse flex-row justify-start space-x-3'>
-        <div className='h-5 w-5 rounded-md bg-slate-200' />
-        <div className='flex w-[40rem] flex-col space-y-3'>
-          <div className='h-5 w-[30rem] rounded-full bg-slate-200' />
-          <div className='max-wq mb-4 h-3 w-[36rem] rounded-full bg-slate-200' />
-          <div className='max-wq mb-4 h-3 w-[36rem] rounded-full bg-slate-200' />
-          <div className='flex flex-row space-x-3 pt-2'>
-            <div className='h-5 w-20 rounded-full bg-slate-200' />
-            <div className='h-5 w-20 rounded-full bg-slate-200' />
-            <div className='h-5 w-20 rounded-full bg-slate-200' />
+      <div className='mr-2 flex w-full max-w-7xl animate-pulse flex-row justify-start space-x-2'>
+        <div className='mr-1 flex w-[calc(100vw-7rem)] max-w-[45rem] flex-row space-x-3 md:w-[calc(65vw-5rem)] ml:w-[calc(70vw-5rem)]'>
+          <div className='h-5 w-5 rounded-md bg-slate-200' />
+          <div className='flex w-[94%] flex-col space-y-3'>
+            <div className='h-5 w-[75%] rounded-full bg-slate-200' />
+            <div className='mb-4 h-3 w-full rounded-full bg-slate-200' />
+            <div className='mb-4 h-3 w-full rounded-full bg-slate-200' />
+            <div className='flex flex-row space-x-3 pt-2'>
+              <RepeatingElements repeats={5}>
+                <div className='h-5 w-20 rounded-full bg-slate-200' />
+              </RepeatingElements>
+            </div>
           </div>
         </div>
-        <div className='h-7 w-7 rounded-full bg-slate-200' />
+        <div className='h-6 w-6 rounded-full bg-slate-200' />
       </div>
     </LoadingSkeletonFragment>
   );

--- a/components/ui/repeatings/repeatingElements.tsx
+++ b/components/ui/repeatings/repeatingElements.tsx
@@ -1,0 +1,18 @@
+import { Types } from '@lib/types';
+import { Fragment } from 'react';
+
+export const RepeatingElements = ({
+  repeats,
+  children,
+}: {
+  repeats: number;
+  children: Types['children'];
+}) => {
+  return (
+    <Fragment>
+      {[...Array(repeats)].map((_, index) => (
+        <ul key={index}>{children}</ul>
+      ))}
+    </Fragment>
+  );
+};

--- a/lib/data/dataObjects.tsx
+++ b/lib/data/dataObjects.tsx
@@ -298,7 +298,7 @@ export const dataMinimizedModal: TypesDataMinimizedModalTransition = {
 export const dataLoadingTodos: TypesDataLoadingState = {
   loadingSkeleton: <LoadingSkeletonTodos />,
   repeatingCount: 10,
-  margin: 'ml-8 mt-5',
+  margin: 'ml-7 mt-5',
   space: 'space-y-10',
 };
 


### PR DESCRIPTION
The loadingStateTodos is now responsive in UI. To improve the code dryness, the new component `repeatingElement` is added to `loadingSkeletonTodos`. The new component can repeat the same element with the given number. As an example, if repeating number is 5 repeatingElement component will return child elements 5 times as a list.