### PR TITLE
feat: integrate the label API with todo API

### DIFF
--- a/components/labels/labelItem.tsx
+++ b/components/labels/labelItem.tsx
@@ -39,7 +39,7 @@ export const LabelItem = ({ label }: Pick<Types, 'label'>) => {
             tooltip={label.name}
             path={paths('/app/label/', label._id)}
             className={classNames('w-full focus:outline-none focus:ring-0 focus:ring-offset-0')}>
-            <div className='flex w-full flex-row py-2 px-2'>
+            <div className='flex w-full flex-row  py-2 px-2'>
               {matchedSlug ? (
                 <SvgIcon
                   data={{
@@ -55,7 +55,9 @@ export const LabelItem = ({ label }: Pick<Types, 'label'>) => {
                   }}
                 />
               )}
-              <div className='pl-2 text-gray-600 group-hover:text-gray-900'>{label.name}</div>
+              <div className='max-w-[10.7rem] truncate pl-2 text-gray-600 group-hover:text-gray-900'>
+                {label.name}
+              </div>
             </div>
           </PrefetchRouterButton>
         </div>

--- a/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/index.tsx
+++ b/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/index.tsx
@@ -66,7 +66,7 @@ export const FooterSidebar = forwardRef<HTMLDivElement>((_, ref) => {
           </div>
         </LayoutLogoFragment>
         <CreateTodoFragment>
-          <div className='mb-4 flex w-full flex-row justify-center bg-transparent px-2'>
+          <div className='mb-4 flex w-full flex-row justify-center bg-transparent pr-2'>
             <DisableButton
               data={dataButtonCreateTodo}
               onClick={() => openModal()}

--- a/components/ui/buttons/iconButton/priorityButton.tsx
+++ b/components/ui/buttons/iconButton/priorityButton.tsx
@@ -50,7 +50,7 @@ export const PriorityButton = ({ todo, data, onClick }: Props) => {
               'fill-yellow-500 [.group-button:hover_&]:fill-yellow-600',
             levelUrgent && priorityUrgent && 'fill-red-600 [.group-button:hover_&]:fill-red-700',
           ),
-          borderRadius: 'rounded-none focus-visible:rounded-lg',
+          borderRadius: 'rounded-md focus-visible:rounded-md',
           margin: 'ml-0',
           hoverBg: 'hover:bg-transparent',
           display: data.display,

--- a/components/ui/dropdowns/dropdown/dropdownMenuItem.tsx
+++ b/components/ui/dropdowns/dropdown/dropdownMenuItem.tsx
@@ -48,7 +48,7 @@ export const DropdownMenuItem = ({
                 isDisabledCloseOnClick && event.preventDefault();
               }}
               className={classNames(
-                'group-1 block w-full cursor-pointer text-left text-sm text-gray-500 hover:bg-slate-600 hover:bg-opacity-10 hover:text-gray-700',
+                'group-1 block w-full cursor-pointer text-left text-sm text-gray-500 hover:bg-slate-600 hover:bg-opacity-10 hover:text-gray-700 focus-visible:rounded-md',
                 padding ?? 'px-4 py-2',
                 active && isActive && STYLE_HOVER_SLATE_LIGHT,
               )}>

--- a/components/ui/dropdowns/dropdown/index.tsx
+++ b/components/ui/dropdowns/dropdown/index.tsx
@@ -73,8 +73,8 @@ export const Dropdown = ({
                   'inline-flex w-full items-center text-gray-400 ease-in hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-0 sm:ml-0',
                   padding,
                   hoverBg,
-                  borderRadius,
-                  !borderRadius && headerContents ? 'rounded-lg' : 'rounded-full',
+                  borderRadius ?? 'rounded-lg',
+                  (!borderRadius && headerContents) || 'rounded-full',
                   visibility(isInitiallyVisible, open),
                 )}
                 ref={setReferenceElement}

--- a/components/ui/dropdowns/labelItemDropdown.tsx
+++ b/components/ui/dropdowns/labelItemDropdown.tsx
@@ -34,6 +34,7 @@ export const LabelItemDropdown = ({
       {/* give menuItemId any ID: string to activate the keyboard navigation */}
       <div className='py-1'>
         <DropdownMenuItem
+          isDisabledCloseOnClick={false}
           onClick={() => openModal()}
           path={ICON_EDIT_NOTE}
           tooltip='Edit'>
@@ -42,6 +43,7 @@ export const LabelItemDropdown = ({
       </div>
       <div className='py-1'>
         <DropdownMenuItem
+          isDisabledCloseOnClick={false}
           onClick={() => removeLabel()}
           path={ICON_DELETE}
           tooltip='Delete'>

--- a/lib/data/dataObjects.tsx
+++ b/lib/data/dataObjects.tsx
@@ -1,37 +1,36 @@
 import { LoadingSkeletonLabels } from '@components/loadable/loadingStates/loadingSkeletons/loadingSkeletonLabels';
 import { LoadingSkeletonTodos } from '@components/loadable/loadingStates/loadingSkeletons/loadingSkeletonTodos';
 import {
-  TypesDataButton,
-  TypesDataDropdown,
-  TypesDataLoadingState,
-  TypesDataMinimizedModalTransition,
-  TypesDataPriority,
-  TypesDataSvg,
+    TypesDataButton,
+    TypesDataDropdown,
+    TypesDataLoadingState,
+    TypesDataMinimizedModalTransition,
+    TypesDataPriority,
+    TypesDataSvg
 } from '@lib/types/typesData';
 import { classNames } from '@states/utils';
 import { isMacOs } from 'react-device-detect';
-import { PRIORITY_LEVEL, POSITION_X, POSITION_Y } from './dataTypesObjects';
+import { POSITION_X, POSITION_Y, PRIORITY_LEVEL } from './dataTypesObjects';
 import {
-  ICON_CHEVRON_LEFT,
-  ICON_CHEVRON_RIGHT,
-  ICON_CLOSE,
-  ICON_DELETE,
-  ICON_EVENT_AVAILABLE_FILL,
-  ICON_FLAG_FILL,
-  ICON_LABEL_IMPORTANT_FILL,
-  ICON_MAXIMIZE,
-  ICON_MINIMIZE,
-  ICON_NEW_LABEL,
-  ICON_OPEN_IN_FULL,
-  ICON_REPORT,
-  ICON_WARNING,
+    ICON_CHEVRON_LEFT,
+    ICON_CHEVRON_RIGHT,
+    ICON_CLOSE,
+    ICON_DELETE,
+    ICON_EVENT_AVAILABLE_FILL,
+    ICON_FLAG_FILL,
+    ICON_LABEL_IMPORTANT_FILL,
+    ICON_MAXIMIZE,
+    ICON_MINIMIZE,
+    ICON_NEW_LABEL,
+    ICON_OPEN_IN_FULL,
+    ICON_REPORT,
+    ICON_WARNING
 } from './materialSymbols';
 import {
-  STYLE_BUTTON_KEY_ONLY_RING,
-  STYLE_BUTTON_NORMAL_BLUE,
-  STYLE_BUTTON_NORMAL_RED,
-  STYLE_BUTTON_NORMAL_WHITE,
-  STYLE_BUTTON_WIDE_BLUE,
+    STYLE_BUTTON_NORMAL_BLUE,
+    STYLE_BUTTON_NORMAL_RED,
+    STYLE_BUTTON_NORMAL_WHITE,
+    STYLE_BUTTON_WIDE_BLUE
 } from './stylePreset';
 
 /**
@@ -261,7 +260,7 @@ export const dataPriorityDropdownUrgent: TypesDataPriority = {
  */
 // Calendar
 export const dataDropdownCalendar: TypesDataDropdown = {
-  borderRadius: classNames('rounded-none focus-visible:rounded-lg', STYLE_BUTTON_KEY_ONLY_RING),
+  borderRadius: classNames('rounded-md focus-visible:rounded-md'),
   padding: 'px-4 py-2',
   menuWidth: 'w-full',
   tooltip: 'Due date',

--- a/lib/states/editors/hooks.tsx
+++ b/lib/states/editors/hooks.tsx
@@ -1,7 +1,6 @@
-import { Todos, Types, TodosEditors } from '@lib/types';
+import { Todos, TodosEditors, Types } from '@lib/types';
 import { atomSelectorTodoItem, atomTodoNew } from '@states/todos';
-import ObjectID from 'bson-objectid';
-import { useRecoilCallback, RecoilValue } from 'recoil';
+import { RecoilValue, useRecoilCallback } from 'recoil';
 import { Descendant } from 'slate';
 import { atomEditorDeserialize, atomEditorSerialize } from '.';
 
@@ -20,7 +19,6 @@ export const useEditorTodoUpdate = (_id: Todos['_id'], titleName: Types['titleNa
       : set(atomTodoNew, {
           ...get(atomTodoNew),
           [titleName]: content,
-          _id: ObjectID().toHexString(),
         }); // Creator
   });
 };

--- a/lib/states/modals/hooks.tsx
+++ b/lib/states/modals/hooks.tsx
@@ -10,6 +10,7 @@ import {
   useConditionCheckTodoTitleEmpty,
   useConditionCompareTodoItemsEqual,
 } from '@states/utils/hooks';
+import ObjectID from 'bson-objectid';
 import { RecoilValue, useRecoilCallback, useResetRecoilState } from 'recoil';
 import {
   atomConfirmModalDelete,
@@ -167,6 +168,8 @@ export const useTodoModalStateOpen = (_id: Todos['_id']) => {
     set(atomTodoModalOpen(_id), true);
     !get(atomCatch(CATCH.todoModal)) && set(atomCatch(CATCH.todoModal), true);
     resetDateItemOnly();
+    typeof _id === 'undefined' &&
+      set(atomTodoNew, { ...get(atomTodoNew), _id: ObjectID().toHexString() });
   });
 };
 

--- a/lib/states/todos/hooks.tsx
+++ b/lib/states/todos/hooks.tsx
@@ -6,7 +6,7 @@ import {
   updateDataTodo,
 } from '@lib/queries/queryTodos';
 import { Todos } from '@lib/types';
-import { useLabelUpdateDataItem } from '@states/labels/hooks';
+import { atomQueryLabels, atomSelectorLabels } from '@states/labels';
 import { atomNetworkStatusEffect } from '@states/misc';
 import { atomConfirmModalDelete } from '@states/modals';
 import { useTodoModalStateReset } from '@states/modals/hooks';
@@ -34,6 +34,7 @@ export const useTodoAdd = () => {
   const updateQueryTodoItem = useRecoilCallback(({ set, reset, snapshot }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
 
+    set(atomQueryLabels, get(atomSelectorLabels));
     set(atomQueryTodoItem(get(atomTodoNew)._id), get(atomTodoNew));
     set(atomQueryTodoIds, [...get(atomQueryTodoIds), { _id: get(atomTodoNew)._id }]);
     reset(atomTodoNew);
@@ -54,7 +55,6 @@ export const useTodoAdd = () => {
 };
 
 export const useTodoUpdateItem = (todoId: Todos['_id']) => {
-  const updateLabelItem = useLabelUpdateDataItem();
   const setNotification = useNotificationState();
   const resetModal = useTodoModalStateReset(todoId);
   const compareTodoItemsEqual = useConditionCompareTodoItemsEqual(todoId);
@@ -63,11 +63,14 @@ export const useTodoUpdateItem = (todoId: Todos['_id']) => {
   const updateQueryTodoItem = useRecoilCallback(({ set, reset, snapshot }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
 
+    set(atomQueryLabels, get(atomSelectorLabels));
     set(atomQueryTodoItem(todoId), get(atomSelectorTodoItem(todoId)));
     updateDataTodo(todoId, get(atomSelectorTodoItem(todoId)));
     set(atomQueryTodoIds, [...get(atomQueryTodoIds)]); // refetch: This will trigger re-Render the list.
     setNotification(NOTIFICATION['updatedTodo']);
+
     reset(atomSelectorTodoItem(todoId));
+    reset(atomSelectorLabels);
   });
 
   return () => {
@@ -79,7 +82,6 @@ export const useTodoUpdateItem = (todoId: Todos['_id']) => {
     updatePriorityRankScore();
     updateQueryTodoItem();
     resetModal();
-    updateLabelItem();
   };
 };
 

--- a/lib/states/todos/index.tsx
+++ b/lib/states/todos/index.tsx
@@ -1,4 +1,4 @@
-import { PATHNAME, PRIORITY_LEVEL, OBJECT_ID } from '@data/dataTypesObjects';
+import { OBJECT_ID, PATHNAME, PRIORITY_LEVEL } from '@data/dataTypesObjects';
 import { Labels, TodoIds, Todos, Types } from '@lib/types';
 import { atomLabelQuerySlug, atomQueryLabels } from '@states/labels';
 import { selectorFilterPriorityRankScore } from '@states/priorities';
@@ -16,6 +16,7 @@ export const atomTodoNew = atom<Todos>({
     note: '',
     completed: false,
     createdDate: new Date(),
+    labelItem: [] as Labels[],
   } as Todos,
 });
 

--- a/lib/states/utils/hooks.tsx
+++ b/lib/states/utils/hooks.tsx
@@ -113,3 +113,12 @@ export const useHorizontalScrollPosition = (ref: RefObject<HTMLDivElement>) => {
 
   return { leftPosition, rightPosition, isOverflow };
 };
+
+export const useCompareToQueryLabels = () => {
+  return useRecoilCallback(({ snapshot }) => (compare: Labels[]) => {
+    const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
+    return compare.filter((label) => {
+      return !get(atomQueryLabels).find((queryLabel) => equal(label, queryLabel));
+    });
+  });
+};

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -60,6 +60,7 @@ export interface Todos extends TodosEditors, TodoIds {
   createdDate: Date;
   dueDate: Date | null;
   completedDate: Date | null;
+  labelItem: Labels[];
 }
 
 export interface TodoIds {

--- a/pages/api/v1/labels/[labelId].tsx
+++ b/pages/api/v1/labels/[labelId].tsx
@@ -24,6 +24,7 @@ const LabelById = async (req: NextApiRequest, res: NextApiResponse) => {
     case 'PUT':
       try {
         const updateLabelById = await Label.findByIdAndUpdate(labelId, body, {
+          upsert: true,
           new: true,
           runValidators: true,
         });

--- a/pages/api/v1/labels/index.tsx
+++ b/pages/api/v1/labels/index.tsx
@@ -41,7 +41,11 @@ const Labels = async (req: NextApiRequest, res: NextApiResponse) => {
       try {
         const updateLabel = await Promise.all(
           body.map(async (label: TypesQuery) => {
-            return await Label.updateMany({ _id: label._id }, { $set: label }, { upsert: true });
+            return await Label.updateMany(
+              { _id: label._id },
+              { $set: label },
+              { upsert: true, new: true, runValidators: true },
+            );
           }),
         );
         if (!updateLabel) return res.status(400).json({ success: false });


### PR DESCRIPTION
Now todo API uses the transaction query along with label model. The label database is created within the separate collection of databases from todo collection. This leads API to be a transaction query to bind all related queries together. The user will behave as either separately update the data or update all together as a transaction. In latter case, the user will update not only label but also other item such as todoItem, todoNote, calendar, and so on.

Also, added reset stale labels data

Now removing the label by clicking the label's removing button will remove labels from editor's state, but not directly update the data.

*editor-mode: editing item within todoModal. It does not can revert to the original state any time by existing todoModal.

add the option to add newly created label into labelComboBox.

Minor changes:

- adjust the CSS
- remove the unnecessary comment
- add logics to remove labels in editor-mode*