### PR TITLE
fix: fix Menu component's focus issue

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -4,7 +4,7 @@ module.exports = {
   jsxSingleQuote: true,
   tabWidth: 2,
   semi: true,
-  printWidth: 100,
+  printWidth: 120,
   tailwindConfig: './tailwind.config.js',
   singleAttributePerLine: true,
   trailingComma: 'all',


### PR DESCRIPTION
On closing Menu(dropdown) component with key, `Escape` causes the focus trapped into the `Menu.Button`. This causes the consecutive opening of modal (aka. dialog)'s initialFocus.

By assigning a focusRef along with keyDown event fixed the issue.

Minor changes:
* chore: update the prettier's printWidth to 120 from 100