### PR TITLE
fix: disable the options on completed todoItem

### DIFF
--- a/components/editors/todoEditor.tsx
+++ b/components/editors/todoEditor.tsx
@@ -1,21 +1,28 @@
 import { Types } from '@lib/types';
+import { atomQueryTodoItem } from '@states/todos/atomQueries';
+import { classNames } from '@states/utils';
 import dynamic from 'next/dynamic';
+import { useRecoilCallback } from 'recoil';
 
 type Props = Partial<Pick<Types, 'todo'>>;
 
 const EditorComposer = dynamic(() => import('./editorComposer').then((mod) => mod.EditorComposer));
 
 export const TodoEditors = ({ todo }: Props) => {
+  const isTodoCompleted = useRecoilCallback(({ snapshot }) => () => {
+    return typeof todo !== 'undefined' && snapshot.getLoadable(atomQueryTodoItem(todo._id)).getValue().completed;
+  });
+
   return (
-    <div className='mx-3 mt-2 space-y-3 text-left'>
+    <div className={classNames('mx-3 mt-2 space-y-3 text-left', isTodoCompleted() && 'opacity-50')}>
       <EditorComposer
-        placeholder='Todo Name'
+        placeholder={!isTodoCompleted() ? 'Todo Name' : ''}
         titleName='title'
         isAutoFocus={true}
         todo={todo}
       />
       <EditorComposer
-        placeholder='Write your Note'
+        placeholder={!isTodoCompleted() ? 'Write your Note' : ''}
         titleName='note'
         todo={todo}
       />

--- a/components/todos/todo/index.tsx
+++ b/components/todos/todo/index.tsx
@@ -32,11 +32,13 @@ export const Todo = ({ todo, index }: Props) => {
             todo={todo}>
             <div className='py-1'>
               <DropdownMenuItem
-                isDisabledCloseOnClick={false}
-                onClick={() => openModal()}
-                path={ICON_EDIT_NOTE}
-                tooltip='Edit'
-                kbd='Enter'>
+                options={{
+                  isDisabledCloseOnClick: false,
+                  path: ICON_EDIT_NOTE,
+                  tooltip: 'Edit',
+                  kbd: 'Enter',
+                }}
+                onClick={() => openModal()}>
                 Edit todo
               </DropdownMenuItem>
             </div>

--- a/components/ui/buttons/iconButton/priorityButton.tsx
+++ b/components/ui/buttons/iconButton/priorityButton.tsx
@@ -1,12 +1,14 @@
 import { IconButton } from '@buttons/iconButton';
+import { SvgIcon } from '@components/icons/svgIcon';
 import { PRIORITY_LEVEL } from '@data/dataTypesObjects';
 import { ICON_FLAG, ICON_FLAG_FILL, ICON_LABEL_IMPORTANT, ICON_LABEL_IMPORTANT_FILL } from '@data/materialSymbols';
 import { Types } from '@lib/types';
 import { TypesOptionsPriority } from '@lib/types/typesOptions';
 import { atomTodoNew, atomSelectorTodoItem } from '@states/todos';
+import { atomQueryTodoItem } from '@states/todos/atomQueries';
 import { classNames } from '@states/utils';
-import { Fragment as TodoPriorityFragment } from 'react';
-import { useRecoilValue } from 'recoil';
+import { Fragment, Fragment as TodoPriorityFragment } from 'react';
+import { useRecoilCallback, useRecoilValue } from 'recoil';
 
 type Props = { options: TypesOptionsPriority } & Partial<Pick<Types, 'todo'>> & Pick<Types, 'onClick'>;
 
@@ -17,47 +19,68 @@ export const PriorityButton = ({ todo, options, onClick }: Props) => {
   const priorityUrgent = todoItem.priorityLevel === PRIORITY_LEVEL['urgent'];
   const levelImportant = options.priorityLevel === PRIORITY_LEVEL['important'];
   const levelUrgent = options.priorityLevel === PRIORITY_LEVEL['urgent'];
+  const conditionalPath = classNames(
+    levelImportant && !priorityImportant && ICON_LABEL_IMPORTANT,
+    levelImportant && priorityImportant && ICON_LABEL_IMPORTANT_FILL,
+    levelUrgent && !priorityUrgent && ICON_FLAG,
+    levelUrgent && priorityUrgent && ICON_FLAG_FILL,
+  );
+  const conditionalFill = classNames(
+    !priorityImportant && !priorityUrgent && 'fill-gray-500 [.group-button:hover_&]:fill-gray-700',
+    levelImportant && priorityImportant && 'fill-yellow-500 [.group-button:hover_&]:fill-yellow-600',
+    levelUrgent && priorityUrgent && 'fill-red-600 [.group-button:hover_&]:fill-red-700',
+  );
+  const conditionalHeaderContent = classNames(
+    levelImportant && !priorityImportant && options.priorityNormal,
+    levelImportant && priorityImportant && options.priorityImportant,
+    levelUrgent && !priorityUrgent && options.priorityNormal,
+    levelUrgent && priorityUrgent && options.priorityUrgent,
+  );
+
+  const isTodoCompleted = useRecoilCallback(({ snapshot }) => () => {
+    return typeof todo !== 'undefined' && snapshot.getLoadable(atomQueryTodoItem(todo?._id)).getValue().completed;
+  });
 
   return (
     <TodoPriorityFragment>
-      <IconButton
-        options={{
-          path: classNames(
-            levelImportant && !priorityImportant && ICON_LABEL_IMPORTANT,
-            levelImportant && priorityImportant && ICON_LABEL_IMPORTANT_FILL,
-            levelUrgent && !priorityUrgent && ICON_FLAG,
-            levelUrgent && priorityUrgent && ICON_FLAG_FILL,
-          ),
-          tooltip: classNames(
-            levelImportant && !priorityImportant && 'Not important',
-            levelImportant && priorityImportant && 'Important',
-            levelUrgent && !priorityUrgent && 'Not urgent',
-            levelUrgent && priorityUrgent && 'Urgent',
-          ),
-          color: classNames(
-            !priorityImportant && !priorityUrgent && 'fill-gray-500 [.group-button:hover_&]:fill-gray-700',
-            levelImportant && priorityImportant && 'fill-yellow-500 [.group-button:hover_&]:fill-yellow-600',
-            levelUrgent && priorityUrgent && 'fill-red-600 [.group-button:hover_&]:fill-red-700',
-          ),
-          borderRadius: 'rounded-md focus-visible:rounded-md',
-          margin: 'ml-0',
-          hoverBg: 'hover:bg-transparent',
-          display: options.display,
-          width: options.width,
-          container: options.container,
-          padding: options.padding,
-        }}
-        headerContents={
-          options.isInitiallyVisible &&
-          classNames(
-            levelImportant && !priorityImportant && options.priorityNormal,
-            levelImportant && priorityImportant && options.priorityImportant,
-            levelUrgent && !priorityUrgent && options.priorityNormal,
-            levelUrgent && priorityUrgent && options.priorityUrgent,
-          )
-        }
-        onClick={onClick}
-      />
+      {isTodoCompleted() ? (
+        <div
+          className={classNames(
+            'flex flex-row rounded-md focus-visible:rounded-md',
+            options.padding ?? 'p-2',
+            options.container,
+          )}>
+          <SvgIcon
+            options={{
+              path: conditionalPath,
+              className: classNames(conditionalFill, options.size ?? 'h-5 w-5', options.color ?? 'fill-gray-500'),
+            }}
+          />
+          <Fragment>{options.isInitiallyVisible && <div className='px-3'> {conditionalHeaderContent}</div>}</Fragment>
+        </div>
+      ) : (
+        <IconButton
+          options={{
+            path: conditionalPath,
+            tooltip: classNames(
+              levelImportant && !priorityImportant && 'Not important',
+              levelImportant && priorityImportant && 'Important',
+              levelUrgent && !priorityUrgent && 'Not urgent',
+              levelUrgent && priorityUrgent && 'Urgent',
+            ),
+            color: conditionalFill,
+            borderRadius: 'rounded-md focus-visible:rounded-md',
+            margin: 'ml-0',
+            hoverBg: 'hover:bg-transparent',
+            display: options.display,
+            width: options.width,
+            container: options.container,
+            padding: options.padding,
+          }}
+          headerContents={options.isInitiallyVisible && conditionalHeaderContent}
+          onClick={onClick}
+        />
+      )}
     </TodoPriorityFragment>
   );
 };

--- a/components/ui/dropdowns/calendarDropdown.tsx
+++ b/components/ui/dropdowns/calendarDropdown.tsx
@@ -1,21 +1,23 @@
 import { Button } from '@buttons/button';
 import { IconButton } from '@buttons/iconButton';
+import { SvgIcon } from '@components/icons/svgIcon';
 import {
-  optionsButtonCalendarResetDate,
   optionsButtonCalendarCancel,
   optionsButtonCalendarConfirm,
+  optionsButtonCalendarResetDate,
 } from '@data/dataOptions';
 import { ICON_EVENT_AVAILABLE, ICON_EVENT_AVAILABLE_FILL } from '@data/materialSymbols';
 import { Menu } from '@headlessui/react';
 import { TypesOptionsDropdown } from '@lib/types/typesOptions';
 import { useCalResetDateAll, useCalResetDateItemOnly, useCalResetDayUpdater } from '@states/calendars/hooks';
 import { atomSelectorTodoItem, atomTodoNew } from '@states/todos';
+import { atomQueryTodoItem } from '@states/todos/atomQueries';
 import { classNames } from '@states/utils';
 import { Calendar } from '@ui/calendars/calendar';
 import { format } from 'date-fns';
 import { Types } from 'lib/types';
-import { Fragment as HeaderContentsFragment } from 'react';
-import { useRecoilValue } from 'recoil';
+import { Fragment, Fragment as HeaderContentsFragment } from 'react';
+import { useRecoilCallback, useRecoilValue } from 'recoil';
 import { Dropdown } from './dropdown';
 
 type Props = { options: TypesOptionsDropdown } & Partial<Pick<Types, 'todo'>> & Pick<Types, 'onClickConfirm'>;
@@ -27,56 +29,83 @@ export const CalendarDropdown = ({ todo, onClickConfirm, options }: Props) => {
   const todoItem =
     typeof todo === 'undefined' ? useRecoilValue(atomTodoNew) : useRecoilValue(atomSelectorTodoItem(todo._id));
   const noDaySelected = todoItem.dueDate == null;
+  const renderDueDate = noDaySelected ? 'Due date' : format(new Date(todoItem.dueDate as Date), 'MMM dd, yy');
+  const isTodoCompleted = useRecoilCallback(({ snapshot }) => () => {
+    return typeof todo !== 'undefined' && snapshot.getLoadable(atomQueryTodoItem(todo?._id)).getValue().completed;
+  });
 
   return (
-    <Dropdown
-      options={{
-        tooltip: options.tooltip,
-        padding: options.padding ?? 'px-2 sm:px-3 py-2',
-        borderRadius: options.borderRadius,
-        color: noDaySelected
-          ? 'fill-gray-500 [.group-calendarDropdown:hover_&]:fill-gray-700'
-          : 'fill-blue-500 [.group-calendarDropdown:hover_&]:fill-blue-700',
-        path: noDaySelected ? ICON_EVENT_AVAILABLE : ICON_EVENT_AVAILABLE_FILL,
-        group: 'group-calendarDropdown',
-        contentWidth: 'w-[21rem]',
-        menuWidth: 'sm:w-full',
-        hoverBg: options.hoverBg,
-        text: classNames('[.group-calendarDropdown:hover_&]:text-gray-700'),
-      }}
-      headerContents={
-        <HeaderContentsFragment>
-          {noDaySelected ? 'Due date' : format(new Date(todoItem.dueDate as Date), 'MMM dd, yy')}
-        </HeaderContentsFragment>
-      }>
-      <div className='p-2'>
-        <Calendar todo={todo} />
-        <div className='flex flex-row items-center justify-between px-4 pb-4 pt-5'>
-          <IconButton
-            options={optionsButtonCalendarResetDate}
-            onClick={() => resetDateAll()}
+    <Fragment>
+      {isTodoCompleted() ? (
+        <div
+          className={classNames(
+            'flex flex-row text-sm font-normal text-gray-500',
+            options.padding ?? 'px-2 py-2 sm:px-3',
+            options.borderRadius,
+            options.container,
+          )}>
+          <SvgIcon
+            options={{
+              path: noDaySelected ? ICON_EVENT_AVAILABLE : ICON_EVENT_AVAILABLE_FILL,
+              className: classNames(
+                'h-5 w-5',
+                noDaySelected
+                  ? 'fill-gray-500 [.group-calendarDropdown:hover_&]:fill-gray-700'
+                  : 'fill-blue-500 [.group-calendarDropdown:hover_&]:fill-blue-700',
+              ),
+            }}
           />
-          <div className='flex flex-row justify-end'>
-            <Menu.Item>
-              <Button
-                options={optionsButtonCalendarCancel}
-                onClick={() => {
-                  resetCalendar();
-                  resetDateItemOnly();
-                }}>
-                Cancel
-              </Button>
-            </Menu.Item>
-            <Menu.Item>
-              <Button
-                options={optionsButtonCalendarConfirm}
-                onClick={onClickConfirm}>
-                Ok
-              </Button>
-            </Menu.Item>
-          </div>
+          <div className='px-3'> {renderDueDate}</div>
         </div>
-      </div>
-    </Dropdown>
+      ) : (
+        <div className={classNames(options.container)}>
+          <Dropdown
+            options={{
+              tooltip: options.tooltip,
+              padding: options.padding ?? 'px-2 sm:px-3 py-2',
+              borderRadius: options.borderRadius,
+              color: noDaySelected
+                ? 'fill-gray-500 [.group-calendarDropdown:hover_&]:fill-gray-700'
+                : 'fill-blue-500 [.group-calendarDropdown:hover_&]:fill-blue-700',
+              path: noDaySelected ? ICON_EVENT_AVAILABLE : ICON_EVENT_AVAILABLE_FILL,
+              group: 'group-calendarDropdown',
+              contentWidth: 'w-[21rem]',
+              menuWidth: 'sm:w-full',
+              hoverBg: options.hoverBg,
+              text: classNames('[.group-calendarDropdown:hover_&]:text-gray-700'),
+            }}
+            headerContents={<HeaderContentsFragment>{renderDueDate}</HeaderContentsFragment>}>
+            <div className='p-2'>
+              <Calendar todo={todo} />
+              <div className='flex flex-row items-center justify-between px-4 pb-4 pt-5'>
+                <IconButton
+                  options={optionsButtonCalendarResetDate}
+                  onClick={() => resetDateAll()}
+                />
+                <div className='flex flex-row justify-end'>
+                  <Menu.Item>
+                    <Button
+                      options={optionsButtonCalendarCancel}
+                      onClick={() => {
+                        resetCalendar();
+                        resetDateItemOnly();
+                      }}>
+                      Cancel
+                    </Button>
+                  </Menu.Item>
+                  <Menu.Item>
+                    <Button
+                      options={optionsButtonCalendarConfirm}
+                      onClick={onClickConfirm}>
+                      Ok
+                    </Button>
+                  </Menu.Item>
+                </div>
+              </div>
+            </div>
+          </Dropdown>
+        </div>
+      )}
+    </Fragment>
   );
 };

--- a/components/ui/dropdowns/dropdown/dropdownMenuItem.tsx
+++ b/components/ui/dropdowns/dropdown/dropdownMenuItem.tsx
@@ -2,37 +2,24 @@ import { SvgIcon } from '@components/icons/svgIcon';
 import { STYLE_HOVER_SLATE_LIGHT } from '@data/stylePreset';
 import { Menu } from '@headlessui/react';
 import { Types } from '@lib/types';
+import { TypesOptionsDropdown } from '@lib/types/typesOptions';
 import { selectorActiveMenuItem } from '@states/misc';
 import { classNames } from '@states/utils';
 import { Tooltip } from '@tooltips/tooltips';
 import { useRecoilValue } from 'recoil';
 
-type Props = Partial<
-  Pick<
-    Types,
-    'tooltip' | 'kbd' | 'onClick' | 'children' | 'isDisabledCloseOnClick' | 'path' | 'padding' | 'size' | 'color'
-  >
->;
+type Props = { options: TypesOptionsDropdown } & Partial<Pick<Types, 'onClick' | 'children'>>;
 
-export const DropdownMenuItem = ({
-  tooltip,
-  kbd,
-  onClick,
-  padding,
-  path,
-  size,
-  color,
-  children,
-  isDisabledCloseOnClick = true,
-}: Props) => {
+export const DropdownMenuItem = ({ options, onClick, children }: Props) => {
   const isActive = useRecoilValue(selectorActiveMenuItem);
+  const { isDisabledCloseOnClick = true, isDisabled = false } = options;
 
   return (
     <span>
       <Tooltip
-        tooltip={tooltip}
-        kbd={kbd}>
-        <Menu.Item>
+        tooltip={options.tooltip}
+        kbd={options.kbd}>
+        <Menu.Item disabled={isDisabled}>
           {({ active }) => (
             <div
               onClick={(event) => {
@@ -40,19 +27,22 @@ export const DropdownMenuItem = ({
                 isDisabledCloseOnClick && event.preventDefault();
               }}
               className={classNames(
-                'group-1 block w-full cursor-pointer text-left text-sm text-gray-500 hover:bg-slate-600 hover:bg-opacity-10 hover:text-gray-700 focus-visible:rounded-md',
-                padding ?? 'px-4 py-2',
+                'group/menuItem block w-full cursor-pointer text-left text-sm text-gray-500',
+                isDisabled
+                  ? 'cursor-not-allowed select-none opacity-50'
+                  : 'hover:bg-slate-600 hover:bg-opacity-10 hover:text-gray-700 focus-visible:rounded-md',
+                options.padding ?? 'px-4 py-2',
                 active && isActive && STYLE_HOVER_SLATE_LIGHT,
               )}>
               <div className='flex flex-row'>
-                {typeof path !== 'undefined' && (
+                {typeof options.path !== 'undefined' && (
                   <SvgIcon
                     options={{
-                      path: path,
+                      path: options.path,
                       className: classNames(
                         'mr-3',
-                        size ?? 'h-5 w-5',
-                        color ?? 'fill-gray-500 [.group-1:hover_&]:fill-gray-700',
+                        options.size ?? 'h-5 w-5',
+                        options.color ?? 'fill-gray-500 group-hover/menuItem:fill-gray-700',
                       ),
                     }}
                   />

--- a/components/ui/dropdowns/labelItemDropdown.tsx
+++ b/components/ui/dropdowns/labelItemDropdown.tsx
@@ -26,19 +26,23 @@ export const LabelItemDropdown = ({ label, options, headerContentsOnClose }: Pro
       {/* give menuItemId any ID: string to activate the keyboard navigation */}
       <div className='py-1'>
         <DropdownMenuItem
-          isDisabledCloseOnClick={false}
-          onClick={() => openModal()}
-          path={ICON_EDIT_NOTE}
-          tooltip='Edit'>
+          options={{
+            isDisabledCloseOnClick: false,
+            path: ICON_EDIT_NOTE,
+            tooltip: 'Edit',
+          }}
+          onClick={() => openModal()}>
           Edit label
         </DropdownMenuItem>
       </div>
       <div className='py-1'>
         <DropdownMenuItem
-          isDisabledCloseOnClick={false}
-          onClick={() => removeLabel()}
-          path={ICON_DELETE}
-          tooltip='Delete'>
+          options={{
+            isDisabledCloseOnClick: false,
+            path: ICON_DELETE,
+            tooltip: 'Delete',
+          }}
+          onClick={() => removeLabel()}>
           Delete
         </DropdownMenuItem>
       </div>

--- a/components/ui/dropdowns/todoItemDropdown.tsx
+++ b/components/ui/dropdowns/todoItemDropdown.tsx
@@ -1,8 +1,8 @@
 import { PriorityButton } from '@buttons/iconButton/priorityButton';
 import {
   optionsDropdownCalendar,
-  optionsPriorityDropdownUrgent,
   optionsPriorityDropdownImportant,
+  optionsPriorityDropdownUrgent,
 } from '@data/dataOptions';
 import { PRIORITY_LEVEL } from '@data/dataTypesObjects';
 import { ICON_DELETE, ICON_MORE_VERT } from '@data/materialSymbols';
@@ -10,8 +10,10 @@ import { TypesOptionsDropdown } from '@lib/types/typesOptions';
 import { useCalUpdateDataItem } from '@states/calendars/hooks';
 import { ActiveDropdownMenuItemEffect } from '@states/misc/activeDropdownMenuItemEffect';
 import { usePriorityUpdate, usePriorityUpdateData } from '@states/priorities/hooks';
+import { atomQueryTodoItem } from '@states/todos/atomQueries';
 import { useTodoRemoveItem } from '@states/todos/hooks';
 import { Types } from 'lib/types';
+import { useRecoilCallback } from 'recoil';
 import { CalendarDropdown } from './calendarDropdown';
 import { Dropdown } from './dropdown';
 import { DropdownMenuItem } from './dropdown/dropdownMenuItem';
@@ -22,6 +24,9 @@ export const TodoItemDropdown = ({ todo, children, options }: Props) => {
   const removeTodo = useTodoRemoveItem(todo?._id);
   const updateCalendarDataItem = useCalUpdateDataItem(todo?._id);
   const setPriority = typeof todo === 'undefined' ? usePriorityUpdate(undefined) : usePriorityUpdateData(todo?._id);
+  const isTodoCompleted = useRecoilCallback(({ snapshot }) => () => {
+    return typeof todo !== 'undefined' && snapshot.getLoadable(atomQueryTodoItem(todo?._id)).getValue().completed;
+  });
 
   return (
     <Dropdown
@@ -34,7 +39,7 @@ export const TodoItemDropdown = ({ todo, children, options }: Props) => {
       {/* give menuItemId any ID: string to activate the keyboard navigation */}
       {children}
       <div className='py-1'>
-        <DropdownMenuItem padding='p-0'>
+        <DropdownMenuItem options={{ padding: 'p-0', isDisabled: isTodoCompleted() && true }}>
           <div className='w-full'>
             <CalendarDropdown
               options={optionsDropdownCalendar}
@@ -45,14 +50,14 @@ export const TodoItemDropdown = ({ todo, children, options }: Props) => {
         </DropdownMenuItem>
       </div>
       <div className='py-1'>
-        <DropdownMenuItem padding='p-0'>
+        <DropdownMenuItem options={{ padding: 'p-0', isDisabled: isTodoCompleted() && true }}>
           <PriorityButton
             options={optionsPriorityDropdownUrgent}
             todo={todo}
             onClick={() => setPriority(PRIORITY_LEVEL['urgent'])}
           />
         </DropdownMenuItem>
-        <DropdownMenuItem padding='p-0'>
+        <DropdownMenuItem options={{ padding: 'p-0', isDisabled: isTodoCompleted() && true }}>
           <PriorityButton
             todo={todo}
             options={optionsPriorityDropdownImportant}
@@ -62,11 +67,13 @@ export const TodoItemDropdown = ({ todo, children, options }: Props) => {
       </div>
       <div className='py-1'>
         <DropdownMenuItem
-          isDisabledCloseOnClick={false}
-          onClick={() => removeTodo()}
-          path={ICON_DELETE}
-          tooltip='Delete'
-          kbd='⌘ + Delete'>
+          options={{
+            isDisabledCloseOnClick: false,
+            tooltip: 'Delete',
+            path: ICON_DELETE,
+            kbd: '⌘ + Delete',
+          }}
+          onClick={() => removeTodo()}>
           Delete
         </DropdownMenuItem>
       </div>

--- a/components/ui/modals/todoModals/todoModal/index.tsx
+++ b/components/ui/modals/todoModals/todoModal/index.tsx
@@ -12,12 +12,13 @@ import { KeysWithTodoModalEffect } from '@states/keybinds/keysWithTodoModalEffec
 import { DisableScrollEffect } from '@states/misc/disableScrollEffect';
 import { atomTodoModalMax, atomTodoModalOpen } from '@states/modals';
 import { useTodoModalStateClose } from '@states/modals/hooks';
+import { atomQueryTodoItem } from '@states/todos/atomQueries';
 import { useTodoAdd } from '@states/todos/hooks';
 import { classNames } from '@states/utils';
 import { useConditionCheckTodoTitleEmpty } from '@states/utils/hooks';
 import { Types } from 'lib/types';
 import { Fragment as TodoModalFragment, useRef } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilCallback, useRecoilValue } from 'recoil';
 import { Button as CancelButton } from '../../../buttons/button';
 import { Divider as PlainLineDivider } from '../../../dividers/divider';
 import { ModalTransitionChild } from '../../modal/modalTransition/modalTransitionChild';
@@ -34,6 +35,9 @@ export const TodoModal = ({ todo, headerContents, headerButtons, footerButtons, 
   const updateCalendarItem = useCalUpdateItem(todo?._id);
   const addTodo = useTodoAdd();
   const condition = useConditionCheckTodoTitleEmpty();
+  const isTodoCompleted = useRecoilCallback(({ snapshot }) => () => {
+    return typeof todo !== 'undefined' && snapshot.getLoadable(atomQueryTodoItem(todo._id)).getValue().completed;
+  });
 
   return (
     <TodoModalFragment>
@@ -67,7 +71,10 @@ export const TodoModal = ({ todo, headerContents, headerButtons, footerButtons, 
             </div>
             <div className='flex flex-row items-center sm:m-1 '>
               <CalendarDropdown
-                options={{ tooltip: 'Due date' }}
+                options={{
+                  tooltip: 'Due date',
+                  container: isTodoCompleted() ? 'cursor-not-allowed select-none opacity-50' : '',
+                }}
                 todo={todo}
                 onClickConfirm={() => updateCalendarItem()}
               />

--- a/components/ui/modals/todoModals/todoModal/todoModalHeaderContents.tsx
+++ b/components/ui/modals/todoModals/todoModal/todoModalHeaderContents.tsx
@@ -4,11 +4,19 @@ import { PRIORITY_LEVEL } from '@data/dataTypesObjects';
 import { Types } from '@lib/types';
 import { HeaderDescription } from '@modals/modal/modalHeaders/headerDescription';
 import { usePriorityUpdate } from '@states/priorities/hooks';
+import { atomQueryTodoItem } from '@states/todos/atomQueries';
+import { mergeObjects } from '@states/utils';
+import { useRecoilCallback } from 'recoil';
 
 type Props = Pick<Types, 'children'> & Partial<Pick<Types, 'todo'>>;
 
 export const TodoModalHeaderContents = ({ todo, children }: Props) => {
   const setPriority = usePriorityUpdate(todo?._id);
+  const isTodoCompleted = useRecoilCallback(({ snapshot }) => () => {
+    return typeof todo !== 'undefined' && snapshot.getLoadable(atomQueryTodoItem(todo._id)).getValue().completed;
+  });
+  const disabledStyle = isTodoCompleted() ? 'cursor-not-allowed opacity-50 select-none' : '';
+  const conditionalHeaderDescription = isTodoCompleted() ? 'Completed todo' : 'Update todo';
 
   return (
     <div className='sm:flex sm:items-center'>
@@ -16,16 +24,18 @@ export const TodoModalHeaderContents = ({ todo, children }: Props) => {
         {children}
         <PriorityButton
           todo={todo}
-          options={optionsPriorityTodoModalImportant}
+          options={mergeObjects(optionsPriorityTodoModalImportant, { container: disabledStyle })}
           onClick={() => setPriority(PRIORITY_LEVEL['important'])}
         />
         <PriorityButton
           todo={todo}
-          options={optionsPriorityTodoModalUrgent}
+          options={mergeObjects(optionsPriorityTodoModalUrgent, { container: disabledStyle })}
           onClick={() => setPriority(PRIORITY_LEVEL['urgent'])}
         />
         <HeaderDescription>
-          <span className='font-semibold'>{typeof todo === 'undefined' ? 'Create todo' : 'Update todo'}</span>
+          <span className='font-semibold'>
+            {typeof todo === 'undefined' ? 'Create todo' : conditionalHeaderDescription}
+          </span>
         </HeaderDescription>
       </div>
     </div>

--- a/lib/states/keybinds/hooks.tsx
+++ b/lib/states/keybinds/hooks.tsx
@@ -68,8 +68,8 @@ export const useKeyWithFocus = (_id: Todos['_id']) => {
         openModal();
         break;
       case event.key === 'Escape':
-        event.preventDefault();
         if (get(atomQueryTodoItem(_id)).completed && get(atomTodoModalOpen(_id))) return;
+        event.preventDefault();
         !get(atomTodoModalMini(_id)) && reset(atomOnFocus);
         reset(atomCurrentFocus);
         set(atomOnBlur, true);

--- a/lib/types/typesOptions.ts
+++ b/lib/types/typesOptions.ts
@@ -20,7 +20,7 @@ export type TypesOptionsPseudoButton = Partial<
 
 export type TypesOptionsPriority = Partial<
   Pick<Types, 'isInitiallyVisible' | 'priorityImportant' | 'priorityNormal' | 'priorityUrgent'> &
-    Pick<TypesStyleAttributes, 'margin' | 'display' | 'width' | 'container' | 'padding'>
+    Pick<TypesStyleAttributes, 'margin' | 'display' | 'width' | 'container' | 'padding' | 'size' | 'color'>
 > &
   Pick<Types, 'priorityLevel'>;
 
@@ -39,10 +39,21 @@ export type TypesOptionsDropdown = Partial<
     | 'isInitiallyVisible'
     | 'hasDropdownBoardStyle'
     | 'isPortal'
+    | 'isDisabledCloseOnClick'
+    | 'isDisabled'
   > &
     Pick<
       TypesStyleAttributes,
-      'group' | 'padding' | 'borderRadius' | 'menuWidth' | 'size' | 'color' | 'text' | 'contentWidth' | 'hoverBg'
+      | 'group'
+      | 'padding'
+      | 'borderRadius'
+      | 'menuWidth'
+      | 'size'
+      | 'color'
+      | 'text'
+      | 'contentWidth'
+      | 'hoverBg'
+      | 'container'
     >
 >;
 


### PR DESCRIPTION
Now users are unable to modify the state of todoItem, which has been marked as completed such modifying the priority, date, and labels. However, users can still delete or undo completion the completed todoItem.

minor change:
fix: fix the unresponsive Escape key on the completed todoModal