### PR TITLE
fix: fix the integration issue between query data and atomEffect

### DIFF
--- a/lib/queries/queryLabels.ts
+++ b/lib/queries/queryLabels.ts
@@ -1,19 +1,20 @@
 import { Labels } from '@lib/types';
+import { fetchWithRetry } from '@states/utils/hooks';
 
 export const getDataLabels = async () => {
-  const response = await fetch(`/api/v1/labels`);
+  const response = await fetchWithRetry(`/api/v1/labels`);
   if (!response.ok) throw new Error(response.statusText);
   return await response.json();
 };
 
 export const getDataLabelItem = async (_id: Labels['_id']) => {
-  const response = await fetch(`/api/v1/labels/${_id}`);
+  const response = await fetchWithRetry(`/api/v1/labels/${_id}`);
   if (!response.ok) throw new Error(response.statusText);
   return await response.json();
 };
 
 export const createDataNewLabel = async (inputValue: Labels) => {
-  const response = await fetch(`/api/v1/labels`, {
+  const response = await fetchWithRetry(`/api/v1/labels`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(inputValue),
@@ -23,7 +24,7 @@ export const createDataNewLabel = async (inputValue: Labels) => {
 };
 
 export const updateDataLabels = async (inputValue: Labels[]) => {
-  const response = await fetch('/api/v1/labels', {
+  const response = await fetchWithRetry('/api/v1/labels', {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(inputValue),
@@ -33,7 +34,7 @@ export const updateDataLabels = async (inputValue: Labels[]) => {
 };
 
 export const updateDataLabelItem = async (_id: Labels['_id'], inputValue: Labels) => {
-  const response = await fetch(`/api/v1/labels/${_id}`, {
+  const response = await fetchWithRetry(`/api/v1/labels/${_id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(inputValue),
@@ -43,7 +44,7 @@ export const updateDataLabelItem = async (_id: Labels['_id'], inputValue: Labels
 };
 
 export const deleteDataLabelItem = async (_id: Labels['_id']) => {
-  const response = await fetch(`/api/v1/labels/${_id}`, {
+  const response = await fetchWithRetry(`/api/v1/labels/${_id}`, {
     method: 'DELETE',
   });
   if (!response.ok) throw new Error(response.statusText);

--- a/lib/queries/queryTodos.ts
+++ b/lib/queries/queryTodos.ts
@@ -1,23 +1,23 @@
 import { Todos, Types } from '@lib/types';
 import { queries } from '@states/utils';
+import { fetchWithRetry } from '@states/utils/hooks';
 
 export const getDataTodoIds = async ({
   model,
-}: Partial<Pick<Types, 'completed' | 'completedFromToday' | 'priorityLevel'>> &
-  Pick<Types, 'model'>) => {
-  const response = await fetch('/api/v1/todos?' + queries('model=' + model));
+}: Partial<Pick<Types, 'completed' | 'completedFromToday' | 'priorityLevel'>> & Pick<Types, 'model'>) => {
+  const response = await fetchWithRetry('/api/v1/todos?' + queries('model=' + model));
   if (!response.ok) throw new Error(response.statusText);
   return await response.json();
 };
 
 export const getDataTodoItem = async ({ _id }: Pick<Types, '_id'>) => {
-  const response = await fetch(`/api/v1/todos/${_id}`);
+  const response = await fetchWithRetry(`/api/v1/todos/${_id}`);
   if (!response.ok) throw new Error(response.statusText);
   return await response.json();
 };
 
 export const createDataNewTodo = async (inputValue: Todos) => {
-  const response = await fetch('/api/v1/todos', {
+  const response = await fetchWithRetry('/api/v1/todos', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(inputValue),
@@ -27,7 +27,7 @@ export const createDataNewTodo = async (inputValue: Todos) => {
 };
 
 export const deleteDataTodo = async (_id: Todos['_id']) => {
-  const response = await fetch(`/api/v1/todos/${_id}`, {
+  const response = await fetchWithRetry(`/api/v1/todos/${_id}`, {
     method: 'DELETE',
   });
   if (!response.ok) throw new Error(response.statusText);
@@ -35,7 +35,7 @@ export const deleteDataTodo = async (_id: Todos['_id']) => {
 };
 
 export const updateDataTodo = async (_id: Todos['_id'], inputValue: Todos) => {
-  const response = await fetch(`/api/v1/todos/${_id}`, {
+  const response = await fetchWithRetry(`/api/v1/todos/${_id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(inputValue),
@@ -49,7 +49,7 @@ export const completeDataTodo = async (
   completed: Todos['completed'],
   completedDate: Todos['completedDate'],
 ) => {
-  const response = await fetch(`/api/v1/todos/${_id}`, {
+  const response = await fetchWithRetry(`/api/v1/todos/${_id}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ completed: completed, completedDate: completedDate }),
@@ -63,7 +63,7 @@ export const updateDataCalendarTodo = async (
   dueDate: Todos['dueDate'],
   priorityRankScore: Todos['priorityRankScore'],
 ) => {
-  const response = await fetch(`/api/v1/todos/${_id}`, {
+  const response = await fetchWithRetry(`/api/v1/todos/${_id}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ dueDate: dueDate, priorityRankScore: priorityRankScore }),
@@ -77,7 +77,7 @@ export const updateDataPriorityTodo = async (
   priority: Todos['priorityLevel'],
   priorityRankScore: Todos['priorityRankScore'],
 ) => {
-  const response = await fetch(`/api/v1/todos/${_id}`, {
+  const response = await fetchWithRetry(`/api/v1/todos/${_id}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({

--- a/lib/queries/queryUsers/index.tsx
+++ b/lib/queries/queryUsers/index.tsx
@@ -1,5 +1,7 @@
+import { fetchWithRetry } from "@states/utils/hooks";
+
 export const getDataUserId = async () => {
   const dummyUserId = '63583219c2cd1c54e452521f';
-  const response = await fetch(`/api/v1/users?_id=${dummyUserId}`);
+  const response = await fetchWithRetry(`/api/v1/users?_id=${dummyUserId}`);
   return await response.json();
 };

--- a/lib/queries/queryUsers/querySettings/index.ts
+++ b/lib/queries/queryUsers/querySettings/index.ts
@@ -1,13 +1,14 @@
 import { Settings, Users } from '@lib/types';
+import { fetchWithRetry } from '@states/utils/hooks';
 
 export const getDataSetting = async (_id: Users['_id']) => {
-  const response = await fetch(`/api/v1/users/settings?userId=${_id}`);
+  const response = await fetchWithRetry(`/api/v1/users/settings?userId=${_id}`);
   if (!response.ok) throw new Error(response.statusText);
   return await response.json();
 };
 
 export const createDataNewSetting = async (inputValue: Settings) => {
-  const response = await fetch('/api/v1/users/settings', {
+  const response = await fetchWithRetry('/api/v1/users/settings', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(inputValue),
@@ -17,7 +18,7 @@ export const createDataNewSetting = async (inputValue: Settings) => {
 };
 
 export const updateDataSetting = async (_id: Settings['_id'], inputValue: Settings) => {
-  const response = await fetch(`/api/v1/users/settings/${_id}`, {
+  const response = await fetchWithRetry(`/api/v1/users/settings/${_id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(inputValue),
@@ -27,7 +28,7 @@ export const updateDataSetting = async (_id: Settings['_id'], inputValue: Settin
 };
 
 export const deleteDataSetting = async (_id: Settings['_id']) => {
-  const response = await fetch(`/api/v1/users/settings/${_id}`, {
+  const response = await fetchWithRetry(`/api/v1/users/settings/${_id}`, {
     method: 'DELETE',
   });
   if (!response.ok) throw new Error(response.statusText);
@@ -38,7 +39,7 @@ export const updateDataTaskCapacityPerDaySetting = async (
   _id: Settings['_id'],
   taskCapacity: Settings['taskCapacityPerDay'],
 ) => {
-  const response = await fetch(`/api/v1/users/settings/${_id}`, {
+  const response = await fetchWithRetry(`/api/v1/users/settings/${_id}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ taskCapacityPerDay: taskCapacity }),

--- a/lib/states/utils/hooks.tsx
+++ b/lib/states/utils/hooks.tsx
@@ -56,13 +56,7 @@ export const useConditionCompareLabelItemsEqual = (_id: Labels['_id']) => {
 };
 
 // recoil test observer: required to observe state change on unit test
-export const RecoilObserver = <T,>({
-  node,
-  onChange,
-}: {
-  node: RecoilState<T>;
-  onChange: Types['onChange'];
-}) => {
+export const RecoilObserver = <T,>({ node, onChange }: { node: RecoilState<T>; onChange: Types['onChange'] }) => {
   const value = useRecoilValue(node);
   useEffect(() => onChange(value), [onChange, value]);
   return null;
@@ -121,4 +115,19 @@ export const useCompareToQueryLabels = () => {
       return !get(atomQueryLabels).find((queryLabel) => equal(label, queryLabel));
     });
   });
+};
+
+export const fetchWithRetry = async (url: string, options?: {}, retryCount = 3) => {
+  let response;
+  for (let i = 0; i < retryCount; i++) {
+    try {
+      response = await fetch(url, options);
+      if (response.ok) return response;
+    } catch (error) {
+      response = error;
+    }
+    // delay re-attempt to fetch every time fetch fails
+    await new Promise((resolve) => setTimeout(resolve, 700));
+  }
+  throw response;
 };


### PR DESCRIPTION
Before the fix is explained, the fundamental data flow between querying and atomEffect must be explained:

1) data is mutated in client-side
2) data is saved to indexedDB
3) data is updated to database
4) refetching the updated data (if the refetch is set to true) 5) compare the refetched data with indexedDB
6) replace client-side data if there do not equal to each other.

The main problem that is not so visible was coming from that data is always returned either failed or success. Since returned data is always different from client-side data if fetch fails, the client-side data is replaced with empty, null data. The result is that todoItem disappears.

By implementing the `fetchWithRetry`, which has default attempt value of 3 meaning it will retry to refetch up to 3 times upon failing of fetching data, the occurrence of error has been reduced. Also, any returning of null data value will not replace the client-side data as happened before.

minor changes:
fix: fix the issue that Focus is not reset after todoItem is removed.