### PR TITLE
feat: add dynamic Title tags

### DIFF
--- a/components/layouts/layoutApp/index.tsx
+++ b/components/layouts/layoutApp/index.tsx
@@ -1,7 +1,9 @@
 import { CATCH } from '@data/dataTypesObjects';
 import { Types } from '@lib/types';
+import { atomHtmlTitleTag } from '@states/misc';
 import { atomCatch } from '@states/utils';
 import dynamic from 'next/dynamic';
+import Head from 'next/head';
 import {
   Fragment as FooterFragment,
   Fragment as HeaderFragment,
@@ -22,9 +24,13 @@ type Props = Pick<Types, 'children'>;
 
 export const LayoutApp = ({ children }: Props) => {
   const catchTodoModal = useRecoilValue(atomCatch(CATCH.todoModal));
+  const slug = useRecoilValue(atomHtmlTitleTag);
 
   return (
     <LayoutAppFragment>
+      <Head>
+        <title>{'My Todo App: ' + slug}</title>
+      </Head>
       <HeaderFragment>
         <Layout>{children}</Layout>
       </HeaderFragment>

--- a/components/layouts/layoutApp/layout/layoutHeader/headerSearchBar.tsx
+++ b/components/layouts/layoutApp/layout/layoutHeader/headerSearchBar.tsx
@@ -1,0 +1,61 @@
+import { IconButton } from '@buttons/iconButton';
+import { SvgIcon } from '@components/icons/svgIcon';
+import { ICON_SEARCH, ICON_CLOSE } from '@data/materialSymbols';
+import { atomSearchInput } from '@states/layouts';
+import { classNames } from '@states/utils';
+import { Fragment as ResetSearchFragment, Fragment as SearchBarFragment } from 'react';
+import { useSetRecoilState, useRecoilValue, useResetRecoilState } from 'recoil';
+
+export const HeaderSearchBar = () => {
+  const setSearchInput = useSetRecoilState(atomSearchInput);
+  const searchInputValue = useRecoilValue(atomSearchInput);
+  const resetSearchInput = useResetRecoilState(atomSearchInput);
+
+  return (
+    <SearchBarFragment>
+      <div className='relative flex flex-1 flex-row items-center justify-between'>
+        <form
+          className={classNames(
+            'md:mr-15 relative flex w-full max-w-xl items-center rounded-md border border-transparent text-gray-400 drop-shadow-sm focus-within:border-slate-200 focus-within:border-opacity-50 focus-within:text-gray-600 focus-within:shadow-lg focus-within:shadow-slate-300/60 sm:mr-10 lg:mr-10 xl:max-w-2xl',
+          )}
+          action='#'
+          method='GET'>
+          <label
+            htmlFor='search-field'
+            className='sr-only'>
+            Search
+          </label>
+          <div className='pointer-events-none absolute inset-y-0 left-4 flex items-center'>
+            <SvgIcon
+              options={{
+                path: ICON_SEARCH,
+                className: 'h-6 w-6 fill-gray-500',
+              }}
+            />
+          </div>
+          <input
+            id='search-field'
+            className='block h-12 w-full rounded-md border-transparent bg-blue-100 bg-opacity-80 pl-12 pr-12 text-base text-gray-900 placeholder-gray-500 focus-within:bg-transparent focus:border-transparent focus:placeholder-gray-400 focus:outline-none focus:ring-0'
+            placeholder='Search'
+            type='search'
+            name='search'
+            value={searchInputValue}
+            onChange={(event) => setSearchInput(event.target.value)}
+          />
+          <ResetSearchFragment>
+            {searchInputValue && (
+              <div className='absolute right-2 bg-transparent'>
+                <IconButton
+                  options={{
+                    path: ICON_CLOSE,
+                  }}
+                  onClick={() => resetSearchInput()}
+                />
+              </div>
+            )}
+          </ResetSearchFragment>
+        </form>
+      </div>
+    </SearchBarFragment>
+  );
+};

--- a/components/layouts/layoutApp/layout/layoutHeader/index.tsx
+++ b/components/layouts/layoutApp/layout/layoutHeader/index.tsx
@@ -1,11 +1,8 @@
 import { IconButton } from '@buttons/iconButton';
-import { SvgIcon } from '@components/icons/svgIcon';
 import { optionsButtonSidebarToggle } from '@data/dataOptions';
-import { ICON_CLOSE, ICON_SEARCH } from '@data/materialSymbols';
 import { STYLE_BUTTON_KEY_ONLY_RING } from '@data/stylePreset';
 import { Menu, Transition } from '@headlessui/react';
 import { LayoutLogo } from '@layouts/layoutApp/layoutLogo';
-import { atomSearchInput } from '@states/layouts';
 import { useSidebarOpen } from '@states/layouts/hooks';
 import { classNames } from '@states/utils';
 import Image from 'next/image';
@@ -14,12 +11,10 @@ import {
   Fragment as LayoutHeaderFragment,
   Fragment as LeftSideFragment,
   Fragment as LogoFragment,
-  Fragment as ResetSearchFragment,
   Fragment as RightSidebarFragment,
-  Fragment as SearchInputFragment,
   Fragment as SidebarButtonFragment,
 } from 'react';
-import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
+import { HeaderSearchBar } from './headerSearchBar';
 
 const userNavigation = [
   { name: 'Settings', href: '#' },
@@ -28,9 +23,6 @@ const userNavigation = [
 
 export const LayoutHeader = () => {
   const setSidebarOpen = useSidebarOpen();
-  const setSearchInput = useSetRecoilState(atomSearchInput);
-  const searchInputValue = useRecoilValue(atomSearchInput);
-  const resetSearchInput = useResetRecoilState(atomSearchInput);
 
   return (
     <LayoutHeaderFragment>
@@ -53,51 +45,7 @@ export const LayoutHeader = () => {
         </LeftSideFragment>
         <RightSidebarFragment>
           <div className='flex flex-1 px-2'>
-            <SearchInputFragment>
-              <div className='relative flex flex-1 flex-row items-center justify-between'>
-                <form
-                  className={classNames(
-                    'md:mr-15 relative flex w-full max-w-xl items-center rounded-md border border-transparent text-gray-400 drop-shadow-sm focus-within:border-slate-200 focus-within:border-opacity-50 focus-within:text-gray-600 focus-within:shadow-lg focus-within:shadow-slate-300/60 sm:mr-10 lg:mr-10 xl:max-w-2xl',
-                  )}
-                  action='#'
-                  method='GET'>
-                  <label
-                    htmlFor='search-field'
-                    className='sr-only'>
-                    Search
-                  </label>
-                  <div className='pointer-events-none absolute inset-y-0 left-4 flex items-center'>
-                    <SvgIcon
-                      options={{
-                        path: ICON_SEARCH,
-                        className: 'h-6 w-6 fill-gray-500',
-                      }}
-                    />
-                  </div>
-                  <input
-                    id='search-field'
-                    className='block h-12 w-full rounded-md border-transparent bg-blue-100 bg-opacity-80 pl-12 pr-12 text-base text-gray-900 placeholder-gray-500 focus-within:bg-transparent focus:border-transparent focus:placeholder-gray-400 focus:outline-none focus:ring-0'
-                    placeholder='Search'
-                    type='search'
-                    name='search'
-                    value={searchInputValue}
-                    onChange={(event) => setSearchInput(event.target.value)}
-                  />
-                  <ResetSearchFragment>
-                    {searchInputValue && (
-                      <div className='absolute right-2 bg-transparent'>
-                        <IconButton
-                          options={{
-                            path: ICON_CLOSE,
-                          }}
-                          onClick={() => resetSearchInput()}
-                        />
-                      </div>
-                    )}
-                  </ResetSearchFragment>
-                </form>
-              </div>
-            </SearchInputFragment>
+            <HeaderSearchBar />
             <div className='ml-4 flex items-center md:ml-6'>
               {/* Profile dropdown */}
               <Menu

--- a/components/layouts/layoutHome/index.tsx
+++ b/components/layouts/layoutHome/index.tsx
@@ -9,7 +9,7 @@ export const LayoutHome = ({ children }: Props) => {
   return (
     <LayoutFragment>
       <Head>
-        <title>Task name</title>
+        <title>Home</title>
       </Head>
       {children}
     </LayoutFragment>

--- a/lib/states/misc/index.tsx
+++ b/lib/states/misc/index.tsx
@@ -1,10 +1,10 @@
-/*
- * Atoms
- * */
-
 import { BREAKPOINT } from '@data/dataTypesObjects';
 import { mediaQueryEffect, networkStatusEffect } from '@effects/atomEffects';
 import { atomFamily, atom, selector } from 'recoil';
+
+/*
+ * Atoms
+ * */
 
 // Media Queries
 export const atomMediaQuery = atomFamily<boolean, BREAKPOINT>({
@@ -42,6 +42,14 @@ export const atomActiveMenuItem = atomFamily<boolean, string | null>({
   ],
 });
 
+export const atomHtmlTitleTag = atom<string>({
+  key: 'atomHtmlTitleTag',
+  default: '',
+});
+
+/**
+ * selector
+ * */
 export const selectorActiveMenuItem = selector({
   key: 'selectorActiveMenuItem',
   get: ({ get }) => {

--- a/lib/states/todos/filterTodoIdsEffect.tsx
+++ b/lib/states/todos/filterTodoIdsEffect.tsx
@@ -1,24 +1,52 @@
 import { PATHNAME } from '@data/dataTypesObjects';
-import { atomLabelQuerySlug } from '@states/labels';
+import { Labels } from '@lib/types';
+import { atomLabelQuerySlug, atomQueryLabels } from '@states/labels';
+import { atomHtmlTitleTag } from '@states/misc';
 import { useNextQuerySlug } from '@states/utils/hooks';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
-import { useRecoilCallback } from 'recoil';
+import { useRecoilCallback, useRecoilValue } from 'recoil';
 import { atomFilterTodoIds } from '.';
 
 export const FilterTodoIdsEffect = () => {
   const labelId = useNextQuerySlug('/app/label');
   const { asPath } = useRouter();
+  const labels = useRecoilCallback(({ snapshot }) => () => {
+    return snapshot.getLoadable(atomQueryLabels).getValue();
+  });
+  const label_id = useRecoilValue(atomLabelQuerySlug);
+  const label = labels().find((label) => label._id === label_id) || ({} as Labels);
 
   const filterTodoIds = useRecoilCallback(({ set }) => () => {
-    if (asPath === PATHNAME['app']) return set(atomFilterTodoIds, 'focus');
-    if (asPath === PATHNAME['urgent']) return set(atomFilterTodoIds, 'urgent');
-    if (asPath === PATHNAME['important']) return set(atomFilterTodoIds, 'important');
-    if (asPath === PATHNAME['showAll']) return set(atomFilterTodoIds, 'showAll');
-    if (asPath === PATHNAME['completed']) return set(atomFilterTodoIds, 'completed');
+    if (asPath === PATHNAME['app']) {
+      set(atomFilterTodoIds, 'focus');
+      set(atomHtmlTitleTag, "Today's Focus");
+      return;
+    }
+    if (asPath === PATHNAME['urgent']) {
+      set(atomFilterTodoIds, 'urgent');
+      set(atomHtmlTitleTag, 'Priority - Urgent');
+      return;
+    }
+    if (asPath === PATHNAME['important']) {
+      set(atomFilterTodoIds, 'important');
+      set(atomHtmlTitleTag, 'Priority - Important');
+      return;
+    }
+    if (asPath === PATHNAME['showAll']) {
+      set(atomFilterTodoIds, 'showAll');
+      set(atomHtmlTitleTag, 'All Todos');
+      return;
+    }
+    if (asPath === PATHNAME['completed']) {
+      set(atomFilterTodoIds, 'completed');
+      set(atomHtmlTitleTag, 'Task Completed Todos');
+      return;
+    }
     if (asPath.match(new RegExp(PATHNAME['label']))) {
       set(atomFilterTodoIds, 'label');
       set(atomLabelQuerySlug, labelId);
+      set(atomHtmlTitleTag, `Label - ${label.name}`);
       return;
     }
   });

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,3 @@
-import { LayoutHome } from '@layouts/layoutHome';
 import { NextPage } from 'next';
 import type { AppProps } from 'next/app';
 import { ReactElement, ReactNode } from 'react';
@@ -16,11 +15,7 @@ type AppPropsWithLayout = AppProps & {
 const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
   const getLayout = Component.getLayout ?? ((page) => page);
 
-  return (
-    <RecoilRoot>
-      <LayoutHome>{getLayout(<Component {...pageProps} />)}</LayoutHome>
-    </RecoilRoot>
-  );
+  return <RecoilRoot>{getLayout(<Component {...pageProps} />)}</RecoilRoot>;
 };
 
 export default MyApp;

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -4,7 +4,7 @@ class MyDocument extends Document {
   render() {
     return (
       <Html>
-        <Head></Head>
+        <Head />
         <body className='overflow-hidden bg-slate-50 font-roboto'>
           <Main />
           <NextScript />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,8 @@
 import { PATHNAME } from '@data/dataTypesObjects';
 import { STYLE_BUTTON_NORMAL_BLUE } from '@data/stylePreset';
+import { LayoutHome } from '@layouts/layoutHome';
 import dynamic from 'next/dynamic';
+import { ReactElement } from 'react';
 
 const PrefetchRouterButton = dynamic(() =>
   import('@buttons/button/prefetchRouterButton').then((mod) => mod.PrefetchRouterButton),
@@ -17,4 +19,9 @@ const Home = () => {
     </div>
   );
 };
+
+Home.getLayout = function getLayout(page: ReactElement) {
+  return <LayoutHome>{page}</LayoutHome>;
+};
+
 export default Home;


### PR DESCRIPTION
Now title tag is generated dynamically based on the given route with the prefix: `My Todo App`, which might change in the future. For example, the title tags is `My Todo App: Priority - Important` if route equals to `/app/important`.

Core Changes:
- feat: add `title` to the `LayoutHome`.
- feat: add new state: atomHtmlTitleTag.
- feat: add dynamic `title` tag to the `LayoutApp`.

Misc Changes:
- feat: split the component from `LayoutHeader` into `HeaderSearchBar`.
- refactor: remove the `LayoutHome` as `perPage` layout of page index.
- refactor: refactor the _document of Head tags.