### PR TITLE
fix: fix incompatibility issues on CSS and UI

### DIFF
--- a/components/labels/labelItem.tsx
+++ b/components/labels/labelItem.tsx
@@ -1,13 +1,17 @@
 import { PrefetchRouterButton } from '@buttons/button/prefetchRouterButton';
 import { SvgIcon } from '@components/icons/svgIcon';
 import { optionsButtonLabelRouteMatched, optionsButtonLabelRouteUnmatched } from '@data/dataOptions';
+import { BREAKPOINT } from '@data/dataTypesObjects';
 import { STYLE_HOVER_ENABLED_SLATE_DARK } from '@data/stylePreset';
 import { TodosCount } from '@layouts/layoutApp/layout/layoutFooter/footerSidebar/todosCount';
 import { Types } from '@lib/types';
+import { useSidebarOpen } from '@states/layouts/hooks';
+import { atomMediaQuery } from '@states/misc';
 import { classNames, paths } from '@states/utils';
 import { useNextQuerySlug } from '@states/utils/hooks';
 import dynamic from 'next/dynamic';
 import { Fragment, Fragment as LabelModalFragment } from 'react';
+import { useRecoilValue } from 'recoil';
 
 const LabelItemDropdown = dynamic(() => import('@dropdowns/labelItemDropdown').then((mod) => mod.LabelItemDropdown), {
   ssr: false,
@@ -27,6 +31,8 @@ const DeleteLabelConfirmModal = dynamic(
 export const LabelItem = ({ label }: Pick<Types, 'label'>) => {
   const slug = useNextQuerySlug('/app/label');
   const matchedSlug = slug === label._id;
+  const isBreakpointMd = useRecoilValue(atomMediaQuery(BREAKPOINT['md']));
+  const setSideBarOpen = useSidebarOpen();
 
   return (
     <Fragment>
@@ -39,7 +45,8 @@ export const LabelItem = ({ label }: Pick<Types, 'label'>) => {
           <PrefetchRouterButton
             tooltip={label.name}
             path={paths('/app/label/', label._id)}
-            className={classNames('w-full focus:outline-none focus:ring-0 focus:ring-offset-0')}>
+            className={classNames('w-full focus:outline-none focus:ring-0 focus:ring-offset-0')}
+            onClick={() => !isBreakpointMd && setSideBarOpen()}>
             <div className='flex w-full flex-row  py-2 px-2'>
               {matchedSlug ? (
                 <SvgIcon options={optionsButtonLabelRouteMatched} />

--- a/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/footerSidebarMenu.tsx
+++ b/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/footerSidebarMenu.tsx
@@ -1,14 +1,20 @@
 import { PrefetchRouterButton } from '@buttons/button/prefetchRouterButton';
 import { SvgIcon } from '@components/icons/svgIcon';
 import { DATA_SIDEBAR_MENU } from '@data/dataArrayObjects';
+import { BREAKPOINT } from '@data/dataTypesObjects';
 import { STYLE_HOVER_SLATE_LIGHT } from '@data/stylePreset';
+import { useSidebarOpen } from '@states/layouts/hooks';
+import { atomMediaQuery } from '@states/misc';
 import { classNames } from '@states/utils';
 import { useRouter } from 'next/router';
 import { Fragment as FooterSidebarMenuFragment, Fragment as TotalNumberTodos } from 'react';
+import { useRecoilValue } from 'recoil';
 import { TodosCount } from './todosCount';
 
 export const FooterSidebarMenu = () => {
   const router = useRouter();
+  const setSidebarOpen = useSidebarOpen();
+  const isBreakpointMd = useRecoilValue(atomMediaQuery(BREAKPOINT['md']));
 
   return (
     <FooterSidebarMenuFragment>
@@ -25,7 +31,8 @@ export const FooterSidebarMenu = () => {
                   ? 'cursor-default bg-blue-100 font-semibold text-gray-900 text-opacity-80'
                   : `font-medium text-gray-600 hover:text-gray-900 ${STYLE_HOVER_SLATE_LIGHT}`,
                 'group flex w-full items-center rounded-md px-2 py-2 text-sm focus:outline-none focus:ring-0 focus:ring-offset-0',
-              )}>
+              )}
+              onClick={() => !isBreakpointMd && setSidebarOpen()}>
               <span className='pr-3'>
                 <SvgIcon
                   options={{

--- a/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/index.tsx
+++ b/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/index.tsx
@@ -47,7 +47,7 @@ export const FooterSidebar = forwardRef<HTMLDivElement>((_, ref) => {
       />
       <div
         ref={ref}
-        className='fixed left-0 top-0 z-20 w-72 bg-white pl-2 pr-0 pt-3 md:top-[4.6rem] md:z-auto md:flex md:w-full md:max-w-[16.5rem] md:flex-col md:bg-transparent md:pt-0 md:pl-2 md:pr-0'>
+        className='fixed left-0 top-0 z-20 h-full w-72 bg-white pl-2 pr-0 pt-3 md:top-[4.6rem] md:z-auto md:flex md:w-full md:max-w-[16.5rem] md:flex-col md:bg-transparent md:pt-0 md:pl-2 md:pr-0'>
         <LayoutLogoFragment>
           <div className='mb-4 mt-0 flex flex-row items-center justify-between pr-3 md:hidden'>
             <IconButton

--- a/components/layouts/layoutApp/layout/layoutFooter/index.tsx
+++ b/components/layouts/layoutApp/layout/layoutFooter/index.tsx
@@ -41,7 +41,9 @@ export const LayoutFooter = ({ children }: Pick<Types, 'children'>) => {
                 'absolute h-[calc(100vh-5.4rem)] w-full sm:h-[calc(100vh-4.4rem)] lg:h-full',
                 isScrollDisabled ? 'overflow-y-hidden' : 'overflow-y-auto',
               )}>
-              <div className='flex w-full justify-center pt-10 pl-5 pb-64 lg:justify-center lg:pl-10'>{children}</div>
+              <div className='flex w-full justify-center pt-10 pb-64 pl-0 sm:pl-5 lg:justify-center lg:pl-10'>
+                {children}
+              </div>
             </main>
           </div>
         </FooterBodyFragment>

--- a/components/todos/todo/index.tsx
+++ b/components/todos/todo/index.tsx
@@ -29,7 +29,7 @@ export const Todo = ({ todo, index }: Props) => {
   return (
     <>
       <div className='flex flex-row items-center justify-center px-1'>
-        <div className='group relative mr-4 flex w-full cursor-pointer flex-row justify-start'>
+        <div className='group relative flex w-full cursor-pointer flex-row justify-start sm:mr-4'>
           <TodoItemFocuser
             todo={todo}
             index={index!}>

--- a/components/todos/todo/todoItemFocuser.tsx
+++ b/components/todos/todo/todoItemFocuser.tsx
@@ -17,7 +17,7 @@ export const TodoItemFocuser = ({ todo, index, children }: Props) => {
       <div
         tabIndex={0}
         className={classNames(
-          'group/focuser mr-1 flex w-full flex-row rounded-lg px-5 pt-4 pb-2 outline-none hover:bg-slate-100 focus:bg-blue-100',
+          'group/focuser mr-1 flex flex-row rounded-lg px-2 pt-4 pb-2 outline-none hover:bg-slate-100 focus:bg-blue-100 sm:px-5',
           'w-[calc(100vw-7rem)] max-w-3xl md:w-[calc(65vw-5rem)] ml:w-[calc(70vw-5rem)]',
         )}
         ref={divFocus}

--- a/components/ui/dropdowns/dropdown/index.tsx
+++ b/components/ui/dropdowns/dropdown/index.tsx
@@ -39,7 +39,7 @@ export const Dropdown = ({ headerContents, headerContentsOnClose, children, show
     <span>
       <Menu
         as='div'
-        className={classNames('relative inline-block text-left', options.menuWidth)}>
+        className={classNames('relative inline-block text-left', options.menuWidth, options.menuHeight)}>
         {({ open }) => (
           <Tooltip
             tooltip={isClicked || open ? undefined : options.tooltip}
@@ -52,7 +52,7 @@ export const Dropdown = ({ headerContents, headerContentsOnClose, children, show
                     'inline-flex w-full items-center text-gray-400 ease-in hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-0 sm:ml-0',
                     options.padding ?? 'p-2',
                     options.hoverBg ?? STYLE_HOVER_SLATE_DARK,
-                    options.borderRadius ?? 'rounded-lg',
+                    options.borderRadius ?? 'rounded-full',
                     (!options.borderRadius && headerContents) || 'rounded-full',
                     visibility(isInitiallyVisible ?? true, open),
                   )}

--- a/components/ui/dropdowns/labelComboBoxDropdown.tsx
+++ b/components/ui/dropdowns/labelComboBoxDropdown.tsx
@@ -30,7 +30,7 @@ export const LabelComboBoxDropdown = ({ todo, selectedQueryLabels, container }: 
       <div
         className={classNames(
           'relative flex flex-row',
-          container ?? 'w-[calc(80vw-5rem)] max-w-[32rem] md:w-[calc(50vw-2rem)] ml:w-[calc(55vw-13rem)]',
+          container ?? 'w-[calc(80vw-6rem)] max-w-[32rem] md:w-[calc(50vw-2rem)] ml:w-[calc(55vw-13rem)]',
         )}>
         <LabelsHorizontalGradients
           scrollRef={scrollRef}

--- a/components/ui/dropdowns/todoItemDropdown.tsx
+++ b/components/ui/dropdowns/todoItemDropdown.tsx
@@ -33,6 +33,7 @@ export const TodoItemDropdown = ({ todo, children, options }: Props) => {
       options={{
         tooltip: 'Menu',
         path: ICON_MORE_VERT,
+        menuHeight: 'mt-2',
         isInitiallyVisible: options.isInitiallyVisible,
       }}>
       <ActiveDropdownMenuItemEffect menuItemId={null} />

--- a/components/ui/modals/minimizedModal.tsx
+++ b/components/ui/modals/minimizedModal.tsx
@@ -9,11 +9,14 @@ import {
   optionsButtonMiniModalOpenFull,
   optionsButtonGlobalClose,
 } from '@data/dataOptions';
+import { BREAKPOINT } from '@data/dataTypesObjects';
+import { atomMediaQuery } from '@states/misc';
 import { atomTodoModalMini } from '@states/modals';
 import { useTodoModalStateClose, useTodoModalStateMaximize, useTodoModalStateExitMinimize } from '@states/modals/hooks';
 import { ModalStateOnBreakpointEffect } from '@states/modals/modalStateOnBreakpointEffect';
 import { atomTodoNew } from '@states/todos';
 import { TypesTodo } from 'lib/types';
+import { Fragment } from 'react';
 import { useRecoilValue } from 'recoil';
 import { MinimizeModalTransition } from './modal/modalTransition/minimizeModalTransition';
 
@@ -25,34 +28,39 @@ export const MinimizedModal = ({ todo }: Props) => {
   const maximizeModal = useTodoModalStateMaximize(todo?._id);
   const exitMinimizeModal = useTodoModalStateExitMinimize(todo?._id);
   const newTodo = useRecoilValue(atomTodoNew);
+  const isMediaQuerySmall = useRecoilValue(atomMediaQuery(BREAKPOINT['sm']));
 
   return (
-    <MinimizeModalTransition
-      show={isTodoModalMiniOpen}
-      options={optionsMinimizedModal}>
-      <div className=' flex flex-shrink-0 flex-row items-center justify-between'>
-        <div className='flex flex-1 flex-col justify-center'>
-          <p className='w-44 break-words text-sm font-medium text-gray-500 line-clamp-1'>{newTodo.title}</p>
-        </div>
-        <div className='flex h-fit flex-row'>
-          <MaxIconButton
-            options={optionsButtonMiniModalMaximize}
-            onClick={() => exitMinimizeModal()}
-          />
-          <OpenFullIconButton
-            options={optionsButtonMiniModalOpenFull}
-            onClick={() => maximizeModal()}
-          />
-          <CloseIconButton
-            options={optionsButtonGlobalClose}
-            onClick={() => closeModal()}
-          />
-        </div>
-      </div>
-      <div>
-        <p className='w-64 break-words text-sm text-gray-400 line-clamp-3'>{newTodo.note}</p>
-      </div>
-      <ModalStateOnBreakpointEffect />
-    </MinimizeModalTransition>
+    <Fragment>
+      {isMediaQuerySmall && (
+        <MinimizeModalTransition
+          show={isTodoModalMiniOpen}
+          options={optionsMinimizedModal}>
+          <div className=' flex flex-shrink-0 flex-row items-center justify-between'>
+            <div className='flex flex-1 flex-col justify-center'>
+              <p className='w-44 break-words text-sm font-medium text-gray-500 line-clamp-1'>{newTodo.title}</p>
+            </div>
+            <div className='flex h-fit flex-row'>
+              <MaxIconButton
+                options={optionsButtonMiniModalMaximize}
+                onClick={() => exitMinimizeModal()}
+              />
+              <OpenFullIconButton
+                options={optionsButtonMiniModalOpenFull}
+                onClick={() => maximizeModal()}
+              />
+              <CloseIconButton
+                options={optionsButtonGlobalClose}
+                onClick={() => closeModal()}
+              />
+            </div>
+          </div>
+          <div>
+            <p className='w-64 break-words text-sm text-gray-400 line-clamp-3'>{newTodo.note}</p>
+          </div>
+          <ModalStateOnBreakpointEffect />
+        </MinimizeModalTransition>
+      )}
+    </Fragment>
   );
 };

--- a/components/ui/modals/todoModals/todoModal/index.tsx
+++ b/components/ui/modals/todoModals/todoModal/index.tsx
@@ -81,7 +81,9 @@ export const TodoModal = ({ todo, headerContents, headerButtons, footerButtons, 
               <LabelComboBoxDropdown
                 todo={todo}
                 container={classNames(
-                  isTodoModalMax ? 'w-full max-w-[85%]' : 'max-w-[32rem] md:w-[75%] w-[calc(70vw-2rem)]',
+                  isTodoModalMax
+                    ? 'w-full max-w-[85%]'
+                    : 'max-w-[32rem] md:w-[75%] sm:w-[calc(70vw-2rem)] w-[calc(70vw-4rem)]',
                 )}
               />
             </div>

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -234,6 +234,7 @@ export interface TypesStyleAttributes {
   space: string;
   text: string;
   menuWidth: string;
+  menuHeight: string;
   display: string;
   width: string;
   container: string;

--- a/lib/types/typesOptions.ts
+++ b/lib/types/typesOptions.ts
@@ -48,6 +48,7 @@ export type TypesOptionsDropdown = Partial<
       | 'padding'
       | 'borderRadius'
       | 'menuWidth'
+      | 'menuHeight'
       | 'size'
       | 'color'
       | 'text'


### PR DESCRIPTION
fix the minor CSS and UI issues on different mediaQueries.

Core changes:
- fix: fix the height of footerSidebar on the mobile view.
- fix: fix the border-radius shape.
- fix: fix the height of TodoItem's dropdown button.
- fix: fix the rendering issue of minimizedModal.

Misc changes:
- feat: add auto-close of sidebar on mediaQuery medium below Now sidebar will auto-close onClick event based on the size of mediaQuery below medium (768px). The sidebar previously stays open on clicking menu.
- feat: add new type, menuHeight, to dropdown