### PR TITLE
fix: fix the label does not return on empty string

### DIFF
--- a/lib/states/keybinds/hooks.tsx
+++ b/lib/states/keybinds/hooks.tsx
@@ -16,6 +16,7 @@ import {
 import { atomQueryTodoItem } from '@states/todos/atomQueries';
 import { useTodoCompleteItem, useTodoRemoveItem, useTodoAdd, useTodoUpdateItem } from '@states/todos/hooks';
 import { atomCatch } from '@states/utils';
+import { useConditionCheckLabelTitleEmpty } from '@states/utils/hooks';
 import { isMacOs } from 'react-device-detect';
 import { useRecoilCallback, RecoilValue } from 'recoil';
 import { Transforms } from 'slate';
@@ -109,6 +110,7 @@ export const useKeyWithEditor = (titleName: Types['titleName'], _id: Todos['_id'
 
 // with labels
 export const useKeyWithLabelModal = (_id: Labels['_id']) => {
+  const isLabelEmpty = useConditionCheckLabelTitleEmpty();
   const addLabel = useLabelAdd();
   const updateLabel = useLabelUpdateItem(_id);
   return useRecoilCallback(({ snapshot }) => (event: KeyboardEvent) => {
@@ -120,7 +122,7 @@ export const useKeyWithLabelModal = (_id: Labels['_id']) => {
 
     switch (event.key) {
       case 'Enter':
-        if (!isLabelModalOpen) return;
+        if (!isLabelModalOpen || isLabelEmpty) return;
         event.preventDefault();
         if (get(atomLabelModalOpen(_id)) && typeof _id !== 'undefined') return updateLabel();
         get(atomLabelModalOpen(undefined)) && addLabel();


### PR DESCRIPTION
Now Enter key will not let user create the label while the input string is empty. Previously, if users presses Enter key while input is empty on the labelModal, it lets users create the label with empty string as ''.

Core change:
- fix: add a condition to `useKeyWithLabelModal` hook.