### PR TITLE
fix: fix the scrolling on mobile

### DIFF
--- a/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/index.tsx
+++ b/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/index.tsx
@@ -79,7 +79,7 @@ export const FooterSidebar = forwardRef<HTMLDivElement>((_, ref) => {
         </CreateTodoFragment>
         <div
           className={classNames(
-            'h- flex w-full flex-grow flex-col bg-transparent pr-2 md:h-[calc(100vh-8.5rem)]',
+            'flex h-[calc(100vh-8.5rem)] w-full flex-grow flex-col bg-transparent pr-2',
             isScrollDisabled ? 'overflow-y-hidden' : 'overflow-y-auto',
           )}>
           <div className='flex flex-grow flex-col'>


### PR DESCRIPTION
fix the mobile scrolling does not work properly. This was due to the height of sidebar was not correctly calculated with the viewport.

Core change:
- fix: fix the height of the mobile footerSidebar.

Misc change:
- refactor: remove the typo.