### PR TITLE
feature: update the deployment method

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@
 #
 # HOST
 # use .env.development.local to override the .env
-HOSTNAME=tp-next-todos-app01-2mjfsfem7q-uc.a.run.app
+HOSTNAME=todo.atalas.dev
 HOST=https://$HOSTNAME:$PORT
 NEXT_PUBLIC_HOST=$HOST
 # API

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -e # exit script if any command exits
+set -x # print each command it executes 
+
+function gcloud_run_deploy() {
+  set -x
+  gcloud run deploy \
+    $VPC_FLAG \
+    $SECRET_FLAG \
+    --image gcr.io/$GCP_PROJECT_ID/$IMAGE_NAME:$IMAGE_TAG \
+    --project $GCP_PROJECT_ID \
+    --region $DEPLOY_REGION \
+    --platform managed \
+    --allow-unauthenticated 
+
+}
+
+source .env.local
+# NOTE: .env.local must hold the following environment variables
+# .env.local SHOULD NOT be shared and only served from the local. 
+#
+# IMAGE_NAME
+# IMAGE_TAG
+# GCP_PROJECT_ID
+# DEPLOY_REGION 
+# VPC_CONNECTOR (optional)
+# VPC_REGION (optional)
+# SECRET_ENVIRONMENT_VARIABLE_* (optional: name of environment variable as secret on Google Cloud Run)
+# SECRET_NAME_* (optional: name of secret from Google Cloud Secret) 
+
+docker build -t $IMAGE_NAME:$IMAGE_TAG .
+docker tag $IMAGE_NAME:$IMAGE_TAG gcr.io/$GCP_PROJECT_ID/$IMAGE_NAME:$IMAGE_TAG
+docker push gcr.io/$GCP_PROJECT_ID/$IMAGE_NAME:$IMAGE_TAG
+
+if [ -n "$VPC_REGION" ] && [ -n "$VPC_CONNECTOR" ]; then
+  VPC_FLAG="--vpc-connector $VPC_CONNECTOR --region=$VPC_REGION --vpc-egress=all-traffic"
+fi
+
+secret_env_vars=(${!SECRET_ENVIRONMENT_VARIABLE_*})
+for env_var_name in "${secret_env_vars[@]}"; do
+  env_var_value="${!env_var_name}"
+  secret_name=$(eval "echo \${SECRET_NAME_${env_var_name#SECRET_ENVIRONMENT_VARIABLE_}}")
+  env_var_name=$(eval "echo \${SECRET_ENVIRONMENT_VARIABLE_${env_var_name#SECRET_ENVIRONMENT_VARIABLE_}}")
+  SECRET_FLAG="$SECRET_FLAG --update-secrets $env_var_name=$secret_name:latest"
+done
+
+gcloud_run_deploy $VPC_FLAG $SECRET_FLAG

--- a/next.config.js
+++ b/next.config.js
@@ -1,57 +1,5 @@
 /** @type {import('next').NextConfig} */
-
-const ContentSecurityPolicy = `
-  default-src 'self'; connect-src 'self'; 
-  child-src 'self' youtube.com;
-  font-src 'self' ;
-  img-src 'self' data:;
-  ${process.env.Node_EVN !== 'production' ? `style-src 'self' 'unsafe-inline' 'unsafe-eval'` : `style-src 'self'`};
-  ${
-    process.env.Node_EVN !== 'production'
-      ? `script-src 'self' 'unsafe-eval' 'unsafe-inline' apis.google.com`
-      : `script-src 'self' apis.google.com`
-  };
-  upgrade-insecure-requests
-  `;
-
-const securityHeaders = [
-  {
-    key: 'Content-Security-Policy',
-    value: ContentSecurityPolicy.replace(/\s{2,}/g, ' ').trim(),
-  },
-  {
-    key: 'X-DNS-Prefetch-Control',
-    value: 'on',
-  },
-  {
-    key: 'Strict-Transport-Security',
-    value: 'max-age=63072000; includeSubDomains; preload',
-  },
-  {
-    key: 'X-XSS-Protection',
-    value: '1; mode=block',
-  },
-  {
-    key: 'X-Frame-Options',
-    value: 'SAMEORIGIN',
-  },
-  {
-    key: 'Permissions-Policy',
-    value: 'camera=(), microphone=(), geolocation=(),  payment=()',
-  },
-  {
-    key: 'X-Content-Type-Options',
-    value: 'nosniff',
-  },
-  {
-    key: 'Referrer-Policy',
-    value: 'origin-when-cross-origin',
-  },
-  {
-    key: 'Access-Control-Allow-Origin',
-    value: process.env.NEXT_PUBLIC_HOST,
-  },
-];
+const securityHeaders = require('./securityHeaders');
 
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
@@ -66,7 +14,7 @@ module.exports = withBundleAnalyzer({
     ignoreDuringBuilds: false,
   },
   images: {
-    domains: process.env.Node_EVN !== 'production' ? ['images.unsplash.com', 'tailwindui.com'] : [''],
+    domains: process.env.NODE_ENV !== 'production' ? ['images.unsplash.com', 'tailwindui.com'] : [''],
   },
   output: 'standalone',
   swcMinify: true,

--- a/securityHeaders.js
+++ b/securityHeaders.js
@@ -1,0 +1,54 @@
+const ContentSecurityPolicy = `
+  default-src 'self'; connect-src 'self'; 
+  child-src 'self' youtube.com;
+  font-src 'self' ;
+  img-src 'self' data:;
+  ${process.env.NODE_ENV !== 'production' ? `style-src 'self' 'unsafe-inline' 'unsafe-eval'` : `style-src 'self'`};
+  ${
+    process.env.NODE_ENV !== 'production'
+      ? `script-src 'self' 'unsafe-eval' 'unsafe-inline' apis.google.com`
+      : `script-src 'self' apis.google.com`
+  };
+  upgrade-insecure-requests
+  `;
+
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: ContentSecurityPolicy.replace(/\s{2,}/g, ' ').trim(),
+  },
+  {
+    key: 'X-DNS-Prefetch-Control',
+    value: 'on',
+  },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
+  {
+    key: 'X-XSS-Protection',
+    value: '1; mode=block',
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'SAMEORIGIN',
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=(),  payment=()',
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin',
+  },
+  {
+    key: 'Access-Control-Allow-Origin',
+    value: process.env.NEXT_PUBLIC_HOST,
+  },
+];
+
+module.exports = securityHeaders;


### PR DESCRIPTION
now deploying to Google Cloud Run can simply be deployed with the deploy.sh script. Users can just run the command `sh deploy.sh` on the terminal then the deployment will automatically proceed. There are things that must be set up initially to proceed with the auto-deployment.

the following environment variables must be set on the .env.local and .env.local should not be shared:

- IMAGE_NAME
- IMAGE_TAG
- GCP_PROJECT_ID
- DEPLOY_REGION
- VPC_CONNECTOR (optional)
- VPC_REGION (optional)
- SECRET_ENVIRONMENT_VARIABLE_* (optional: name of the environment variable as a secret on Google Cloud Run)
- SECRET_NAME_* (optional: name of secret from Google Cloud Secret)

to use the optional Environment Variables such as VPC_CONNECTOR, VPC, or SECRET, they must be set on the Google Cloud RUN.

note: you must enter the service name at the end of the deployment process. Put the same service you have done deployment before or put a new one to create a new service.

Core changes:
- feature: update the HOSTNAME from the environment variable.
- feature: add deploy.sh to automatically run the deployment to the Google Cloud Run.

Misc changes:
- fix: fix the typo. feature: fix the casing on NODE_ENV of environmental. variable.
- feature: split the securityHeaders from the next.config.js.