### PR TITLE
feat: added new environment variable to deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -7,6 +7,7 @@ function gcloud_run_deploy() {
   gcloud run deploy \
     $VPC_FLAG \
     $SECRET_FLAG \
+    $SERVICE_NAME \
     --image gcr.io/$GCP_PROJECT_ID/$IMAGE_NAME:$IMAGE_TAG \
     --project $GCP_PROJECT_ID \
     --region $DEPLOY_REGION \
@@ -19,6 +20,7 @@ source .env.local
 # NOTE: .env.local must hold the following environment variables
 # .env.local SHOULD NOT be shared and only served from the local. 
 #
+# SERVICE_NAME
 # IMAGE_NAME
 # IMAGE_TAG
 # GCP_PROJECT_ID


### PR DESCRIPTION
a new environment variable has been included in deploy.sh to enable automatic deployment. This environment variable, `SERVICE_NAME`, indicates the name of the app running on Google Cloud Run. It is essential to deploy with the same service name to avoid creating a new service on Google Cloud Run due to a different service name.

The `SERVICE_NAME` is also defined within the `.env.local` file, which should be ignored by Git.

Core changes:
feat: added `SERVICE_NAME` to deploy.sh.