### PR TITLE
feat: update the schemas with new index and field

### DIFF
--- a/lib/models/Label/index.ts
+++ b/lib/models/Label/index.ts
@@ -23,11 +23,17 @@ const LabelSchema = new mongoose.Schema({
       required: false,
     },
   ],
+  update: {
+    type: Number,
+    default: Date.now,
+    required: false,
+  },
   user_id: {
     type: mongoose.Types.ObjectId,
     required: false,
   },
 });
-LabelSchema.index({ _id: 1, parent_id: 1, title_id: 1, user_id: -1 }, { unique: true });
+LabelSchema.index({ update: 1, parent_id: 1, title_id: 1, user_id: -1 }, { unique: true });
+LabelSchema.index({ name: 'text' });
 
 export default mongoose.models['Labels'] || mongoose.model('Labels', LabelSchema);

--- a/lib/models/Todo/TodoItems.ts
+++ b/lib/models/Todo/TodoItems.ts
@@ -38,11 +38,17 @@ const TodoItemSchema = new mongoose.Schema({
     type: Number,
     required: false,
   },
+  update: {
+    type: Number,
+    default: Date.now,
+    required: false,
+  },
   user_id: {
     type: mongoose.Types.ObjectId,
     required: true,
   },
 });
-TodoItemSchema.index({ _id: 1, user_id: -1 }, { unique: true });
+TodoItemSchema.index({ update: 1, user_id: -1 }, { unique: true });
+TodoItemSchema.index({ title: 'text' });
 
 export default mongoose.models['Todo-Items'] || mongoose.model('Todo-Items', TodoItemSchema);

--- a/lib/models/Todo/TodoNotes.ts
+++ b/lib/models/Todo/TodoNotes.ts
@@ -11,11 +11,18 @@ const TodoNoteSchema = new mongoose.Schema({
     type: mongoose.Types.ObjectId,
     required: true,
   },
+  update: {
+    type: Boolean,
+    default: true,
+    required: true,
+  },
   user_id: {
     type: mongoose.Types.ObjectId,
     required: true,
   },
 });
 
-TodoNoteSchema.index({ title_id: 1, user_id: -1 }, { unique: true });
+TodoNoteSchema.index({ update: 1, title_id: 1, user_id: -1 }, { unique: true });
+TodoNoteSchema.index({ note: 'text' });
+
 export default mongoose.models['Todo-Notes'] || mongoose.model('Todo-Notes', TodoNoteSchema);


### PR DESCRIPTION
introduced the new field `update`, to the schemas of Labels, TodoItems, and TodoNotes. The update field has a default value of Date.now() to return a number type, and this can be used to query only the updated fields from the documents.

Core changes:
- feat: add new field in the schemas: `update`.
- feat: remove the `_id` index from the schemas.
- feat: add special index 'text' to  any field has a type of string.