### PR TITLE
feat: restructure the API with new field of Schemas

### DIFF
--- a/lib/dataConnections/aggregationPipeline.ts
+++ b/lib/dataConnections/aggregationPipeline.ts
@@ -18,6 +18,7 @@ export const aggregatedTodoItem = ({
       $match: {
         _id: new mongoose.Types.ObjectId(`${todoId}`),
         user_id: new mongoose.Types.ObjectId(`${userId}`),
+        deleted: { $ne: true },
       },
     },
     { $sort: { _id: -1 } },

--- a/lib/dataConnections/indexedDB.ts
+++ b/lib/dataConnections/indexedDB.ts
@@ -3,6 +3,8 @@ import { IDB } from '@data/dataTypesObjects';
 import { Types, TypesIDB } from '@lib/types';
 import { openDB } from 'idb';
 
+// this will create new database per object store. This is easier to modify 
+// the schema if necessary.                   
 const dbPromise = async (storeName: Types['storeName'], dbVersion?: Types['dbVersion']) => {
   const dbName = DATA_IDB.find((db: TypesIDB) => db.store === storeName)?.name as IDB;
 

--- a/lib/models/Label/index.ts
+++ b/lib/models/Label/index.ts
@@ -28,12 +28,17 @@ const LabelSchema = new mongoose.Schema({
     default: Date.now,
     required: false,
   },
+  deleted: {
+    type: Boolean,
+    default: false,
+    required: false,
+  },
   user_id: {
     type: mongoose.Types.ObjectId,
     required: false,
   },
 });
-LabelSchema.index({ update: 1, parent_id: 1, title_id: 1, user_id: -1 }, { unique: true });
+LabelSchema.index({ deleted: 1, update: 1, title_id: 1, user_id: -1 }, { unique: true });
 LabelSchema.index({ name: 'text' });
 
 export default mongoose.models['Labels'] || mongoose.model('Labels', LabelSchema);

--- a/lib/models/Todo/TodoItems.ts
+++ b/lib/models/Todo/TodoItems.ts
@@ -43,12 +43,17 @@ const TodoItemSchema = new mongoose.Schema({
     default: Date.now,
     required: false,
   },
+  deleted: {
+    type: Boolean,
+    default: false,
+    required: false,
+  },
   user_id: {
     type: mongoose.Types.ObjectId,
     required: true,
   },
 });
-TodoItemSchema.index({ update: 1, user_id: -1 }, { unique: true });
+TodoItemSchema.index({ deleted: 1, update: 1, user_id: -1 }, { unique: true });
 TodoItemSchema.index({ title: 'text' });
 
 export default mongoose.models['Todo-Items'] || mongoose.model('Todo-Items', TodoItemSchema);

--- a/lib/models/Todo/TodoNotes.ts
+++ b/lib/models/Todo/TodoNotes.ts
@@ -12,9 +12,14 @@ const TodoNoteSchema = new mongoose.Schema({
     required: true,
   },
   update: {
+    type: Number,
+    default: Date.now,
+    required: false,
+  },
+  deleted: {
     type: Boolean,
-    default: true,
-    required: true,
+    default: false,
+    required: false,
   },
   user_id: {
     type: mongoose.Types.ObjectId,
@@ -22,7 +27,7 @@ const TodoNoteSchema = new mongoose.Schema({
   },
 });
 
-TodoNoteSchema.index({ update: 1, title_id: 1, user_id: -1 }, { unique: true });
+TodoNoteSchema.index({ deleted: 1, update: 1, title_id: 1, user_id: -1 }, { unique: true });
 TodoNoteSchema.index({ note: 'text' });
 
 export default mongoose.models['Todo-Notes'] || mongoose.model('Todo-Notes', TodoNoteSchema);

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -71,6 +71,7 @@ export interface TodoIds {
   priorityLevel?: PRIORITY_LEVEL | null;
   priorityRankScore?: number;
   completedDate?: Date | null;
+  deleted?: boolean | { $ne: boolean };
 }
 
 export interface TodosEditors {
@@ -97,6 +98,7 @@ export interface Labels extends LabelIds {
 
 export interface LabelIds {
   _id?: OBJECT_ID;
+  deleted?: boolean | { $ne: boolean };
 }
 
 export interface TypesLabel {

--- a/pages/api/v1/labels/index.tsx
+++ b/pages/api/v1/labels/index.tsx
@@ -11,17 +11,15 @@ const Labels = async (req: NextApiRequest, res: NextApiResponse) => {
 
   const data: Labels = body;
 
-  const filter = () => {
-    const query: Partial<Labels> = {};
-    query.user_id = userInfo._id;
-
-    return query;
+  const query: Partial<Labels> = {
+    deleted: { $ne: true },
+    user_id: userInfo._id,
   };
 
   switch (method) {
     case 'GET':
       try {
-        const getLabels = await Label.find(filter())
+        const getLabels = await Label.find(query)
           .select({ _id: 1, name: 1, parent_id: 1, title_id: 1, color: 1 })
           .lean();
         res.status(200).json({ success: true, data: getLabels });

--- a/pages/api/v1/todos/index.tsx
+++ b/pages/api/v1/todos/index.tsx
@@ -18,9 +18,10 @@ const Todos = async (req: NextApiRequest, res: NextApiResponse) => {
   } = req;
 
   const data: Todos = body;
-  const query: Partial<Todos> = {};
-
-  query.user_id = userInfo._id;
+  const query: Partial<Todos> = {
+    deleted: { $ne: true },
+    user_id: userInfo._id,
+  };
 
   switch (method) {
     case 'GET':


### PR DESCRIPTION
restructured the API of todos and labels with new Schema's field called `deleted`. The data is permanently deleted previously whenever user requested the deletion. This caused the one main issue of synchronizing the multiple devices with browsers. Deleted item may stale on the other browser within indexedDB. With this new field, the deleted item will stay within the server-side database temporary, 15 days for example, and can be used to trigger the clean-up the stale data of other browsers.

Core changes:
- feat: add the new field to the schemas.
- feat: add `deleted` field to the schema to restructure the deleting module.
- feat: update the API with new field.
- feat: update the types of Todos and Labels.
- feat: add deleted option to the aggregation pipeline.

Misc changes:
- feat: add comment to the indexedDB.
- feat: add the `deleted` field to the index in Schemas.