### PR TITLE
feat: add `localStorageEffect` with atom

### DIFF
--- a/lib/states/effects/localStorageEffects.tsx
+++ b/lib/states/effects/localStorageEffects.tsx
@@ -1,0 +1,34 @@
+import { TypesLocalStorageEffect } from '@lib/types';
+
+export const localStorageEffects: TypesLocalStorageEffect =
+  ({ isLocalStorageOnMount, isLocalStorageSetOnFocus, isLocalStorageSetOnBlur, storageKey, storageValue }) =>
+  ({ setSelf, onSet, trigger }) => {
+    if (typeof window === 'undefined') return;
+
+    const localStorageSync = () => {
+      const value = storageValue();
+      setSelf(JSON.parse(value));
+      localStorage.setItem(storageKey, JSON.stringify(value));
+    };
+
+    // isLocalStorageOnMount: true then get new value. if storageValue is static, the value will be same
+    // isLocalStorageOnMount: false then get stored value from localStorage
+    if (trigger === 'get') {
+      const localStorageValue = localStorage.getItem(storageKey);
+      const localStorageAsValue = localStorageValue && setSelf(JSON.parse(localStorageValue));
+      isLocalStorageOnMount ? localStorageSync() : localStorageAsValue;
+    }
+
+    onSet((newValue, _, isReset) => {
+      if (isReset) return localStorage.removeItem(storageKey);
+      localStorage.setItem(storageKey, JSON.stringify(newValue));
+      setSelf(newValue);
+    });
+
+    isLocalStorageSetOnFocus && window.addEventListener('focus', localStorageSync);
+    isLocalStorageSetOnBlur && window.addEventListener('blur', localStorageSync);
+    return () => {
+      isLocalStorageSetOnFocus && window.removeEventListener('focus', localStorageSync);
+      isLocalStorageSetOnBlur && window.removeEventListener('blur', localStorageSync);
+    };
+  };

--- a/lib/states/misc/index.tsx
+++ b/lib/states/misc/index.tsx
@@ -1,10 +1,24 @@
 import { BREAKPOINT } from '@data/dataTypesObjects';
 import { mediaQueryEffect, networkStatusEffect } from '@effects/atomEffects';
+import { localStorageEffects } from '@effects/localStorageEffects';
 import { atomFamily, atom, selector } from 'recoil';
 
 /*
  * Atoms
  * */
+
+// Update Effect
+export const atomLocalStorageLastUpdate = atom<string>({
+  key: 'atomUpdateEffect',
+  default: '',
+  effects: [
+    localStorageEffects({
+      storageKey: 'lastUpdate',
+      storageValue: () => Date.now().toString(),
+      isLocalStorageSetOnBlur: true,
+    }),
+  ],
+});
 
 // Media Queries
 export const atomMediaQuery = atomFamily<boolean, BREAKPOINT>({

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -323,11 +323,24 @@ export interface TypesEffects {
   breakpoint: BREAKPOINT;
   isStateUnderBreakpoint: boolean;
   isStateOverBreakpoint: boolean;
+  // Local Storage Effect
+  storageKey: string;
+  storageValue(): string;
+  isLocalStorageOnMount: boolean;
+  isLocalStorageSetOnFocus: boolean;
+  isLocalStorageSetOnBlur: boolean;
 }
 /**
  * Types Atom Effects - Recoil
  * none-collectable Types
  */
+
+export type TypesLocalStorageEffect = <T>({
+  isLocalStorageOnMount,
+  isLocalStorageSetOnBlur,
+  isLocalStorageSetOnFocus,
+}: Partial<Pick<Types, 'isLocalStorageOnMount' | 'isLocalStorageSetOnFocus' | 'isLocalStorageSetOnBlur'>> &
+  Pick<Types, 'storageKey' | 'storageValue'>) => AtomEffect<T>;
 
 export type TypesRefetchEffect = <T>({
   queryKey,


### PR DESCRIPTION
add `localStorageEffect` that can save a string into localStorage only. This effect is intentionally saving data only in client-side unlike queryEffect, which stores data within client-side as well as integrated with server-side states.

This update value can be used to compare the update values saved into the document of server-side database, and fetch the only updated value to synchronize the data across different browsers.

Core changes:
- feat: add new types for the localStorageEffect.
- feat: add new atom: atomLocalStoageLastUpdate.