### PR TITLE
feat: improve the update efficiency of `lastUpdate`

### DIFF
--- a/lib/states/effects/localStorageEffects.tsx
+++ b/lib/states/effects/localStorageEffects.tsx
@@ -1,7 +1,14 @@
 import { TypesLocalStorageEffect } from '@lib/types';
 
 export const localStorageEffects: TypesLocalStorageEffect =
-  ({ isLocalStorageOnMount, isLocalStorageSetOnFocus, isLocalStorageSetOnBlur, storageKey, storageValue }) =>
+  ({
+    isLocalStorageOnMount,
+    isLocalStorageSetOnFocus,
+    isLocalStorageSetOnBlur,
+    isLocalStorageSetOnBeforeUnload,
+    storageKey,
+    storageValue,
+  }) =>
   ({ setSelf, onSet, trigger }) => {
     if (typeof window === 'undefined') return;
 
@@ -27,8 +34,10 @@ export const localStorageEffects: TypesLocalStorageEffect =
 
     isLocalStorageSetOnFocus && window.addEventListener('focus', localStorageSync);
     isLocalStorageSetOnBlur && window.addEventListener('blur', localStorageSync);
+    isLocalStorageSetOnBeforeUnload && window.addEventListener('beforeunload', localStorageSync);
     return () => {
       isLocalStorageSetOnFocus && window.removeEventListener('focus', localStorageSync);
       isLocalStorageSetOnBlur && window.removeEventListener('blur', localStorageSync);
+      isLocalStorageSetOnBeforeUnload && window.removeEventListener('beforeunload', localStorageSync);
     };
   };

--- a/lib/states/misc/index.tsx
+++ b/lib/states/misc/index.tsx
@@ -15,7 +15,7 @@ export const atomLocalStorageLastUpdate = atom<string>({
     localStorageEffects({
       storageKey: 'lastUpdate',
       storageValue: () => Date.now().toString(),
-      isLocalStorageSetOnBlur: true,
+      isLocalStorageSetOnBeforeUnload: true,
     }),
   ],
 });

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -329,6 +329,7 @@ export interface TypesEffects {
   isLocalStorageOnMount: boolean;
   isLocalStorageSetOnFocus: boolean;
   isLocalStorageSetOnBlur: boolean;
+  isLocalStorageSetOnBeforeUnload: boolean;
 }
 /**
  * Types Atom Effects - Recoil
@@ -339,7 +340,13 @@ export type TypesLocalStorageEffect = <T>({
   isLocalStorageOnMount,
   isLocalStorageSetOnBlur,
   isLocalStorageSetOnFocus,
-}: Partial<Pick<Types, 'isLocalStorageOnMount' | 'isLocalStorageSetOnFocus' | 'isLocalStorageSetOnBlur'>> &
+  isLocalStorageSetOnBeforeUnload,
+}: Partial<
+  Pick<
+    Types,
+    'isLocalStorageOnMount' | 'isLocalStorageSetOnFocus' | 'isLocalStorageSetOnBlur' | 'isLocalStorageSetOnBeforeUnload'
+  >
+> &
   Pick<Types, 'storageKey' | 'storageValue'>) => AtomEffect<T>;
 
 export type TypesRefetchEffect = <T>({


### PR DESCRIPTION
Now `atomLocalStorageLastUpdate` can effectively update the value of the `lastUpdate`. This is done by addition of new DOM API, `beforeunload`, to the `localStorageEffect`.