### PR TITLE
fix: fix the Key does not work on editing with LabelModal

### DIFF
--- a/components/ui/modals/labelModals/labelModal/index.tsx
+++ b/components/ui/modals/labelModals/labelModal/index.tsx
@@ -1,6 +1,10 @@
 import { DisableButton } from '@buttons/disableButton';
 import { IconButton } from '@buttons/iconButton';
-import { optionsButtonTodoModalClose, optionsButtonTodoModalCancel, optionsButtonLabelModalAddLabel } from '@data/dataOptions';
+import {
+  optionsButtonTodoModalClose,
+  optionsButtonTodoModalCancel,
+  optionsButtonLabelModalAddLabel,
+} from '@data/dataOptions';
 import { KeysWithLabelModalEffect } from '@states/keybinds/KeysWithLabelModalEffect';
 import { atomLabelNew, atomSelectorLabelItem } from '@states/labels';
 import { useLabelValueUpdate, useLabelAdd } from '@states/labels/hooks';

--- a/lib/states/keybinds/hooks.tsx
+++ b/lib/states/keybinds/hooks.tsx
@@ -110,7 +110,7 @@ export const useKeyWithEditor = (titleName: Types['titleName'], _id: Todos['_id'
 
 // with labels
 export const useKeyWithLabelModal = (_id: Labels['_id']) => {
-  const isLabelEmpty = useConditionCheckLabelTitleEmpty();
+  const isLabelEmpty = typeof _id === 'undefined' && useConditionCheckLabelTitleEmpty();
   const addLabel = useLabelAdd();
   const updateLabel = useLabelUpdateItem(_id);
   return useRecoilCallback(({ snapshot }) => (event: KeyboardEvent) => {


### PR DESCRIPTION
When editing a label with LabelModal, the keybinding did not work properly. This was due to a conditional check that prevented it from firing whenever the label was empty. By adding an additional condition to check for the labelItem, which means that the label is already created, the keybinding issue could be resolved.