### PR TITLE
fix: resolve the footerBody's height rendering issue on different med…

### DIFF
--- a/components/layouts/layoutApp/layout/layoutFooter/index.tsx
+++ b/components/layouts/layoutApp/layout/layoutFooter/index.tsx
@@ -38,7 +38,7 @@ export const LayoutFooter = ({ children }: Pick<Types, 'children'>) => {
             )}>
             <main
               className={classNames(
-                'absolute h-[calc(100vh-5.4rem)] w-full sm:h-[calc(100vh-4.4rem)] lg:h-full',
+                'absolute mb-10 h-full w-full',
                 isScrollDisabled ? 'overflow-y-hidden' : 'overflow-y-auto',
               )}>
               <div className='flex w-full justify-center pt-2 pb-64 sm:pt-10 sm:pl-5 lg:justify-center lg:pl-10'>

--- a/components/layouts/layoutApp/layout/layoutHeader/index.tsx
+++ b/components/layouts/layoutApp/layout/layoutHeader/index.tsx
@@ -26,7 +26,7 @@ export const LayoutHeader = () => {
 
   return (
     <LayoutHeaderFragment>
-      <div className='sticky top-1 z-10 mb-2 flex max-h-[4rem] min-h-[4rem] flex-row items-center justify-between bg-transparent'>
+      <div className='sticky top-1 z-10 flex max-h-[4rem] min-h-[4rem] flex-row items-center justify-between bg-transparent sm:mb-2'>
         <LeftSideFragment>
           <div className='flex flex-row items-center justify-between pl-3 md:w-full md:max-w-3xs'>
             <SidebarButtonFragment>


### PR DESCRIPTION
…ia queries

Due to the `height` calc property based on media queries, the height styling is not being applied correctly. By changing the `height` property to `h-full` (which sets the height to 100%), the issue has been resolved.

Misc Change:
- refactor: improve the footerBody rendering in smaller mediaQuery