### PR TITLE
fix: fix the issues of keybinding and styles

### DIFF
--- a/components/layouts/layoutApp/layout/layoutFooter/index.tsx
+++ b/components/layouts/layoutApp/layout/layoutFooter/index.tsx
@@ -38,7 +38,7 @@ export const LayoutFooter = ({ children }: Pick<Types, 'children'>) => {
             )}>
             <main
               className={classNames(
-                'absolute h-[calc(100vh-5.4rem)] w-full sm:h-[calc(100vh-4.4rem)] lg:h-full',
+                'absolute mb-10 h-full w-full',
                 isScrollDisabled ? 'overflow-y-hidden' : 'overflow-y-auto',
               )}>
               <div className='flex w-full justify-center pt-2 pb-64 sm:pt-10 sm:pl-5 lg:justify-center lg:pl-10'>

--- a/components/layouts/layoutApp/layout/layoutHeader/index.tsx
+++ b/components/layouts/layoutApp/layout/layoutHeader/index.tsx
@@ -26,7 +26,7 @@ export const LayoutHeader = () => {
 
   return (
     <LayoutHeaderFragment>
-      <div className='sticky top-1 z-10 mb-2 flex max-h-[4rem] min-h-[4rem] flex-row items-center justify-between bg-transparent'>
+      <div className='sticky top-1 z-10 flex max-h-[4rem] min-h-[4rem] flex-row items-center justify-between bg-transparent sm:mb-2'>
         <LeftSideFragment>
           <div className='flex flex-row items-center justify-between pl-3 md:w-full md:max-w-3xs'>
             <SidebarButtonFragment>

--- a/components/ui/modals/labelModals/labelModal/index.tsx
+++ b/components/ui/modals/labelModals/labelModal/index.tsx
@@ -1,6 +1,10 @@
 import { DisableButton } from '@buttons/disableButton';
 import { IconButton } from '@buttons/iconButton';
-import { optionsButtonTodoModalClose, optionsButtonTodoModalCancel, optionsButtonLabelModalAddLabel } from '@data/dataOptions';
+import {
+  optionsButtonTodoModalClose,
+  optionsButtonTodoModalCancel,
+  optionsButtonLabelModalAddLabel,
+} from '@data/dataOptions';
 import { KeysWithLabelModalEffect } from '@states/keybinds/KeysWithLabelModalEffect';
 import { atomLabelNew, atomSelectorLabelItem } from '@states/labels';
 import { useLabelValueUpdate, useLabelAdd } from '@states/labels/hooks';

--- a/lib/states/keybinds/hooks.tsx
+++ b/lib/states/keybinds/hooks.tsx
@@ -110,7 +110,7 @@ export const useKeyWithEditor = (titleName: Types['titleName'], _id: Todos['_id'
 
 // with labels
 export const useKeyWithLabelModal = (_id: Labels['_id']) => {
-  const isLabelEmpty = useConditionCheckLabelTitleEmpty();
+  const isLabelEmpty = typeof _id === 'undefined' && useConditionCheckLabelTitleEmpty();
   const addLabel = useLabelAdd();
   const updateLabel = useLabelUpdateItem(_id);
   return useRecoilCallback(({ snapshot }) => (event: KeyboardEvent) => {


### PR DESCRIPTION
This branch fixes a minor keybinding issue related to the itemLabelModal, as well as a styling issue with the footerBody on different media queries.

Core Changes:
- fix: fix the Key does not work on editing with LabelModal (#283)
- fix: resolve the footerBody's height rendering issue on different media queries (#284)