### PR TITLE
refactor: remove ssr option from dynamic imports

### DIFF
--- a/components/editors/todoEditor.tsx
+++ b/components/editors/todoEditor.tsx
@@ -6,7 +6,7 @@ import { useRecoilCallback } from 'recoil';
 
 type Props = Partial<Pick<Types, 'todo'>>;
 
-const EditorComposer = dynamic(() => import('./editorComposer').then((mod) => mod.EditorComposer), { ssr: false });
+const EditorComposer = dynamic(() => import('./editorComposer').then((mod) => mod.EditorComposer));
 
 export const TodoEditors = ({ todo }: Props) => {
   const isTodoCompleted = useRecoilCallback(({ snapshot }) => () => {

--- a/components/labels/labelItem.tsx
+++ b/components/labels/labelItem.tsx
@@ -13,19 +13,12 @@ import dynamic from 'next/dynamic';
 import { Fragment, Fragment as LabelModalFragment } from 'react';
 import { useRecoilValue } from 'recoil';
 
-const LabelItemDropdown = dynamic(() => import('@dropdowns/labelItemDropdown').then((mod) => mod.LabelItemDropdown), {
-  ssr: false,
-});
-const ItemLabelModal = dynamic(
-  () => import('@modals/labelModals/labelModal/itemLabelModal').then((mod) => mod.ItemLabelModal),
-  { ssr: false },
+const LabelItemDropdown = dynamic(() => import('@dropdowns/labelItemDropdown').then((mod) => mod.LabelItemDropdown));
+const ItemLabelModal = dynamic(() =>
+  import('@modals/labelModals/labelModal/itemLabelModal').then((mod) => mod.ItemLabelModal),
 );
-const DeleteLabelConfirmModal = dynamic(
-  () =>
-    import('@modals/confirmModal/deleteConfirmModal/deleteLabelConfirmModal').then(
-      (mod) => mod.DeleteLabelConfirmModal,
-    ),
-  { ssr: false },
+const DeleteLabelConfirmModal = dynamic(() =>
+  import('@modals/confirmModal/deleteConfirmModal/deleteLabelConfirmModal').then((mod) => mod.DeleteLabelConfirmModal),
 );
 
 export const LabelItem = ({ label }: Pick<Types, 'label'>) => {

--- a/components/layouts/layoutApp/index.tsx
+++ b/components/layouts/layoutApp/index.tsx
@@ -12,23 +12,14 @@ import {
   Fragment as ModalActionsFragment,
 } from 'react';
 import { useRecoilValue } from 'recoil';
-const CreateTodoModal = dynamic(() => import('@modals/todoModals/todoModal').then((mod) => mod.TodoModal), {
-  ssr: false,
-});
-const MinimizedModal = dynamic(() => import('@modals/minimizedModal').then((mod) => mod.MinimizedModal), {
-  ssr: false,
-});
-const Notification = dynamic(() => import('components/notifications/notification').then((mod) => mod.Notification), {
-  ssr: false,
-});
-const LabelModal = dynamic(() => import('@modals/labelModals/labelModal').then((mod) => mod.LabelModal), {
-  ssr: false,
-});
-const WindowBeforeunloadEffect = dynamic(
-  () => import('@states/misc/windowBeforeunloadEffect').then((mod) => mod.WindowBeforeunloadEffect),
-  { ssr: false },
+const CreateTodoModal = dynamic(() => import('@modals/todoModals/todoModal').then((mod) => mod.TodoModal));
+const MinimizedModal = dynamic(() => import('@modals/minimizedModal').then((mod) => mod.MinimizedModal));
+const Notification = dynamic(() => import('components/notifications/notification').then((mod) => mod.Notification));
+const LabelModal = dynamic(() => import('@modals/labelModals/labelModal').then((mod) => mod.LabelModal));
+const WindowBeforeunloadEffect = dynamic(() =>
+  import('@states/misc/windowBeforeunloadEffect').then((mod) => mod.WindowBeforeunloadEffect),
 );
-const Layout = dynamic(() => import('./layout').then((mod) => mod.Layout), { ssr: false });
+const Layout = dynamic(() => import('./layout').then((mod) => mod.Layout));
 
 type Props = Pick<Types, 'children'>;
 

--- a/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/index.tsx
+++ b/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/index.tsx
@@ -20,13 +20,11 @@ import {
 import { useRecoilCallback, useRecoilValue } from 'recoil';
 import { FooterSidebarMenu } from './footerSidebarMenu';
 
-const LoadingLabels = dynamic(
-  () => import('@components/loadable/loadingStates/loadingLabels').then((mod) => mod.LoadingLabels),
-  { ssr: false },
+const LoadingLabels = dynamic(() =>
+  import('@components/loadable/loadingStates/loadingLabels').then((mod) => mod.LoadingLabels),
 );
 const LabelList = dynamic(() => import('@components/labels/labelList').then((mod) => mod.LabelList), {
   loading: () => <LoadingLabels />,
-  ssr: false,
 });
 
 export const FooterSidebar = forwardRef<HTMLDivElement>((_, ref) => {

--- a/components/notifications/networkStatus.tsx
+++ b/components/notifications/networkStatus.tsx
@@ -5,7 +5,7 @@ import dynamic from 'next/dynamic';
 import { Fragment as NetworkStatusFragment } from 'react';
 import { useRecoilValue } from 'recoil';
 
-const SvgIcon = dynamic(() => import('components/icons/svgIcon').then((mod) => mod.SvgIcon), { ssr: false });
+const SvgIcon = dynamic(() => import('components/icons/svgIcon').then((mod) => mod.SvgIcon));
 
 export const NetworkStatus = () => {
   const isOnline = useRecoilValue(atomNetworkStatusEffect);

--- a/components/notifications/notification.tsx
+++ b/components/notifications/notification.tsx
@@ -8,7 +8,7 @@ import dynamic from 'next/dynamic';
 import { Fragment as NotificationFragment } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
-const SvgIcon = dynamic(() => import('components/icons/svgIcon').then((mod) => mod.SvgIcon), { ssr: false });
+const SvgIcon = dynamic(() => import('components/icons/svgIcon').then((mod) => mod.SvgIcon));
 
 export const Notification = () => {
   const notification = useRecoilValue(selectorNotificationState) as TypesNotification;

--- a/components/todos/todo/index.tsx
+++ b/components/todos/todo/index.tsx
@@ -8,17 +8,11 @@ import { Fragment as ModalActionsFragment } from 'react';
 import { TodoItem } from './todoItem';
 import { TodoItemFocuser } from './todoItemFocuser';
 
-const DeleteTodoConfirmModal = dynamic(
-  () =>
-    import('@modals/confirmModal/deleteConfirmModal/deleteTodoConfirmModal').then((mod) => mod.DeleteTodoConfirmModal),
-  { ssr: false },
+const DeleteTodoConfirmModal = dynamic(() =>
+  import('@modals/confirmModal/deleteConfirmModal/deleteTodoConfirmModal').then((mod) => mod.DeleteTodoConfirmModal),
 );
-const ItemTodoModal = dynamic(() => import('@modals/todoModals/itemTodoModal').then((mod) => mod.ItemTodoModal), {
-  ssr: false,
-});
-const MinimizedModal = dynamic(() => import('@modals/minimizedModal').then((mod) => mod.MinimizedModal), {
-  ssr: false,
-});
+const ItemTodoModal = dynamic(() => import('@modals/todoModals/itemTodoModal').then((mod) => mod.ItemTodoModal));
+const MinimizedModal = dynamic(() => import('@modals/minimizedModal').then((mod) => mod.MinimizedModal));
 
 type Props = Pick<TypesTodo, 'todo'> & Partial<Pick<TypesTodo, 'index'>>;
 

--- a/components/ui/buttons/button/index.tsx
+++ b/components/ui/buttons/button/index.tsx
@@ -3,7 +3,7 @@ import { Types } from 'lib/types';
 import dynamic from 'next/dynamic';
 import { forwardRef, useState } from 'react';
 
-const Tooltip = dynamic(() => import('@tooltips/tooltips').then((mod) => mod.Tooltip), { ssr: false });
+const Tooltip = dynamic(() => import('@tooltips/tooltips').then((mod) => mod.Tooltip));
 
 type Props = { options: TypesOptionsButton } & Partial<
   Pick<Types, 'onKeyDown' | 'children' | 'onClick' | 'onDoubleClick' | 'onMouseEnter' | 'onMouseOver'>

--- a/components/ui/dropdowns/dropdown/index.tsx
+++ b/components/ui/dropdowns/dropdown/index.tsx
@@ -11,7 +11,7 @@ import { Fragment as MenuFragment, useRef, useState } from 'react';
 import { usePopper } from 'react-popper';
 import { useSetRecoilState } from 'recoil';
 import { ConditionalPortal } from './conditionalPortal';
-const Tooltip = dynamic(() => import('@tooltips/tooltips').then((mod) => mod.Tooltip), { ssr: false });
+const Tooltip = dynamic(() => import('@tooltips/tooltips').then((mod) => mod.Tooltip));
 
 type Props = { options: TypesOptionsDropdown } & Partial<
   Pick<Types, 'headerContents' | 'show' | 'headerContentsOnClose'>

--- a/components/ui/inputs/input/index.tsx
+++ b/components/ui/inputs/input/index.tsx
@@ -3,7 +3,7 @@ import { classNames } from '@states/utils';
 import { Types, TypesElement, TypesInputAttributes } from 'lib/types';
 import dynamic from 'next/dynamic';
 import { useState } from 'react';
-const Tooltip = dynamic(() => import('@tooltips/tooltips').then((mod) => mod.Tooltip), { ssr: false });
+const Tooltip = dynamic(() => import('@tooltips/tooltips').then((mod) => mod.Tooltip));
 
 type Props = Partial<
   Pick<Types, 'className' | 'name' | 'isDisabled' | 'kbd' | 'tooltip'> & {

--- a/components/ui/modals/confirmModal/deleteConfirmModal/deleteLabelConfirmModal.tsx
+++ b/components/ui/modals/confirmModal/deleteConfirmModal/deleteLabelConfirmModal.tsx
@@ -6,9 +6,7 @@ import dynamic from 'next/dynamic';
 import { Fragment } from 'react';
 import { useRecoilValue } from 'recoil';
 
-const DeleteConfirmModal = dynamic(() => import('../deleteConfirmModal').then((mod) => mod.DeleteConfirmModal), {
-  ssr: false,
-});
+const DeleteConfirmModal = dynamic(() => import('../deleteConfirmModal').then((mod) => mod.DeleteConfirmModal));
 
 type Props = Pick<Types, 'label'>;
 

--- a/components/ui/modals/confirmModal/deleteConfirmModal/deleteTodoConfirmModal.tsx
+++ b/components/ui/modals/confirmModal/deleteConfirmModal/deleteTodoConfirmModal.tsx
@@ -6,9 +6,7 @@ import dynamic from 'next/dynamic';
 import { Fragment } from 'react';
 import { useRecoilValue } from 'recoil';
 
-const DeleteConfirmModal = dynamic(() => import('../deleteConfirmModal').then((mod) => mod.DeleteConfirmModal), {
-  ssr: false,
-});
+const DeleteConfirmModal = dynamic(() => import('../deleteConfirmModal').then((mod) => mod.DeleteConfirmModal));
 
 type Props = Pick<Types, 'todo'>;
 

--- a/components/ui/modals/confirmModal/deleteConfirmModal/index.tsx
+++ b/components/ui/modals/confirmModal/deleteConfirmModal/index.tsx
@@ -5,8 +5,8 @@ import { HeaderDescription } from '@modals/modal/modalHeaders/headerDescription'
 import { HeaderTitle } from '@modals/modal/modalHeaders/headerTitle';
 import dynamic from 'next/dynamic';
 import { Fragment as DeleteHeaderContentFragment, Fragment as HeaderContentFragment, useRef } from 'react';
-const ConfirmModal = dynamic(() => import('..').then((mod) => mod.ConfirmModal), { ssr: false });
-const SvgIcon = dynamic(() => import('@components/icons/svgIcon').then((mod) => mod.SvgIcon), { ssr: false });
+const ConfirmModal = dynamic(() => import('..').then((mod) => mod.ConfirmModal));
+const SvgIcon = dynamic(() => import('@components/icons/svgIcon').then((mod) => mod.SvgIcon));
 
 type Props = Pick<Types, 'onClickConfirm' | 'show' | 'deletingItem'> & Partial<Pick<Types, 'itemIds'>>;
 

--- a/components/ui/modals/confirmModal/discardConfirmModal.tsx
+++ b/components/ui/modals/confirmModal/discardConfirmModal.tsx
@@ -8,8 +8,8 @@ import { useTodoModalConfirmStateDiscard } from '@states/modals/hooks';
 import dynamic from 'next/dynamic';
 import { Fragment as DiscardHeaderContentFragment, Fragment as HeaderContentFragment, useRef } from 'react';
 import { useRecoilValue } from 'recoil';
-const ConfirmModal = dynamic(() => import('.').then((mod) => mod.ConfirmModal), { ssr: false });
-const SvgIcon = dynamic(() => import('@components/icons/svgIcon').then((mod) => mod.SvgIcon), { ssr: false });
+const ConfirmModal = dynamic(() => import('.').then((mod) => mod.ConfirmModal));
+const SvgIcon = dynamic(() => import('@components/icons/svgIcon').then((mod) => mod.SvgIcon));
 
 export const DiscardConfirmModal = ({ todo }: Partial<Pick<Types, 'todo'>>) => {
   const discardConfirmModal = useTodoModalConfirmStateDiscard(todo?._id);

--- a/components/ui/modals/todoModals/itemTodoModal.tsx
+++ b/components/ui/modals/todoModals/itemTodoModal.tsx
@@ -13,7 +13,7 @@ import { useConditionCompareTodoItemsEqual } from '@states/utils/hooks';
 import dynamic from 'next/dynamic';
 import { Fragment as FooterButtonsFragment, Fragment as HeaderContentFragment } from 'react';
 import { useRecoilValue } from 'recoil';
-const TodoModal = dynamic(() => import('@modals/todoModals/todoModal').then((mod) => mod.TodoModal), { ssr: false });
+const TodoModal = dynamic(() => import('@modals/todoModals/todoModal').then((mod) => mod.TodoModal));
 
 export const ItemTodoModal = ({ todo }: Pick<Types, 'todo'>) => {
   const updateTodo = useTodoUpdateItem(todo._id);

--- a/components/ui/pseudoButtons/pseudoButton/index.tsx
+++ b/components/ui/pseudoButtons/pseudoButton/index.tsx
@@ -3,7 +3,7 @@ import { Types } from 'lib/types';
 import dynamic from 'next/dynamic';
 import { forwardRef, useState } from 'react';
 
-const Tooltip = dynamic(() => import('@tooltips/tooltips').then((mod) => mod.Tooltip), { ssr: false });
+const Tooltip = dynamic(() => import('@tooltips/tooltips').then((mod) => mod.Tooltip));
 
 type Props = { options: TypesOptionsPseudoButton } & Partial<
   Pick<Types, 'onKeyDown' | 'children' | 'onClick' | 'onDoubleClick' | 'onMouseEnter' | 'onMouseOver'>

--- a/components/ui/pseudoButtons/pseudoIconButton/index.tsx
+++ b/components/ui/pseudoButtons/pseudoIconButton/index.tsx
@@ -4,8 +4,8 @@ import { classNames } from '@states/utils';
 import dynamic from 'next/dynamic';
 import { Fragment as HeaderContentsFragment } from 'react';
 
-const SvgIcon = dynamic(() => import('@components/icons/svgIcon').then((mod) => mod.SvgIcon), { ssr: false });
-const PseudoButton = dynamic(() => import('../pseudoButton').then((mod) => mod.PseudoButton), { ssr: false });
+const SvgIcon = dynamic(() => import('@components/icons/svgIcon').then((mod) => mod.SvgIcon));
+const PseudoButton = dynamic(() => import('../pseudoButton').then((mod) => mod.PseudoButton));
 
 type Props = { options: TypesOptionsButton } & Partial<
   Pick<Types, 'headerContents' | 'children' | 'onClick' | 'children'>

--- a/pages/app/[...app].tsx
+++ b/pages/app/[...app].tsx
@@ -1,7 +1,7 @@
 import dynamic from 'next/dynamic';
 import { Fragment, ReactElement } from 'react';
 
-const LayoutApp = dynamic(() => import('@layouts/layoutApp').then((mod) => mod.LayoutApp), { ssr: false });
+const LayoutApp = dynamic(() => import('@layouts/layoutApp').then((mod) => mod.LayoutApp));
 
 const CatchAllApp = () => {
   return <Fragment>Nothing to show you</Fragment>;

--- a/pages/app/[appId].tsx
+++ b/pages/app/[appId].tsx
@@ -3,19 +3,17 @@ import { LayoutApp } from '@layouts/layoutApp';
 import dynamic from 'next/dynamic';
 import { Fragment as AppByIdFragment, ReactElement } from 'react';
 
-const LoadingTodos = dynamic(
-  () => import('@components/loadable/loadingStates/loadingTodos').then((mod) => mod.LoadingTodos),
-  { ssr: false },
+const LoadingTodos = dynamic(() =>
+  import('@components/loadable/loadingStates/loadingTodos').then((mod) => mod.LoadingTodos),
 );
 const TodoList = dynamic(() => import('components/todos/todoList').then((mod) => mod.TodoList), {
   loading: () => <LoadingTodos />,
   ssr: false,
 });
-const FilterTodoIdsEffect = dynamic(
-  () => import('@states/todos/filterTodoIdsEffect').then((mod) => mod.FilterTodoIdsEffect),
-  { ssr: false },
+const FilterTodoIdsEffect = dynamic(() =>
+  import('@states/todos/filterTodoIdsEffect').then((mod) => mod.FilterTodoIdsEffect),
 );
-const ErrorBoundary = dynamic(() => import('react-error-boundary').then((mod) => mod.ErrorBoundary), { ssr: false });
+const ErrorBoundary = dynamic(() => import('react-error-boundary').then((mod) => mod.ErrorBoundary));
 
 const AppById = () => {
   return (

--- a/pages/app/index.tsx
+++ b/pages/app/index.tsx
@@ -3,19 +3,17 @@ import { LayoutApp } from '@layouts/layoutApp';
 import dynamic from 'next/dynamic';
 import { Fragment as AppFragment, ReactElement } from 'react';
 
-const LoadingTodos = dynamic(
-  () => import('@components/loadable/loadingStates/loadingTodos').then((mod) => mod.LoadingTodos),
-  { ssr: false },
+const LoadingTodos = dynamic(() =>
+  import('@components/loadable/loadingStates/loadingTodos').then((mod) => mod.LoadingTodos),
 );
 const TodoList = dynamic(() => import('components/todos/todoList').then((mod) => mod.TodoList), {
   loading: () => <LoadingTodos />,
   ssr: false,
 });
-const FilterTodoIdsEffect = dynamic(
-  () => import('@states/todos/filterTodoIdsEffect').then((mod) => mod.FilterTodoIdsEffect),
-  { ssr: false },
+const FilterTodoIdsEffect = dynamic(() =>
+  import('@states/todos/filterTodoIdsEffect').then((mod) => mod.FilterTodoIdsEffect),
 );
-const ErrorBoundary = dynamic(() => import('react-error-boundary').then((mod) => mod.ErrorBoundary), { ssr: false });
+const ErrorBoundary = dynamic(() => import('react-error-boundary').then((mod) => mod.ErrorBoundary));
 
 const App = () => {
   return (

--- a/pages/app/label/[labelId].tsx
+++ b/pages/app/label/[labelId].tsx
@@ -3,19 +3,17 @@ import { LayoutApp } from '@layouts/layoutApp';
 import dynamic from 'next/dynamic';
 import { Fragment, ReactElement } from 'react';
 
-const LoadingTodos = dynamic(
-  () => import('@components/loadable/loadingStates/loadingTodos').then((mod) => mod.LoadingTodos),
-  { ssr: false },
+const LoadingTodos = dynamic(() =>
+  import('@components/loadable/loadingStates/loadingTodos').then((mod) => mod.LoadingTodos),
 );
 const TodoList = dynamic(() => import('components/todos/todoList').then((mod) => mod.TodoList), {
   loading: () => <LoadingTodos />,
   ssr: false,
 });
-const FilterTodoIdsEffect = dynamic(
-  () => import('@states/todos/filterTodoIdsEffect').then((mod) => mod.FilterTodoIdsEffect),
-  { ssr: false },
+const FilterTodoIdsEffect = dynamic(() =>
+  import('@states/todos/filterTodoIdsEffect').then((mod) => mod.FilterTodoIdsEffect),
 );
-const ErrorBoundary = dynamic(() => import('react-error-boundary').then((mod) => mod.ErrorBoundary), { ssr: false });
+const ErrorBoundary = dynamic(() => import('react-error-boundary').then((mod) => mod.ErrorBoundary));
 
 const LabelById = () => {
   return (


### PR DESCRIPTION
Previously, there were known issues in Next.js that caused false warning on the console.log warnings to appear in the browser when using dynamic imports. To temporarily fix the issue, we set the `ssr: false` option on the dynamic imports.

With the release of the latest version of Next.js (13.12.1 as of today), the previous issue has been fixed, and we no longer need to use the `ssr` option. Therefore, the option is removed from the dynamic imports.