### PR TITLE
feat: disable keybindings on mobile and improve the style

### DIFF
--- a/components/todos/todo/index.tsx
+++ b/components/todos/todo/index.tsx
@@ -28,7 +28,7 @@ export const Todo = ({ todo, index }: Props) => {
   return (
     <>
       <div className='flex flex-row items-center justify-center px-1'>
-        <div className='group relative flex w-full cursor-pointer flex-row justify-start sm:mr-4'>
+        <div className='group relative flex w-full cursor-pointer flex-row justify-start'>
           <TodoItemFocuser
             todo={todo}
             index={index!}>

--- a/components/ui/gradients/labelsHorizontalGradients.tsx
+++ b/components/ui/gradients/labelsHorizontalGradients.tsx
@@ -20,7 +20,8 @@ export const LabelsHorizontalGradients = ({ scrollRef, position }: Props) => {
           <div
             className={classNames(
               'absolute -left-2 top-1/2 ml-1 block h-[calc(100%-20%)] w-10 -translate-y-2/4 bg-gradient-to-r sm:-left-2',
-              leftPosition > 0 && 'from-white group-hover/focuser:from-slate-100 group-focus/focuser:from-blue-100',
+              leftPosition > 0 &&
+                'from-slate-50 group-hover/focuser:from-slate-100 group-focus/focuser:from-blue-100 sm:from-white',
             )}
           />
         </GradientLeftFragment>
@@ -32,10 +33,10 @@ export const LabelsHorizontalGradients = ({ scrollRef, position }: Props) => {
               'absolute top-1/2 -right-1 block h-[calc(100%-20%)] w-5 -translate-y-2/4 bg-gradient-to-l sm:-right-1',
               isOverflow &&
                 rightPosition !== 0 &&
-                'from-white group-hover/focuser:from-slate-100 group-focus/focuser:from-blue-100',
+                'from-slate-50 group-hover/focuser:from-slate-100 group-focus/focuser:from-blue-100 sm:from-white',
               rightPosition === 0 &&
                 'from-transparent group-hover/focuser:from-transparent group-focus/focuser:from-transparent',
-              isOverflow && rightPosition < 0 && 'from-white group-hover/focuser:from-slate-100',
+              isOverflow && rightPosition < 0 && 'from-slate-50 group-hover/focuser:from-slate-100 sm:from-white',
             )}
           />
         </GradientRightFragment>


### PR DESCRIPTION
Since keybindings are not useful on touch devices such as smartphones and tablets, they are now disabled based on the device type (mobile and tablet) instead of using media queries.

The styles of the horizontalGradient of labels have been improved, and minor styles have been refactored for better code organization.