### PR TITLE
style: improve styles on different media queries and devices

### DIFF
--- a/components/layouts/layoutApp/layout/layoutFooter/index.tsx
+++ b/components/layouts/layoutApp/layout/layoutFooter/index.tsx
@@ -34,7 +34,7 @@ export const LayoutFooter = ({ children }: Pick<Types, 'children'>) => {
           <div
             className={classNames(
               'relative flex w-full flex-row justify-between rounded-md bg-transparent transition-all duration-200 ease-in-out sm:mr-3 sm:mb-3 sm:bg-white sm:shadow-md sm:shadow-slate-200',
-              isSidebarOpen ? 'ml-3 md:ml-[266px]' : 'sm:ml-3',
+              isSidebarOpen ? 'md:ml-[266px]' : 'md:ml-3',
             )}>
             <main
               className={classNames(

--- a/components/todos/todo/todoItemFocuser.tsx
+++ b/components/todos/todo/todoItemFocuser.tsx
@@ -4,6 +4,7 @@ import { KeysWithNavigationEffect } from '@states/keybinds/KeysWithNavigateEffec
 import { classNames } from '@states/utils';
 import { Types, TypesTodo } from 'lib/types';
 import { Fragment as FocuserFragment, useRef } from 'react';
+import { isMobile } from 'react-device-detect';
 
 type Props = Pick<TypesTodo, 'todo' | 'index'> & Pick<Types, 'children'>;
 
@@ -18,7 +19,8 @@ export const TodoItemFocuser = ({ todo, index, children }: Props) => {
         tabIndex={0}
         className={classNames(
           'group/focuser mr-1 flex flex-row rounded-lg px-2 pt-4 pb-2 outline-none hover:bg-slate-100 focus:bg-blue-100 sm:px-5',
-          'w-[calc(100vw-5rem)] max-w-3xl sm:w-[calc(100vw-7rem)] md:w-[calc(65vw-5rem)] ml:w-[calc(70vw-5rem)]',
+          'w-[calc(100vw-5rem)] max-w-3xl md:w-[calc(65vw-5rem)] ml:w-[calc(70vw-5rem)]',
+          isMobile ? 'sm:w-[calc(100vw-13rem)]' : 'sm:w-[calc(100vw-7rem)]',
         )}
         ref={divFocus}
         onKeyDown={focusKeyHandler}


### PR DESCRIPTION
This commit makes minor changes to the styles of the `footerBody` on different media queries to improve consistency and readability.

Additionally, the width of the `todoItem` now takes dynamic changes based on whether it is being viewed on a mobile device or in a browser. This dynamic width also applies when the mobile device is rotated to a different orientation.