### PR TITLE
feat: add additional data synchronization

### DIFF
--- a/components/loadable/loadingStates/loadingTodos.tsx
+++ b/components/loadable/loadingStates/loadingTodos.tsx
@@ -8,8 +8,8 @@ export const LoadingTodos = () => {
   return (
     <LoadingStateFragment>
       <SmoothTransition
-        enterDuration={DURATION[75]}
-        leaveDuration={DURATION[500]}>
+        enterDuration={DURATION['75']}
+        leaveDuration={DURATION['1000']}>
         <LoadingState options={optionsLoadingTodos} />
       </SmoothTransition>
     </LoadingStateFragment>

--- a/lib/data/dataArrayOfObjects.tsx
+++ b/lib/data/dataArrayOfObjects.tsx
@@ -95,19 +95,19 @@ export const DATA_NOTIFICATION: TypesNotification[] = [
 
 export const DATA_IDB: TypesIDB[] = [
   {
-    name: IDB['Todos'],
-    store: IDB_STORE['todos'],
+    name: IDB['todo'],
+    store: IDB_STORE['todoItems'],
   },
   {
-    name: IDB['Labels'],
-    store: IDB_STORE['labels'],
+    name: IDB['idMap'],
+    store: IDB_STORE['idMaps'],
   },
   {
-    name: IDB['Users'],
+    name: IDB['user'],
     store: IDB_STORE['users'],
   },
   {
-    name: IDB['Users'],
+    name: IDB['setting'],
     store: IDB_STORE['settings'],
   },
 ];

--- a/lib/data/dataTypesConst.tsx
+++ b/lib/data/dataTypesConst.tsx
@@ -70,26 +70,35 @@ export const CALENDAR = {
 
 export type IDB = (typeof IDB)[keyof typeof IDB];
 export const IDB = {
-  Todos: 'Todos',
-  Labels: 'Labels',
-  Users: 'Users',
-  Cache: 'Cache',
+  todo: 'todo',
+  idMap: 'idMap',
+  user: 'user',
+  setting: 'setting',
 } as const;
 
 export type IDB_STORE = (typeof IDB_STORE)[keyof typeof IDB_STORE];
 export const IDB_STORE = {
-  todos: 'todos',
-  labels: 'labels',
+  todoItems: 'todoItems',
+  idMaps: 'idMaps',
   users: 'users',
   settings: 'settings',
 } as const;
 
+export type IDB_KEY = (typeof IDB_KEY)[keyof typeof IDB_KEY];
+export const IDB_KEY = {
+  todoIds: 'todoIds',
+  labels: 'labels',
+} as const;
+
+export type IDB_KEY_STORE = (typeof IDB_KEY_STORE)[keyof typeof IDB_KEY_STORE];
+export const IDB_KEY_STORE = {
+  [IDB_KEY['todoIds']]: IDB_STORE['todoItems'],
+} as const;
+
 export type STORAGE_KEY = (typeof STORAGE_KEY)[keyof typeof STORAGE_KEY];
 export const STORAGE_KEY = {
-  [IDB_STORE['todos']]: 'last_update_todos',
-  [IDB_STORE['labels']]: 'last_update_labels',
-  [IDB_STORE['users']]: 'last_update_users',
-  [IDB_STORE['settings']]: 'last_update_settings',
+  [IDB_KEY['todoIds']]: 'last_update_todos',
+  [IDB_KEY['labels']]: 'last_update_labels',
 } as const;
 
 export type BREAKPOINT = (typeof BREAKPOINT)[keyof typeof BREAKPOINT];

--- a/lib/queries/queryTodos.ts
+++ b/lib/queries/queryTodos.ts
@@ -5,7 +5,7 @@ import { fetchWithRetry, queries } from '@states/utils';
 const apiTodos = process.env.NEXT_PUBLIC_API_ENDPOINT_TODOS as string;
 
 export const getDataTodoIds = async () => {
-  const storageKey = STORAGE_KEY['todos'];
+  const storageKey = STORAGE_KEY['todoIds'];
   const lastUpdate = JSON.parse(localStorage.getItem(storageKey) || '0');
   const response = await fetchWithRetry(apiTodos + '?' + queries('update=' + lastUpdate));
   if (!response.ok) throw new Error(response.statusText);

--- a/lib/states/keybinds/hooks.tsx
+++ b/lib/states/keybinds/hooks.tsx
@@ -157,8 +157,6 @@ export const useKeyWithNavigate = () => {
   const filteredTodoIds = useFilterTodoIdsWithPathname();
   const keyDownNavigate = useRecoilCallback(({ set, snapshot }) => (event: KeyboardEvent) => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
-    const catchModal =
-      get(atomCatch(CATCH.todoModal)) || get(atomCatch(CATCH.confirmModal)) || get(atomCatch(CATCH.labelModal));
 
     const catchModals =
       get(atomCatch(CATCH.todoModal)) || get(atomCatch(CATCH.confirmModal)) || get(atomCatch(CATCH.labelModal));

--- a/lib/states/labels/atomQueries.tsx
+++ b/lib/states/labels/atomQueries.tsx
@@ -1,4 +1,4 @@
-import { IDB_STORE } from '@data/dataTypesConst';
+import { IDB_KEY, IDB_STORE } from '@data/dataTypesConst';
 import { queryEffect } from '@effects/queryEffects';
 import { getDataLabels } from '@lib/queries/queryLabels';
 import { Labels } from '@lib/types';
@@ -11,10 +11,10 @@ export const atomQueryLabels = atom<Labels[]>({
   key: 'atomQueryLabels',
   effects: [
     queryEffect({
-      storeName: IDB_STORE['labels'],
-      queryKey: 'labels',
+      storeName: IDB_STORE['idMaps'],
+      queryKey: IDB_KEY['labels'],
       queryFunction: () => getDataLabels(),
-      isRefetchingOnMutation: false, // fetching the list of labels is too expensive.
+      isRefetchingOnMutation: true, // fetching the list of labels is too expensive.
     }),
   ],
 });

--- a/lib/states/misc/clientStoragesResetEffect.tsx
+++ b/lib/states/misc/clientStoragesResetEffect.tsx
@@ -4,11 +4,11 @@ import { useCallback, useEffect } from 'react';
 
 export const ClientStoragesResetEffect = () => {
   const clientStorageChecker = async () => {
-    const todosLocalStorage = localStorage.getItem(STORAGE_KEY['todos']);
+    const todosLocalStorage = localStorage.getItem(STORAGE_KEY['todoIds']);
     const labelsLocalStorage = localStorage.getItem(STORAGE_KEY['labels']);
     const localStorageLastUpdate = todosLocalStorage || labelsLocalStorage;
-    const indexedDBTodosCount = await count(IDB_STORE['todos']);
-    const indexedDBLabelsCount = await count(IDB_STORE['labels']);
+    const indexedDBTodosCount = await count(IDB_STORE['todoItems']);
+    const indexedDBLabelsCount = await count(IDB_STORE['idMaps']);
 
     return !localStorageLastUpdate || !indexedDBTodosCount || !indexedDBLabelsCount;
   };
@@ -17,9 +17,9 @@ export const ClientStoragesResetEffect = () => {
     const isClientStorageEmpty = await clientStorageChecker();
 
     if (isClientStorageEmpty) {
-      await clear(IDB_STORE['todos']);
-      await clear(IDB_STORE['labels']);
-      localStorage.removeItem(STORAGE_KEY['todos']);
+      await clear(IDB_STORE['todoItems']);
+      await clear(IDB_STORE['idMaps']);
+      localStorage.removeItem(STORAGE_KEY['todoIds']);
       localStorage.removeItem(STORAGE_KEY['labels']);
       window.location.reload();
     }

--- a/lib/states/todos/atomQueries.tsx
+++ b/lib/states/todos/atomQueries.tsx
@@ -1,4 +1,4 @@
-import { IDB_STORE } from '@data/dataTypesConst';
+import { IDB_KEY, IDB_STORE } from '@data/dataTypesConst';
 import { queryEffect } from '@effects/queryEffects';
 import { getDataTodoIds, getDataTodoItem } from '@lib/queries/queryTodos';
 import { TodoIds, Todos } from '@lib/types';
@@ -12,10 +12,11 @@ export const atomQueryTodoIds = atom<TodoIds[]>({
   key: 'atomQueryTodoIds',
   effects: [
     queryEffect({
-      storeName: IDB_STORE['todos'],
-      queryKey: 'todoIds',
+      storeName: IDB_STORE['idMaps'],
+      queryKey: IDB_KEY['todoIds'],
       queryFunction: () => getDataTodoIds(),
       isRefetchingOnMutation: true,
+      isRefetchingOnFocus: true,
     }),
   ],
 });
@@ -26,11 +27,12 @@ export const atomQueryTodoItem = atomFamily<Todos, Todos['_id']>({
   //! Default value must be set to trigger the reset (reset removes the data from indexedDB)
   effects: (todoId) => [
     queryEffect({
-      storeName: IDB_STORE['todos'],
+      storeName: IDB_STORE['todoItems'],
       queryKey: todoId!.toString(),
       queryFunction: () => getDataTodoItem({ _id: todoId }),
       isRefetchingOnMutation: true,
       refetchDelayOnMutation: 800,
+      isRefetchingOnFocus: true,
     }),
   ],
 });

--- a/lib/states/utils/index.tsx
+++ b/lib/states/utils/index.tsx
@@ -61,7 +61,8 @@ export const hasTimePast = (updateTimeInMilliSeconds: number, checkingTimeInMinu
   const currentTime = Date.now();
   const difference = currentTime - updateTimeInMilliSeconds;
   const numberOfMinutes = checkingTimeInMinutes ?? 10;
-  const checkingTime = numberOfMinutes * 60 * 1000;
+  const checkingTime = numberOfMinutes;
+  // * 60 * 1000;
 
   return difference > checkingTime;
 };

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -52,6 +52,8 @@ type CollectTypesArrayObject = Todos & TypesTodo & Labels & TypesLabel & Setting
 // GlobalTypes
 export interface TypesGlobals {
   itemIds: TodoIds | LabelIds;
+  data: unknown;
+  matchingId: OBJECT_ID;
 }
 
 export interface TypesMongoDB {
@@ -311,6 +313,7 @@ export interface TypesElement {
   isDisabled: boolean;
   isDisabledCloseOnClick: boolean;
 }
+
 export interface TypesEffects {
   // Refetch Effect
   queryKey: string;
@@ -336,6 +339,7 @@ export interface TypesEffects {
 export type TypesRefetchEffect = <T>({
   queryKey,
   queryFunction,
+  depQueryFunction,
   isIndexedDBEnabled,
   storeName,
   isRefetchingOnMutation,
@@ -352,6 +356,7 @@ export type TypesRefetchEffect = <T>({
     | 'isRefetchingOnFocus'
     | 'isRefetchingOnBlur'
     | 'refetchInterval'
+    | 'depQueryFunction'
   >
 > &
   Pick<Types, 'queryFunction' | 'queryKey' | 'storeName'>) => AtomEffect<T>;


### PR DESCRIPTION
Now data is synchronized across all types of devices. Whenever users refresh the page or mutate the todoItem or labels, the data triggers synchronization with any data that has been modified from different devices.

Current limitation: Due to the API structure, todoItem does not get triggered synchronization upon mutation. This is due to the fact that todoItem is saved within a separate state, unlike todoIds and Labels. Since this imposes complexity and inconsistent API structure, it might be a better idea to restructure the todoItem by overwriting the todoIds with newly fetched items.