### PR TITLE
fix: fix the dynamic imports due to Next.js's 13.2.0 update

### DIFF
--- a/components/layouts/layoutApp/layout/index.tsx
+++ b/components/layouts/layoutApp/layout/index.tsx
@@ -1,6 +1,6 @@
 import { Types } from '@lib/types';
 import dynamic from 'next/dynamic';
-import { Fragment as LayoutFragment } from 'react';
+import { Fragment as LayoutFragment, Suspense } from 'react';
 import { LayoutHeader } from './layoutHeader';
 
 const LayoutFooter = dynamic(() => import('./layoutFooter').then((mod) => mod.LayoutFooter), {
@@ -12,7 +12,9 @@ export const Layout = ({ children }: Pick<Types, 'children'>) => {
     <LayoutFragment>
       <div className='flex h-screen flex-col'>
         <LayoutHeader />
-        <LayoutFooter>{children}</LayoutFooter>
+        <Suspense>
+          <LayoutFooter>{children}</LayoutFooter>
+        </Suspense>
       </div>
     </LayoutFragment>
   );

--- a/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/index.tsx
+++ b/components/layouts/layoutApp/layout/layoutFooter/footerSidebar/index.tsx
@@ -1,6 +1,7 @@
 import { DisableButton } from '@buttons/disableButton';
 import { IconButton } from '@buttons/iconButton';
 import { SvgIcon } from '@components/icons/svgIcon';
+import { LabelList } from '@components/labels/labelList';
 import { optionsButtonCreateTodo, optionsButtonSidebarToggle } from '@data/dataOptions';
 import { ICON_ADD_TASK } from '@data/materialSymbols';
 import { LayoutLogo } from '@layouts/layoutApp/layoutLogo';
@@ -10,7 +11,6 @@ import { useTodoModalStateOpen } from '@states/modals/hooks';
 import { atomDisableScroll, classNames } from '@states/utils';
 import { useConditionCheckCreateModalOpen } from '@states/utils/hooks';
 import { Backdrop } from '@ui/backdrops/backdrop';
-import dynamic from 'next/dynamic';
 import {
   forwardRef,
   Fragment as CreateTodoFragment,
@@ -19,13 +19,6 @@ import {
 } from 'react';
 import { useRecoilCallback, useRecoilValue } from 'recoil';
 import { FooterSidebarMenu } from './footerSidebarMenu';
-
-const LoadingLabels = dynamic(() =>
-  import('@components/loadable/loadingStates/loadingLabels').then((mod) => mod.LoadingLabels),
-);
-const LabelList = dynamic(() => import('@components/labels/labelList').then((mod) => mod.LabelList), {
-  loading: () => <LoadingLabels />,
-});
 
 export const FooterSidebar = forwardRef<HTMLDivElement>((_, ref) => {
   const isScrollDisabled = useRecoilValue(atomDisableScroll);

--- a/pages/app/[appId].tsx
+++ b/pages/app/[appId].tsx
@@ -1,13 +1,10 @@
 import { ErrorState } from '@components/loadable/errorState';
+import { LoadingTodos } from '@components/loadable/loadingStates/loadingTodos';
 import { LayoutApp } from '@layouts/layoutApp';
 import dynamic from 'next/dynamic';
-import { Fragment as AppByIdFragment, ReactElement } from 'react';
+import { Fragment as AppByIdFragment, ReactElement, Suspense } from 'react';
 
-const LoadingTodos = dynamic(() =>
-  import('@components/loadable/loadingStates/loadingTodos').then((mod) => mod.LoadingTodos),
-);
 const TodoList = dynamic(() => import('components/todos/todoList').then((mod) => mod.TodoList), {
-  loading: () => <LoadingTodos />,
   ssr: false,
 });
 const FilterTodoIdsEffect = dynamic(() =>
@@ -18,9 +15,11 @@ const ErrorBoundary = dynamic(() => import('react-error-boundary').then((mod) =>
 const AppById = () => {
   return (
     <AppByIdFragment>
-      <FilterTodoIdsEffect />
       <ErrorBoundary fallback={<ErrorState />}>
-        <TodoList />
+        <Suspense fallback={<LoadingTodos />}>
+          <FilterTodoIdsEffect />
+          <TodoList />
+        </Suspense>
       </ErrorBoundary>
     </AppByIdFragment>
   );

--- a/pages/app/index.tsx
+++ b/pages/app/index.tsx
@@ -1,13 +1,10 @@
 import { ErrorState } from '@components/loadable/errorState';
+import { LoadingTodos } from '@components/loadable/loadingStates/loadingTodos';
 import { LayoutApp } from '@layouts/layoutApp';
 import dynamic from 'next/dynamic';
-import { Fragment as AppFragment, ReactElement } from 'react';
+import { Fragment as AppFragment, ReactElement, Suspense } from 'react';
 
-const LoadingTodos = dynamic(() =>
-  import('@components/loadable/loadingStates/loadingTodos').then((mod) => mod.LoadingTodos),
-);
 const TodoList = dynamic(() => import('components/todos/todoList').then((mod) => mod.TodoList), {
-  loading: () => <LoadingTodos />,
   ssr: false,
 });
 const FilterTodoIdsEffect = dynamic(() =>
@@ -18,9 +15,11 @@ const ErrorBoundary = dynamic(() => import('react-error-boundary').then((mod) =>
 const App = () => {
   return (
     <AppFragment>
-      <FilterTodoIdsEffect />
       <ErrorBoundary fallback={<ErrorState />}>
-        <TodoList />
+        <Suspense fallback={<LoadingTodos />}>
+          <FilterTodoIdsEffect />
+          <TodoList />
+        </Suspense>
       </ErrorBoundary>
     </AppFragment>
   );

--- a/pages/app/label/[labelId].tsx
+++ b/pages/app/label/[labelId].tsx
@@ -1,13 +1,10 @@
 import { ErrorState } from '@components/loadable/errorState';
+import { LoadingTodos } from '@components/loadable/loadingStates/loadingTodos';
 import { LayoutApp } from '@layouts/layoutApp';
 import dynamic from 'next/dynamic';
-import { Fragment, ReactElement } from 'react';
+import { Fragment, ReactElement, Suspense } from 'react';
 
-const LoadingTodos = dynamic(() =>
-  import('@components/loadable/loadingStates/loadingTodos').then((mod) => mod.LoadingTodos),
-);
 const TodoList = dynamic(() => import('components/todos/todoList').then((mod) => mod.TodoList), {
-  loading: () => <LoadingTodos />,
   ssr: false,
 });
 const FilterTodoIdsEffect = dynamic(() =>
@@ -18,9 +15,11 @@ const ErrorBoundary = dynamic(() => import('react-error-boundary').then((mod) =>
 const LabelById = () => {
   return (
     <Fragment>
-      <FilterTodoIdsEffect />
       <ErrorBoundary fallback={<ErrorState />}>
-        <TodoList />
+        <Suspense fallback={<LoadingTodos />}>
+          <FilterTodoIdsEffect />
+          <TodoList />
+        </Suspense>
       </ErrorBoundary>
     </Fragment>
   );


### PR DESCRIPTION
Since Next.js version 13.2.0, the new update reverts the `Loading` option from the dynamic imports. According to Next.js's team, the new dynamic import that combines `React.Lazy` and `Suspense` causes more issues than its benefits. As of version 13.2.0, the option of `Loading` is now unavailable in dynamic imports. All dynamic imports using `Loading` options have been reverted to use the `Suspense`.