### PR TITLE
feat: add new environment variable IMAGE_DOMAIN

### DIFF
--- a/.env
+++ b/.env
@@ -7,6 +7,9 @@
 # use .env.development.local to override the .env
 HOST=https://$HOSTNAME
 NEXT_PUBLIC_HOST=$HOST
+# IMAGE DOMAIN
+IMAGE=https://$IMAGE_DOMAIN
+NEXT_PUBLIC_IMAGE_DOMAIN=$IMAGE
 # API
 API_BASE=/api/v1
 API_TODOS=/todos

--- a/deploy.sh
+++ b/deploy.sh
@@ -8,12 +8,12 @@ function gcloud_run_deploy() {
     $VPC_FLAG \
     $SECRET_FLAG \
     $SERVICE_NAME \
+    $ENV_VARS \
     --image gcr.io/$GCP_PROJECT_ID/$IMAGE_NAME:$IMAGE_TAG \
     --project $GCP_PROJECT_ID \
     --region $DEPLOY_REGION \
     --platform managed \
-    --allow-unauthenticated \
-    --set-env-vars HOSTNAME=$HOSTNAME
+    --allow-unauthenticated
 }
 
 source .env.local
@@ -25,6 +25,8 @@ source .env.local
 # IMAGE_TAG
 # GCP_PROJECT_ID
 # DEPLOY_REGION 
+# HOSTNAME 
+# IMAGE_DOMAIN (optional)
 # VPC_CONNECTOR (optional)
 # VPC_REGION (optional)
 # SECRET_ENVIRONMENT_VARIABLE_* (optional: name of environment variable as secret on Google Cloud Run)
@@ -33,6 +35,12 @@ source .env.local
 docker build -t $IMAGE_NAME:$IMAGE_TAG .
 docker tag $IMAGE_NAME:$IMAGE_TAG gcr.io/$GCP_PROJECT_ID/$IMAGE_NAME:$IMAGE_TAG
 docker push gcr.io/$GCP_PROJECT_ID/$IMAGE_NAME:$IMAGE_TAG
+
+if [ -n "$IMAGE_DOMAIN" ]; then
+  IMAGE_VARS=",IMAGE_DOMAIN=$IMAGE_DOMAIN"
+fi
+
+ENV_VARS="--set-env-vars HOSTNAME=$HOSTNAME${IMAGE_VARS}"
 
 if [ -n "$VPC_REGION" ] && [ -n "$VPC_CONNECTOR" ]; then
   VPC_FLAG="--vpc-connector $VPC_CONNECTOR --region=$VPC_REGION --vpc-egress=all-traffic"

--- a/next.config.js
+++ b/next.config.js
@@ -14,7 +14,10 @@ module.exports = withBundleAnalyzer({
     ignoreDuringBuilds: false,
   },
   images: {
-    domains: process.env.NODE_ENV !== 'production' ? ['images.unsplash.com', 'tailwindui.com'] : [''],
+    domains:
+      process.env.NODE_ENV !== 'production'
+        ? ['images.unsplash.com', 'tailwindui.com', process.env.IMAGE_DOMAIN || '']
+        : [process.env.IMAGE_DOMAIN || ''],
   },
   output: 'standalone',
   swcMinify: true,


### PR DESCRIPTION
The `deploy.sh` script now accepts `IMAGE_DOMAIN` as an optional parameter. If provided, it will be added to the environment variables of Cloud Run. To make the build process smoother, the Next.js configuration will check for the `IMAGE_DOMAIN` variable first, but will return an empty string if no variable is provided.

While it is still possible to provide `IMAGE_DOMAIN` in the `.env` file, it is recommended to put it in the `.env.local` file if Google Cloud Run's environment variable will be used. This is because `deploy.sh` will use the values from `.env.local`.