### PR TITLE
feat: add placeholder images on empty todoList

### DIFF
--- a/components/layouts/layoutApp/layout/layoutHeader/index.tsx
+++ b/components/layouts/layoutApp/layout/layoutHeader/index.tsx
@@ -44,7 +44,7 @@ export const LayoutHeader = () => {
           </div>
         </LeftSideFragment>
         <RightSidebarFragment>
-          <div className='flex flex-1 px-2'>
+          <div className='flex flex-1 pl-2 pr-3'>
             <HeaderSearchBar />
             <div className='ml-4 flex items-center md:ml-6'>
               {/* Profile dropdown */}
@@ -59,11 +59,11 @@ export const LayoutHeader = () => {
                     )}>
                     <span className='sr-only'>Open user menu</span>
                     <Image
-                      width={40}
-                      height={40}
-                      className='rounded-full drop-shadow-md'
-                      src='https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80'
-                      alt=''
+                      width={32}
+                      height={32}
+                      className='rounded-full drop-shadow-lg'
+                      src={process.env.NEXT_PUBLIC_IMAGE_DOMAIN + '/user_avatar.webp'}
+                      alt='User avatar'
                     />
                   </Menu.Button>
                 </div>

--- a/components/loadable/loadingStates/loadingLabels.tsx
+++ b/components/loadable/loadingStates/loadingLabels.tsx
@@ -8,8 +8,8 @@ export const LoadingLabels = () => {
   return (
     <Fragment>
       <SmoothTransition
-        enterDuration={DURATION[75]}
-        leaveDuration={DURATION[300]}>
+        enterDuration={DURATION['500']}
+        leaveDuration={DURATION['500']}>
         <LoadingState options={optionsLoadingLabels} />
       </SmoothTransition>
     </Fragment>

--- a/components/loadable/loadingStates/loadingTodos.tsx
+++ b/components/loadable/loadingStates/loadingTodos.tsx
@@ -8,8 +8,8 @@ export const LoadingTodos = () => {
   return (
     <LoadingStateFragment>
       <SmoothTransition
-        enterDuration={DURATION['75']}
-        leaveDuration={DURATION['1000']}>
+        enterDuration={DURATION['500']}
+        leaveDuration={DURATION['500']}>
         <LoadingState options={optionsLoadingTodos} />
       </SmoothTransition>
     </LoadingStateFragment>

--- a/components/todos/todoList.tsx
+++ b/components/todos/todoList.tsx
@@ -1,4 +1,9 @@
+import { DATA_PATHNAME_IMAGE } from '@data/dataArrayOfObjects';
+import { TypesPathnameImage } from '@lib/types';
+import { atomPathnameImage } from '@states/misc';
 import { selectorFilterTodoIds } from '@states/todos';
+import { SmoothTransition } from '@ui/transitions/smoothTransition';
+import Image from 'next/image';
 import { Fragment as TodosFragment } from 'react';
 import { useRecoilValue } from 'recoil';
 import { Todo } from './todo';
@@ -6,18 +11,41 @@ import { Todo } from './todo';
 export const TodoList = () => {
   const todoIds = useRecoilValue(selectorFilterTodoIds);
   const todoIdsReversed = [...todoIds].reverse();
+  const imagePath = useRecoilValue(atomPathnameImage);
+  const image = DATA_PATHNAME_IMAGE.find((item) => item.path === imagePath) || ({} as TypesPathnameImage);
 
   return (
     <TodosFragment>
       <ul>
-        {todoIdsReversed.map((todo, index) => (
-          <li key={todo._id?.toString()}>
-            <Todo
-              todo={todo}
-              index={index}
-            />
-          </li>
-        ))}
+        {todoIdsReversed.length !== 0 ? (
+          <SmoothTransition>
+            {todoIdsReversed.map((todo, index) => (
+              <li key={todo._id?.toString()}>
+                <Todo
+                  todo={todo}
+                  index={index}
+                />
+              </li>
+            ))}
+          </SmoothTransition>
+        ) : (
+          <SmoothTransition>
+            <div className='mt-7 flex flex-col items-center justify-center'>
+              <div className='flex h-full min-h-[300px] flex-col items-center justify-end'>
+                <Image
+                  width={300}
+                  height={100}
+                  src={`${process.env.NEXT_PUBLIC_IMAGE_DOMAIN}${image.path}`}
+                  alt={image.alt}
+                />
+              </div>
+              <div className='mb-2 text-lg'>{image.title}</div>
+              <div className='max-w-xs text-center text-sm tracking-wide text-slate-400 sm:max-w-md'>
+                {image.description}
+              </div>
+            </div>
+          </SmoothTransition>
+        )}
       </ul>
     </TodosFragment>
   );

--- a/components/ui/transitions/smoothTransition.tsx
+++ b/components/ui/transitions/smoothTransition.tsx
@@ -2,32 +2,24 @@ import { DURATION } from '@data/dataTypesConst';
 import { Transition } from '@headlessui/react';
 import { Types } from '@lib/types';
 import { classNames } from '@states/utils';
-import { useCallback, useEffect, useState } from 'react';
 
 type Props = Pick<Types, 'children'> & Partial<Pick<Types, 'enterDuration' | 'leaveDuration'>>;
 
-export const SmoothTransition = ({ children, enterDuration = DURATION[100], leaveDuration = DURATION[150] }: Props) => {
-  const [isShowing, setIsShowing] = useState(false);
-
-  const setTransition = useCallback(() => {
-    setIsShowing(true);
-  }, []);
-
-  useEffect(() => {
-    setTransition();
-  }, [setTransition]);
-
+export const SmoothTransition = ({
+  children,
+  enterDuration = DURATION['300'],
+  leaveDuration = DURATION['500'],
+}: Props) => {
   return (
     <Transition
-      show={isShowing}
-      as='div'
+      appear={true}
+      show={true}
       enter={classNames('transition-opacity ease-in-out', enterDuration)}
       enterFrom='opacity-0'
       enterTo='opacity-100'
       leave={classNames('transition-opacity ease-in-out', leaveDuration)}
       leaveFrom='opacity-100'
-      leaveTo='opacity-0'
-      className='flex'>
+      leaveTo='opacity-0'>
       {children}
     </Transition>
   );

--- a/lib/data/dataArrayOfObjects.tsx
+++ b/lib/data/dataArrayOfObjects.tsx
@@ -1,5 +1,5 @@
-import { TypesIDB, TypesNotification } from 'lib/types';
-import { NOTIFICATION, IDB, IDB_STORE, PATHNAME } from './dataTypesConst';
+import { TypesIDB, TypesNotification, TypesPathnameImage, TypesSidebarMenu } from 'lib/types';
+import { IDB, IDB_STORE, NOTIFICATION, PATHNAME } from './dataTypesConst';
 import {
   ICON_DELETE,
   ICON_DONE_ALL,
@@ -112,7 +112,7 @@ export const DATA_IDB: TypesIDB[] = [
   },
 ];
 
-export const DATA_SIDEBAR_MENU = [
+export const DATA_SIDEBAR_MENU: TypesSidebarMenu[] = [
   {
     name: "Today's Focus",
     tooltip: "Today's Focus",
@@ -152,5 +152,46 @@ export const DATA_SIDEBAR_MENU = [
     iconActive: ICON_DONE_ALL,
     iconColor: 'fill-green-600',
     path: PATHNAME['completed'],
+  },
+];
+
+export const DATA_PATHNAME_IMAGE: TypesPathnameImage[] = [
+  {
+    path: '/focus.webp',
+    alt: 'Placeholder image of focus',
+    title: "Todos for today's focus",
+    description:
+      "Congratulations! You've completed all of your todos for today's focus. Take a moment to celebrate your accomplishments.",
+  },
+  {
+    path: '/urgent.webp',
+    alt: 'Placeholder image of urgent',
+    title: 'Your urgent todos',
+    description: 'Prioritize time-sensitive todos that require immediate attention.',
+  },
+  {
+    path: '/important.webp',
+    alt: 'Placeholder image of important',
+    title: 'Your important todos',
+    description: 'Identify todos that are crucial to your long-term goals and success.',
+  },
+  {
+    path: '/showall.webp',
+    alt: 'Placeholder image of showall',
+    title: 'All uncompleted todos',
+    description:
+      'This is a complete list of all your todos, including those that have not yet been completed. Keep track of your progress here.',
+  },
+  {
+    path: '/completed.webp',
+    alt: 'Placeholder image of completed',
+    title: 'Your completed todos',
+    description: 'While there are no completed todos yet, every step counts towards achieving your goals.',
+  },
+  {
+    path: '/label.webp',
+    alt: 'Placeholder image of label',
+    title: 'Your labeled todos',
+    description: 'Organize your todos by using labels to keep track of your progress and priorities.',
   },
 ];

--- a/lib/data/dataTypesConst.tsx
+++ b/lib/data/dataTypesConst.tsx
@@ -135,6 +135,16 @@ export const PATHNAME = {
   label: '/app/label/(.*)$',
 } as const;
 
+export type PATHNAME_IMAGE = (typeof PATHNAME_IMAGE)[keyof typeof PATHNAME_IMAGE];
+export const PATHNAME_IMAGE = {
+  app: '/focus.webp',
+  urgent: '/urgent.webp',
+  important: '/important.webp',
+  showAll: '/showall.webp',
+  completed: '/completed.webp',
+  label: '/label.webp',
+};
+
 export type DURATION = (typeof DURATION)[keyof typeof DURATION];
 export const DURATION = {
   75: 'duration-75',

--- a/lib/states/misc/index.tsx
+++ b/lib/states/misc/index.tsx
@@ -1,4 +1,4 @@
-import { BREAKPOINT } from '@data/dataTypesConst';
+import { BREAKPOINT, PATHNAME_IMAGE } from '@data/dataTypesConst';
 import { mediaQueryEffect, networkStatusEffect } from '@effects/atomEffects';
 import { atom, atomFamily, selector } from 'recoil';
 
@@ -45,6 +45,11 @@ export const atomActiveMenuItem = atomFamily<boolean, string | null>({
 export const atomHtmlTitleTag = atom<string>({
   key: 'atomHtmlTitleTag',
   default: '',
+});
+
+export const atomPathnameImage = atom<PATHNAME_IMAGE>({
+  key: 'atomPathnameImage',
+  default: PATHNAME_IMAGE['app'],
 });
 
 /**

--- a/lib/states/todos/filterTodoIdsEffect.tsx
+++ b/lib/states/todos/filterTodoIdsEffect.tsx
@@ -1,8 +1,8 @@
-import { PATHNAME } from '@data/dataTypesConst';
+import { PATHNAME, PATHNAME_IMAGE } from '@data/dataTypesConst';
 import { Labels } from '@lib/types';
 import { atomLabelQuerySlug } from '@states/labels';
 import { atomQueryLabels } from '@states/labels/atomQueries';
-import { atomHtmlTitleTag } from '@states/misc';
+import { atomHtmlTitleTag, atomPathnameImage } from '@states/misc';
 import { useNextQuerySlug } from '@states/utils/hooks';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
@@ -22,32 +22,38 @@ export const FilterTodoIdsEffect = () => {
     if (asPath === PATHNAME['app']) {
       set(atomFilterTodoIds, 'focus');
       set(atomHtmlTitleTag, "Today's Focus");
+      set(atomPathnameImage, PATHNAME_IMAGE['app']);
       return;
     }
     if (asPath === PATHNAME['urgent']) {
       set(atomFilterTodoIds, 'urgent');
       set(atomHtmlTitleTag, 'Priority - Urgent');
+      set(atomPathnameImage, PATHNAME_IMAGE['urgent']);
       return;
     }
     if (asPath === PATHNAME['important']) {
       set(atomFilterTodoIds, 'important');
       set(atomHtmlTitleTag, 'Priority - Important');
+      set(atomPathnameImage, PATHNAME_IMAGE['important']);
       return;
     }
     if (asPath === PATHNAME['showAll']) {
       set(atomFilterTodoIds, 'showAll');
       set(atomHtmlTitleTag, 'All Todos');
+      set(atomPathnameImage, PATHNAME_IMAGE['showAll']);
       return;
     }
     if (asPath === PATHNAME['completed']) {
       set(atomFilterTodoIds, 'completed');
       set(atomHtmlTitleTag, 'Task Completed Todos');
+      set(atomPathnameImage, PATHNAME_IMAGE['completed']);
       return;
     }
     if (asPath.match(new RegExp(PATHNAME['label']))) {
       set(atomFilterTodoIds, 'label');
       set(atomLabelQuerySlug, labelId);
       set(atomHtmlTitleTag, `Label - ${label.name}`);
+      set(atomPathnameImage, PATHNAME_IMAGE['label']);
       return;
     }
   });

--- a/lib/states/utils/index.tsx
+++ b/lib/states/utils/index.tsx
@@ -61,8 +61,7 @@ export const hasTimePast = (updateTimeInMilliSeconds: number, checkingTimeInMinu
   const currentTime = Date.now();
   const difference = currentTime - updateTimeInMilliSeconds;
   const numberOfMinutes = checkingTimeInMinutes ?? 10;
-  const checkingTime = numberOfMinutes;
-  // * 60 * 1000;
+  const checkingTime = numberOfMinutes * 60 * 1000;
 
   return difference > checkingTime;
 };

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -6,6 +6,7 @@ import {
   NOTIFICATION,
   OBJECT_ID,
   PATHNAME,
+  PATHNAME_IMAGE,
   POSITION_X,
   POSITION_Y,
   PRIORITY_LEVEL,
@@ -147,6 +148,21 @@ export interface TypesNotification {
 export interface TypesIDB {
   name: IDB;
   store: IDB_STORE;
+}
+
+export interface TypesSidebarMenu {
+  name: string;
+  tooltip: string;
+  icon: string;
+  iconActive: string;
+  iconColor: string;
+  path: PATHNAME;
+}
+export interface TypesPathnameImage {
+  path: PATHNAME_IMAGE;
+  alt: string;
+  title: string;
+  description: string;
 }
 
 /**


### PR DESCRIPTION
Now, when no todos are present, placeholder images will be displayed on the list. These images are dynamic and based on the route, so a different image will be shown for each route, except for the label. Since the labels are dynamic data, each route on label will show the same image placeholder.

Additionally, a custom avatar image has been added to display the default image for user avatars. Currently, the login module is not implemented, but will be implemented within upcoming updates.

Instead of placing the images within the public folder, they are located within Google Cloud Storage and then cached through Cloudflare.

Core Changes:
- feat: add the custom avatar image and placeholder images.
- feat: update the images URLs with environment variable.
- feat: add the new type: `TypesPathnameImage`.
- feat: add new `dataArrayOfObjects`.
- feat: add `atomPathnameImage` to `filterTodoIdsEffect`.

Misc Changes:
- refactor: refactor the style.
- feat: add missing types.
- refactor: update the types.
- fix: fixe the typo.
- refactor: refactor smoothTransition component.