### PR TITLE
fix: fix the type errors and other minor errors

### DIFF
--- a/components/ui/backdrops/backdrop/index.tsx
+++ b/components/ui/backdrops/backdrop/index.tsx
@@ -25,7 +25,7 @@ export const Backdrop = ({ options, onClick, onBlur, onFocus, show }: Props) => 
       <ConditionalPortal isPortal={options.isPortal ?? true}>
         <Transition
           show={show ?? isShow}
-          as={options.as ?? Fragment}
+          as={Fragment}
           appear={true}
           enter={classNames('transition-opacity ease-in-out', options.enterDuration ?? 'duration-200')}
           enterFrom='opacity-0'

--- a/components/ui/dropdowns/dropdown/index.tsx
+++ b/components/ui/dropdowns/dropdown/index.tsx
@@ -7,7 +7,7 @@ import { classNames } from '@states/utils';
 import { SvgIcon } from 'components/icons/svgIcon';
 import { Types } from 'lib/types';
 import dynamic from 'next/dynamic';
-import { Fragment as MenuFragment, useRef, useState } from 'react';
+import { Fragment, Fragment as MenuFragment, useRef, useState } from 'react';
 import { usePopper } from 'react-popper';
 import { useSetRecoilState } from 'recoil';
 import { ConditionalPortal } from './conditionalPortal';
@@ -46,42 +46,44 @@ export const Dropdown = ({ headerContents, headerContentsOnClose, children, show
             kbd={isClicked || open ? undefined : options.kbd}>
             <MenuFragment>
               <div ref={setReferenceElement}>
-                <Menu.Button
-                  className={classNames(
-                    options.group ?? 'group',
-                    'inline-flex w-full items-center text-gray-400 ease-in hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-0 sm:ml-0',
-                    options.padding ?? 'p-2',
-                    options.hoverBg ?? STYLE_HOVER_SLATE_DARK,
-                    options.borderRadius && headerContents ? options.borderRadius : 'rounded-full',
-                    visibility(isInitiallyVisible ?? true, open),
-                  )}
-                  onMouseDown={() => setClick(true)}
-                  onMouseEnter={() => setClick(false)}
-                  onMouseLeave={() => setClick(true)}
-                  onClick={() => setFocusOnBlur(true)}
-                  onKeyDown={(event: React.KeyboardEvent) => {
-                    event.preventDefault();
-                    event.key === 'Escape' && focusRef.current!.blur();
-                  }}
-                  ref={focusRef}>
-                  <SvgIcon
-                    options={{
-                      path: options.path,
-                      className: classNames(
-                        options.size ?? 'h-5 w-5',
-                        options.color ?? 'fill-gray-500 group-hover:fill-gray-700',
-                      ),
+                <Menu.Button as={Fragment}>
+                  <button
+                    className={classNames(
+                      options.group ?? 'group',
+                      'inline-flex w-full items-center text-gray-400 ease-in hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-0 sm:ml-0',
+                      options.padding ?? 'p-2',
+                      options.hoverBg ?? STYLE_HOVER_SLATE_DARK,
+                      options.borderRadius && headerContents ? options.borderRadius : 'rounded-full',
+                      visibility(isInitiallyVisible ?? true, open),
+                    )}
+                    onMouseDown={() => setClick(true)}
+                    onMouseEnter={() => setClick(false)}
+                    onMouseLeave={() => setClick(true)}
+                    onClick={() => setFocusOnBlur(true)}
+                    onKeyDown={(event: React.KeyboardEvent) => {
+                      event.preventDefault();
+                      event.key === 'Escape' && focusRef.current!.blur();
                     }}
-                  />
-                  {headerContents && (
-                    <span
-                      className={classNames(
-                        'flex flex-row items-start justify-start whitespace-nowrap pl-3 text-sm font-normal text-gray-500',
-                        options.text ?? 'group-hover:text-gray-700',
-                      )}>
-                      {headerContents}
-                    </span>
-                  )}
+                    ref={focusRef}>
+                    <SvgIcon
+                      options={{
+                        path: options.path,
+                        className: classNames(
+                          options.size ?? 'h-5 w-5',
+                          options.color ?? 'fill-gray-500 group-hover:fill-gray-700',
+                        ),
+                      }}
+                    />
+                    {headerContents && (
+                      <span
+                        className={classNames(
+                          'flex flex-row items-start justify-start whitespace-nowrap pl-3 text-sm font-normal text-gray-500',
+                          options.text ?? 'group-hover:text-gray-700',
+                        )}>
+                        {headerContents}
+                      </span>
+                    )}
+                  </button>
                 </Menu.Button>
               </div>
               {!open && headerContentsOnClose}

--- a/lib/models/User/index.ts
+++ b/lib/models/User/index.ts
@@ -1,9 +1,8 @@
 import mongoose from 'mongoose';
-import { ObjectID } from 'bson';
 
 const UserSchema = new mongoose.Schema({
   _id: {
-    type: ObjectID,
+    type: mongoose.Types.ObjectId,
     required: true,
   },
   email: {

--- a/lib/models/User/setting.ts
+++ b/lib/models/User/setting.ts
@@ -1,9 +1,8 @@
 import mongoose from 'mongoose';
-import { ObjectID } from 'bson';
 
 const SettingSchema = new mongoose.Schema({
   _id: {
-    type: ObjectID,
+    type: mongoose.Types.ObjectId,
     required: true,
   },
   createdDate: {
@@ -11,7 +10,11 @@ const SettingSchema = new mongoose.Schema({
     required: false,
     default: new Date().toISOString(),
   },
-  userId: { type: ObjectID, required: true, unique: true },
+  userId: {
+    type: mongoose.Types.ObjectId,
+    required: true,
+    unique: true,
+  },
 });
 
 export default mongoose.models.Setting || mongoose.model('Setting', SettingSchema);

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -12,15 +12,7 @@ import {
   PRIORITY_LEVEL,
 } from '@data/dataTypesConst';
 import { Placement } from '@popperjs/core';
-import {
-  ElementType,
-  FocusEventHandler,
-  KeyboardEventHandler,
-  MouseEventHandler,
-  ReactElement,
-  ReactNode,
-  RefObject,
-} from 'react';
+import { FocusEventHandler, KeyboardEventHandler, MouseEventHandler, ReactElement, ReactNode, RefObject } from 'react';
 import { TriggerType } from 'react-popper-tooltip';
 import { AtomEffect } from 'recoil';
 import { Descendant } from 'slate';
@@ -294,7 +286,6 @@ export interface TypesComboboxAttributes {
 export interface TypesDropdownAttributes {
   hasDropdownBoardStyle: boolean;
   headerContentsOnClose: Types['children'];
-  as: ElementType;
 }
 
 export interface TypesInputAttributes {

--- a/lib/types/typesOptions.ts
+++ b/lib/types/typesOptions.ts
@@ -28,7 +28,7 @@ export type TypesOptionsPriority = Partial<
   Pick<Types, 'priorityLevel'>;
 
 export type TypesOptionsBackdrop = Partial<
-  Pick<Types, 'isPortal' | 'enterDuration' | 'leaveDuration' | 'as'> & Pick<TypesStyleAttributes, 'color' | 'zIndex'>
+  Pick<Types, 'isPortal' | 'enterDuration' | 'leaveDuration'> & Pick<TypesStyleAttributes, 'color' | 'zIndex'>
 >;
 
 export type TypesOptionsDropdown = Partial<


### PR DESCRIPTION
Fix the Headless UI's type and Menu.Button issues. Headless UI's Menu.Button does not take the onClick and onKeyDown events. To workaround, render Menu.Button as Fragment then wrap the button element or component as children.

### Core Changes:
- fix: fix the type of schema's objectId
- fix: fix the type error on backdrop by removing unnecessary object props
- fix: fix the Headless UI's Menu.Button issue