### PR TITLE
feat: add auto-deletion of indexedDB upon version changes

### DIFF
--- a/lib/data/dataArrayOfObjects.tsx
+++ b/lib/data/dataArrayOfObjects.tsx
@@ -1,5 +1,5 @@
 import { TypesIDB, TypesNotification, TypesPathnameImage, TypesSidebarMenu } from 'lib/types';
-import { IDB, IDB_STORE, NOTIFICATION, PATHNAME } from './dataTypesConst';
+import { IDB, IDB_STORE, IDB_VERSION, NOTIFICATION, PATHNAME } from './dataTypesConst';
 import {
   ICON_DELETE,
   ICON_DONE_ALL,
@@ -95,20 +95,28 @@ export const DATA_NOTIFICATION: TypesNotification[] = [
 
 export const DATA_IDB: TypesIDB[] = [
   {
-    name: IDB['todo'],
+    dbName: IDB['todo'],
     store: IDB_STORE['todoItems'],
+    oldVersion: IDB_VERSION['previous'],
+    newVersion: IDB_VERSION['current'],
   },
   {
-    name: IDB['idMap'],
+    dbName: IDB['idMap'],
     store: IDB_STORE['idMaps'],
+    oldVersion: IDB_VERSION['previous'],
+    newVersion: IDB_VERSION['current'],
   },
   {
-    name: IDB['user'],
+    dbName: IDB['user'],
     store: IDB_STORE['users'],
+    oldVersion: IDB_VERSION['previous'],
+    newVersion: IDB_VERSION['current'],
   },
   {
-    name: IDB['setting'],
+    dbName: IDB['setting'],
     store: IDB_STORE['settings'],
+    oldVersion: IDB_VERSION['previous'],
+    newVersion: IDB_VERSION['current'],
   },
 ];
 

--- a/lib/data/dataTypesConst.tsx
+++ b/lib/data/dataTypesConst.tsx
@@ -68,6 +68,12 @@ export const CALENDAR = {
   days: 'days',
 } as const;
 
+export type IDB_VERSION = (typeof IDB_VERSION)[keyof typeof IDB_VERSION];
+export const IDB_VERSION = {
+  previous: 0,
+  current: 1,
+};
+
 export type IDB = (typeof IDB)[keyof typeof IDB];
 export const IDB = {
   todo: 'todo',

--- a/lib/states/effects/queryEffects.tsx
+++ b/lib/states/effects/queryEffects.tsx
@@ -1,4 +1,4 @@
-import { IDB_KEY, IDB_KEY_STORE, IDB_STORE, STORAGE_KEY } from '@data/dataTypesConst';
+import { IDB_KEY, IDB_KEY_STORE, IDB_STORE, IDB_VERSION, STORAGE_KEY } from '@data/dataTypesConst';
 import { del, get, set } from '@lib/dataConnections/indexedDB';
 import { TypesRefetchEffect } from '@lib/types';
 import { hasTimePast } from '@states/utils';
@@ -25,7 +25,7 @@ export const queryEffect: TypesRefetchEffect =
 
     //concat indexedDB with data if data is in array
     const concatDataWithIndexedDB = async (data: unknown) => {
-      const indexedDB = await get(storeName, queryKey);
+      const indexedDB = await get(storeName, queryKey, IDB_VERSION['current']);
       const arrayIndexedDB = Array.isArray(indexedDB) && indexedDB;
       const arrayData = Array.isArray(data) && data;
 
@@ -51,7 +51,7 @@ export const queryEffect: TypesRefetchEffect =
         if (Array.isArray(updatedData)) {
           await Promise.all(
             updatedData.map((updatedItem) =>
-              del(IDB_KEY_STORE[queryKey as keyof typeof IDB_KEY_STORE], updatedItem._id),
+              del(IDB_KEY_STORE[queryKey as keyof typeof IDB_KEY_STORE], updatedItem._id, IDB_VERSION['current']),
             ),
           );
         }
@@ -68,35 +68,43 @@ export const queryEffect: TypesRefetchEffect =
     const queryInitial = async () => {
       const { data } = await queryFunction();
       const newData = await concatDataWithIndexedDB(data);
-      isIdMapQueryKey && set(storeName, queryKey + 'Temp', data);
-      set(storeName, queryKey, newData);
+      isIdMapQueryKey && set(storeName, queryKey + 'Temp', data, IDB_VERSION['current']);
+      set(storeName, queryKey, newData, IDB_VERSION['current']);
       return newData as DefaultValue;
     };
 
     //  Re-Sync * the MisMatched* dataSet if local and remote data do not match
     const querySyncData = async () => {
       // do not fetch if item is not updated
-      const indexedDB = await get(IDB_STORE['idMaps'], IDB_KEY_STORE[queryKey as keyof typeof IDB_KEY_STORE] + 'Temp');
+      const indexedDB = await get(
+        IDB_STORE['idMaps'],
+        IDB_KEY_STORE[queryKey as keyof typeof IDB_KEY_STORE] + 'Temp',
+        IDB_VERSION['current'],
+      );
       const isQueryKeyInTemp = Array.isArray(indexedDB) && indexedDB.some((idb) => idb._id === queryKey);
       if (!isQueryKeyInTemp && !isIdMapQueryKey) return;
       // proceed normal fetch
       const { data } = await queryFunction();
       const newData = (await concatDataWithIndexedDB(data)) as DefaultValue;
-      isIdMapQueryKey && set(storeName, queryKey + 'Temp', data);
-      set(storeName, queryKey, newData);
+      isIdMapQueryKey && set(storeName, queryKey + 'Temp', data, IDB_VERSION['current']);
+      set(storeName, queryKey, newData, IDB_VERSION['current']);
       setSelf(newData);
     };
 
     if (trigger === 'get') {
       onIndexedDB && !hasFiveMinTimePast
-        ? setSelf(get(storeName, queryKey).then((value) => (value != null ? value : queryInitial())))
+        ? setSelf(
+            get(storeName, queryKey, IDB_VERSION['current']).then((value) => (value != null ? value : queryInitial())),
+          )
         : setSelf(queryInitial());
     }
 
     onSet((newValue, _, isReset) => {
       // change will directly reflect to the indexedDb.
       //! Recoil Reset will remove the data from indexedDb. Atom must have default value to reset
-      isReset ? del(storeName, queryKey) : set(storeName, queryKey, newValue);
+      isReset
+        ? del(storeName, queryKey, IDB_VERSION['current'])
+        : set(storeName, queryKey, newValue, IDB_VERSION['current']);
 
       // refetch and re-sync indexedDb with database if they are not matching.
       if (isRefetchingOnMutation && typeof isRefetchingOnMutation !== 'undefined' && !isReset) {

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -3,6 +3,7 @@ import {
   DURATION,
   IDB,
   IDB_STORE,
+  IDB_VERSION,
   NOTIFICATION,
   OBJECT_ID,
   PATHNAME,
@@ -138,8 +139,10 @@ export interface TypesNotification {
 }
 
 export interface TypesIDB {
-  name: IDB;
+  dbName: IDB;
   store: IDB_STORE;
+  oldVersion: IDB_VERSION;
+  newVersion: IDB_VERSION;
 }
 
 export interface TypesSidebarMenu {


### PR DESCRIPTION
IndexedDB will now automatically delete the old version and update to the new version upon upgrading the database's version. To maintain consistency across the application, the version is managed using the IDB_VERSION object, which contains `previous` and `current` properties. For example, changing previous from 0 to 1 and current from 1 to 2 will trigger a full page reload, remove the old database, and create a new database with the version number appended to its name (e.g., databaseNamev2).

This ensures consistency in the face of schema changes in indexedDB. Because deleting and creating new databases can be expensive operations, this should only be done when there are schema changes.