### PR TITLE
feat: add authentication as well as the page protection

### DIFF
--- a/components/auth/authForm.tsx
+++ b/components/auth/authForm.tsx
@@ -2,6 +2,7 @@ import { USER } from '@data/dataTypesConst';
 import { atomUserNew } from '@states/users';
 import { useUserCreate, useUserValueUpdate } from '@states/users/hooks';
 import { signIn } from 'next-auth/react';
+import { useRouter } from 'next/router';
 import { FormEvent, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 
@@ -10,17 +11,19 @@ export const AuthForm = () => {
   const user = useRecoilValue(atomUserNew);
   const updateUser = useUserValueUpdate();
   const createUser = useUserCreate();
+  const router = useRouter();
 
   const onSubmitHandler = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    isLogin
-      ? await signIn('credentials', {
-          redirect: false,
-          email: user.email,
-          password: user.password,
-          callbackUrl: `${window.location.origin}`,
-        })
-      : createUser();
+    if (isLogin) {
+      const response = await signIn('credentials', {
+        redirect: false,
+        email: user.email,
+        password: user.password,
+      });
+      return response && !response.error && router.replace('/app');
+    }
+    createUser();
   };
 
   return (

--- a/components/layouts/layoutApp/layout/index.tsx
+++ b/components/layouts/layoutApp/layout/index.tsx
@@ -6,6 +6,7 @@ import { LayoutHeader } from './layoutHeader';
 const LayoutFooter = dynamic(() => import('./layoutFooter').then((mod) => mod.LayoutFooter), {
   ssr: false,
 });
+// const LayoutHeader = dynamic(() => import('./layoutHeader').then((mod) => mod.LayoutHeader), { ssr: false });
 
 export const Layout = ({ children }: Pick<Types, 'children'>) => {
   return (

--- a/components/layouts/layoutApp/layout/layoutHeader/headerUser.tsx
+++ b/components/layouts/layoutApp/layout/layoutHeader/headerUser.tsx
@@ -1,0 +1,31 @@
+import { Button } from '@buttons/button';
+import { STYLE_BUTTON_NORMAL_BLUE } from '@data/stylePreset';
+import { UserDropdown } from '@dropdowns/v2/userDropdown';
+import { atomIDBUserSession } from '@states/users';
+import { UserSessionEffect } from '@states/users/userSessionEffect';
+import { classNames } from '@states/utils';
+import { signIn } from 'next-auth/react';
+import { Fragment } from 'react';
+import { useRecoilValue } from 'recoil';
+
+export const HeaderUser = () => {
+  const isSession = useRecoilValue(atomIDBUserSession);
+
+  return (
+    <Fragment>
+      <UserSessionEffect />
+      {isSession ? (
+        <UserDropdown />
+      ) : (
+        <Button
+          options={{
+            className: classNames(STYLE_BUTTON_NORMAL_BLUE),
+            tooltip: 'Sign in',
+          }}
+          onClick={() => signIn()}>
+          Sign In
+        </Button>
+      )}
+    </Fragment>
+  );
+};

--- a/components/layouts/layoutApp/layout/layoutHeader/index.tsx
+++ b/components/layouts/layoutApp/layout/layoutHeader/index.tsx
@@ -1,24 +1,22 @@
-import { Button } from '@buttons/button';
 import { IconButton } from '@buttons/iconButton';
 import { optionsButtonSidebarToggle } from '@data/dataOptions';
-import { STYLE_BUTTON_NORMAL_BLUE } from '@data/stylePreset';
-import { UserDropdown } from '@dropdowns/v2/userDropdown';
 import { LayoutLogo } from '@layouts/layoutApp/layoutLogo';
 import { useSidebarOpen } from '@states/layouts/hooks';
-import { classNames } from '@states/utils';
-import { signIn, useSession } from 'next-auth/react';
+import dynamic from 'next/dynamic';
 import {
   Fragment as LayoutHeaderFragment,
   Fragment as LeftSideFragment,
   Fragment as LogoFragment,
   Fragment as RightSidebarFragment,
   Fragment as SidebarButtonFragment,
+  Suspense,
 } from 'react';
 import { HeaderSearchBar } from './headerSearchBar';
 
+const HeaderUser = dynamic(() => import('./headerUser').then((mod) => mod.HeaderUser), { ssr: false });
+
 export const LayoutHeader = () => {
   const setSidebarOpen = useSidebarOpen();
-  const { data: session } = useSession();
 
   return (
     <LayoutHeaderFragment>
@@ -43,18 +41,9 @@ export const LayoutHeader = () => {
           <div className='flex flex-1 pl-2 pr-3'>
             <HeaderSearchBar />
             <div className='ml-4 flex items-center md:ml-6'>
-              {session ? (
-                <UserDropdown />
-              ) : (
-                <Button
-                  options={{
-                    className: classNames(STYLE_BUTTON_NORMAL_BLUE),
-                    tooltip: 'Sign in',
-                  }}
-                  onClick={() => signIn()}>
-                  Sign In
-                </Button>
-              )}
+              <Suspense>
+                <HeaderUser />
+              </Suspense>
             </div>
           </div>
         </RightSidebarFragment>

--- a/components/ui/dropdowns/v2/dropdown/menuItem.tsx
+++ b/components/ui/dropdowns/v2/dropdown/menuItem.tsx
@@ -16,7 +16,7 @@ export const MenuItem = ({ options, onClick, children }: Props) => {
 
   return (
     <span>
-      <Tooltip options={options}>
+      <Tooltip options={!isDisabled ? options : {}}>
         <Menu.Item disabled={isDisabled}>
           {({ active }) => (
             <div
@@ -40,7 +40,8 @@ export const MenuItem = ({ options, onClick, children }: Props) => {
                       className: classNames(
                         'mr-3',
                         options.size ?? 'h-5 w-5',
-                        options.color ?? 'fill-gray-500 group-hover/menuItem:fill-gray-700',
+                        options.color ?? 'fill-gray-500',
+                        !options.color && !isDisabled && 'group-hover/menuItem:fill-gray-700',
                       ),
                     }}
                   />

--- a/components/ui/dropdowns/v2/userDropdown.tsx
+++ b/components/ui/dropdowns/v2/userDropdown.tsx
@@ -1,5 +1,6 @@
 import { ICON_LOGOUT, ICON_SETTINGS } from '@data/materialSymbols';
 import { ActiveDropdownMenuItemEffect } from '@states/misc/activeDropdownMenuItemEffect';
+import { signOut } from 'next-auth/react';
 import Image from 'next/image';
 import { Fragment } from 'react';
 import { Dropdown } from './dropdown';
@@ -28,6 +29,7 @@ export const UserDropdown = () => {
           options={{
             path: ICON_SETTINGS,
             tooltip: 'Settings',
+            isDisabled: true,
           }}>
           Settings
         </MenuItem>
@@ -37,7 +39,8 @@ export const UserDropdown = () => {
           options={{
             path: ICON_LOGOUT,
             tooltip: 'Sign out',
-          }}>
+          }}
+          onClick={() => signOut({ callbackUrl: process.env.NEXT_PUBLIC_HOST + '/app' })}>
           Sign out
         </MenuItem>
       </div>

--- a/lib/data/dataTypesConst.tsx
+++ b/lib/data/dataTypesConst.tsx
@@ -94,6 +94,7 @@ export type IDB_KEY = (typeof IDB_KEY)[keyof typeof IDB_KEY];
 export const IDB_KEY = {
   todoIds: 'todoIds',
   labels: 'labels',
+  session: 'session',
 } as const;
 
 export type IDB_KEY_STORE = (typeof IDB_KEY_STORE)[keyof typeof IDB_KEY_STORE];

--- a/lib/states/effects/atomEffects.tsx
+++ b/lib/states/effects/atomEffects.tsx
@@ -1,4 +1,7 @@
-import { TypesAtomEffect, TypesMediaQueryEffect } from '@lib/types';
+import { IDB_VERSION } from '@data/dataTypesConst';
+import { del, get, set } from '@lib/dataConnections/indexedDB';
+import { TypesAtomEffect, TypesIndexedDBEffect, TypesMediaQueryEffect } from '@lib/types';
+import { DefaultValue } from 'recoil';
 
 /**
  * Media Queries
@@ -37,3 +40,18 @@ export const networkStatusEffect: TypesAtomEffect<boolean> = ({ setSelf }) => {
     window.removeEventListener('offline', netWorkOnChange);
   };
 };
+
+export const indexedDBEffect: TypesIndexedDBEffect =
+  ({ storeName, queryKey }) =>
+  ({ onSet, setSelf, trigger }) => {
+    if (trigger === 'get') {
+      setSelf(
+        get(storeName, queryKey, IDB_VERSION['current']).then((value) => (value != null ? value : new DefaultValue())),
+      );
+    }
+    onSet((newValue, _, isReset) => {
+      isReset
+        ? del(storeName, queryKey, IDB_VERSION['current'])
+        : set(storeName, queryKey, newValue, IDB_VERSION['current']);
+    });
+  };

--- a/lib/states/users/index.tsx
+++ b/lib/states/users/index.tsx
@@ -1,7 +1,20 @@
+import { IDB_KEY, IDB_STORE } from '@data/dataTypesConst';
+import { indexedDBEffect } from '@effects/atomEffects';
 import { Users } from '@lib/types';
 import { atom } from 'recoil';
 
 export const atomUserNew = atom<Users>({
   key: 'atomUserNew',
   default: { email: '', password: '' } as Users,
+});
+
+export const atomIDBUserSession = atom<boolean>({
+  key: 'atomIDBUserSession',
+  default: false,
+  effects: [
+    indexedDBEffect({
+      storeName: IDB_STORE['users'],
+      queryKey: IDB_KEY['session'],
+    }),
+  ],
 });

--- a/lib/states/users/userSessionEffect.tsx
+++ b/lib/states/users/userSessionEffect.tsx
@@ -1,0 +1,24 @@
+import { useSession } from 'next-auth/react';
+import { useEffect } from 'react';
+import { RecoilValue, useRecoilCallback } from 'recoil';
+import { atomIDBUserSession } from '.';
+
+export const UserSessionEffect = () => {
+  const { status } = useSession();
+
+  const userSession = useRecoilCallback(({ set, reset, snapshot }) => () => {
+    const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
+
+    if (status === 'authenticated') {
+      !get(atomIDBUserSession) && set(atomIDBUserSession, true);
+      return;
+    }
+    get(atomIDBUserSession) && reset(atomIDBUserSession);
+    return;
+  });
+
+  useEffect(() => {
+    userSession();
+  }, [userSession]);
+  return null;
+};

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -377,6 +377,11 @@ export type TypesRefetchEffect = <T>({
 > &
   Pick<Types, 'queryFunction' | 'queryKey' | 'storeName'>) => AtomEffect<T>;
 
+export type TypesIndexedDBEffect = <T>({
+  storeName,
+  queryKey,
+}: Pick<Types, 'storeName' | 'queryKey'>) => AtomEffect<T | boolean>;
+
 export type TypesMediaQueryEffect = <T>({
   breakpoint,
   isStateUnderBreakpoint,

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,11 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function middleware(req: NextRequest) {
+  const session = req.cookies.get('next-auth.session-token');
+
+  if (req.nextUrl.pathname.match('/auth')) {
+    if (session) {
+      return NextResponse.redirect(new URL('/app', req.url));
+    }
+    return;
+  }
   if (req.nextUrl.pathname.match('/')) {
     return NextResponse.redirect(new URL('/app', req.url));
   }
 }
 
 export const config = {
-  matcher: ['/'],
+  matcher: ['/', '/auth'],
 };

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -17,11 +17,13 @@ const MyApp = ({ Component, pageProps: { session, ...pageProps } }: AppPropsWith
   const getLayout = Component.getLayout ?? ((page) => page);
 
   return (
-    <SessionProvider
-      session={session}
-      basePath={process.env.NEXT_PUBLIC_NEXTAUTH_BASE_PATH}>
-      <RecoilRoot>{getLayout(<Component {...pageProps} />)}</RecoilRoot>
-    </SessionProvider>
+    <RecoilRoot>
+      <SessionProvider
+        session={session}
+        basePath={process.env.NEXT_PUBLIC_NEXTAUTH_BASE_PATH}>
+        {getLayout(<Component {...pageProps} />)}
+      </SessionProvider>
+    </RecoilRoot>
   );
 };
 

--- a/pages/api/v1/auth/[...nextauth].tsx
+++ b/pages/api/v1/auth/[...nextauth].tsx
@@ -33,10 +33,15 @@ export default NextAuth({
   ],
   pages: {
     signIn: '/auth',
+    signOut: '/app',
   },
   adapter: MongoDBAdapter(clientPromise),
   session: {
     strategy: 'jwt',
   },
   debug: process.env.NODE_ENV === 'development',
+  jwt: {
+    secret: process.env.NEXTAUTH_JWT_SECRET,
+  },
+  secret: process.env.NEXTAUTH_SECRET,
 });

--- a/pages/auth.tsx
+++ b/pages/auth.tsx
@@ -6,7 +6,7 @@ const Auth = () => {
   return (
     <Fragment>
       <Head>
-        <title>My Todo App: Log in</title>
+        <title>My Todo App: Sign in</title>
       </Head>
       <div className='mt-20 flex flex-row items-center justify-center'>
         <AuthForm />


### PR DESCRIPTION
Users can now sign in and sign out, and will be redirected to the home page. The current default page is set to '/app'. The page protection, which redirects unauthorized users to the sign-in page, is implemented using Next.js middleware. The middleware can provide a fast response before a request is even made, and can run on both the server and client.

To improve consistency, the header title of the sign-in page is updated.

To resolve flickering issues when using next-auth with client-side only, the atomEffect is added. The atomEffect, atomUserSession, can store and delete the boolean value of the user's session in indexedDB temporarily, preventing flickering issues.