### PR TITLE
feat: add auto-deletion of old IndexedDB versions

### DIFF
--- a/lib/data/dataArrayOfObjects.tsx
+++ b/lib/data/dataArrayOfObjects.tsx
@@ -97,26 +97,22 @@ export const DATA_IDB: TypesIDB[] = [
   {
     dbName: IDB['todo'],
     store: IDB_STORE['todoItems'],
-    oldVersion: IDB_VERSION['previous'],
-    newVersion: IDB_VERSION['current'],
+    currentVersion: IDB_VERSION['current'],
   },
   {
     dbName: IDB['idMap'],
     store: IDB_STORE['idMaps'],
-    oldVersion: IDB_VERSION['previous'],
-    newVersion: IDB_VERSION['current'],
+    currentVersion: IDB_VERSION['current'],
   },
   {
     dbName: IDB['user'],
     store: IDB_STORE['users'],
-    oldVersion: IDB_VERSION['previous'],
-    newVersion: IDB_VERSION['current'],
+    currentVersion: IDB_VERSION['current'],
   },
   {
     dbName: IDB['setting'],
     store: IDB_STORE['settings'],
-    oldVersion: IDB_VERSION['previous'],
-    newVersion: IDB_VERSION['current'],
+    currentVersion: IDB_VERSION['current'],
   },
 ];
 

--- a/lib/data/dataTypesConst.tsx
+++ b/lib/data/dataTypesConst.tsx
@@ -71,7 +71,6 @@ export const CALENDAR = {
 export type IDB_VERSION = (typeof IDB_VERSION)[keyof typeof IDB_VERSION];
 export const IDB_VERSION = {
   current: Number(process.env.NEXT_PUBLIC_IDB_VERSION_CURRENT),
-  previous: Number(process.env.NEXT_PUBLIC_IDB_VERSION_CURRENT) - 1,
 };
 
 export type IDB = (typeof IDB)[keyof typeof IDB];

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -142,8 +142,7 @@ export interface TypesNotification {
 export interface TypesIDB {
   dbName: IDB;
   store: IDB_STORE;
-  oldVersion: IDB_VERSION;
-  newVersion: IDB_VERSION;
+  currentVersion: IDB_VERSION;
 }
 
 export interface TypesSidebarMenu {


### PR DESCRIPTION
IndexedDB will now automatically find and delete old versions whenever there is a version upgrade. Previously, the scope of deletion was limited to the current version minus one. However, since there may be multiple versioning jumps (e.g. upgrading from version 2 to version 5), the new deletion method ensures that any old version is deleted.

Note: Due to IndexedDB does not allow downgrading of the version, only lower versions will be considered.