### PR TITLE
feat: add deletion of indexedDB and localStorage upon sign out

### DIFF
--- a/lib/dataConnections/indexedDB.ts
+++ b/lib/dataConnections/indexedDB.ts
@@ -15,12 +15,13 @@ const dbPromise = async (storeName: Types['storeName'], dbVersion?: Types['dbVer
     // To auto upgrade indexedDB, update the IDB_VERSION's previous and current.
     // The purpose of upgrade is the schema changes in indexedDB
     upgrade(db) {
-      db.createObjectStore(storeName);
+      const objectStore = db.createObjectStore(storeName);
+      objectStore.put(true, storeName + 'Data');
     },
   });
-  if (oldIDBNames) {
-    await Promise.all(oldIDBNames.map((dbName) => dbName && deleteDB(dbName)));
-  }
+  if (oldIDBNames) await Promise.all(oldIDBNames.map((dbName) => dbName && deleteDB(dbName)));
+  // if (!session) await Promise.all(allIDBs.map((idb) => idb && deleteDB(idb.name as IDB)));
+
   return db;
 };
 


### PR DESCRIPTION
Implemented client storage actions to delete the indexedDB and localStorage whenever a user signs out. The data is completely destroyed instead of just being cleared out. This ensures that data stored on the client-side is not accessible by other users."