### PR TITLE
feat: add the OAuth, Google and GitHub

### DIFF
--- a/components/auth/authForm.tsx
+++ b/components/auth/authForm.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@buttons/button';
+import { SvgLogoButton } from '@buttons/button/svgLogoButton';
 import { optionsFloatingLabelsEmail } from '@data/dataOptions';
 import { ERROR_TYPE, USER } from '@data/dataTypesConst';
 import { STYLE_BUTTON_FULL_BLUE } from '@data/stylePreset';
@@ -6,6 +7,7 @@ import { FloatingLabelInput } from '@inputs/floatingLabelInput';
 import { atomUserError, atomUser } from '@states/users';
 import { useUserAuthFormSubmit, useUserValueUpdate } from '@states/users/hooks';
 import { classNames, validateEmailFormat } from '@states/utils';
+import { Divider } from '@ui/dividers/divider';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { AuthErrorMessage } from './authErrorMessage';
 
@@ -59,6 +61,9 @@ export const AuthForm = () => {
             }}>
             Sign in with email
           </Button>
+          <div className='mb-5' />
+          <Divider margin='mb-5'>or</Divider>
+          <SvgLogoButton />
         </form>
       </section>
     </div>

--- a/components/icons/svgLogo.tsx
+++ b/components/icons/svgLogo.tsx
@@ -1,0 +1,24 @@
+import { DATA_SVG_LOGO } from '@data/dataArrayOfObjects';
+import { SVG_LOGO } from '@data/dataTypesConst';
+import { TypesOptionsSvg } from '@lib/types/typesOptions';
+
+type Props = { options: TypesOptionsSvg } & { svgLogo: SVG_LOGO };
+
+export const SvgLogo = ({ svgLogo, options }: Props) => {
+  const dataLogo = DATA_SVG_LOGO.filter((logo) => logo.name === svgLogo);
+  return (
+    <>
+      {dataLogo.map((logo) => (
+        <svg
+          key={logo.name}
+          xmlns='http://www.w3.org/2000/svg'
+          aria-hidden={true}
+          height={options.height ?? '24'}
+          width={options.width ?? '24'}
+          viewBox={logo.viewBox}>
+          {logo.path}
+        </svg>
+      ))}
+    </>
+  );
+};

--- a/components/layouts/layoutApp/layout/index.tsx
+++ b/components/layouts/layoutApp/layout/index.tsx
@@ -6,7 +6,6 @@ import { LayoutHeader } from './layoutHeader';
 const LayoutFooter = dynamic(() => import('./layoutFooter').then((mod) => mod.LayoutFooter), {
   ssr: false,
 });
-// const LayoutHeader = dynamic(() => import('./layoutHeader').then((mod) => mod.LayoutHeader), { ssr: false });
 
 export const Layout = ({ children }: Pick<Types, 'children'>) => {
   return (

--- a/components/ui/buttons/button/svgLogoButton.tsx
+++ b/components/ui/buttons/button/svgLogoButton.tsx
@@ -1,0 +1,37 @@
+import { DATA_SVG_LOGO } from '@data/dataArrayOfObjects';
+import { TypesOptionsSvg } from '@lib/types/typesOptions';
+import { signIn } from 'next-auth/react';
+import { Button } from '.';
+
+type Props = { options?: TypesOptionsSvg };
+
+export const SvgLogoButton = ({ options = {} }: Props) => {
+  return (
+    <>
+      {DATA_SVG_LOGO.map((logo) => (
+        <div
+          key={logo.name}
+          className='mb-3'>
+          <Button
+            options={{
+              type: 'button',
+              className: logo.className,
+            }}
+            onClick={() => signIn(logo.name.toLowerCase())}>
+            <span className='pr-2'>
+              <svg
+                xmlns='http://www.w3.org/2000/svg'
+                aria-hidden={true}
+                height={options.height ?? '24'}
+                width={options.width ?? '24'}
+                viewBox={logo.viewBox}>
+                {logo.path}
+              </svg>
+            </span>
+            <span>Continue with {logo.name}</span>
+          </Button>
+        </div>
+      ))}
+    </>
+  );
+};

--- a/components/ui/dividers/divider/index.tsx
+++ b/components/ui/dividers/divider/index.tsx
@@ -1,18 +1,19 @@
 import { Types } from '@lib/types';
+import { classNames } from '@states/utils';
 
-type Props = Partial<Pick<Types, 'children'>>;
+type Props = Partial<Pick<Types, 'children' | 'margin'>>;
 
-export const Divider = ({ children }: Props) => {
+export const Divider = ({ children, margin }: Props) => {
   return (
-    <div className='relative'>
-      <div className='absolute inset-0 flex items-center' aria-hidden='true'>
+    <div className={classNames('relative', margin)}>
+      <div
+        className='absolute inset-0 flex items-center'
+        aria-hidden='true'>
         <div className='w-full border-t border-gray-200' />
       </div>
       {children && (
         <div className='relative flex justify-center'>
-          <span className='bg-white px-2 text-sm text-gray-500'>
-            {children}
-          </span>
+          <span className='bg-slate-50 px-2 text-sm text-gray-500'>{children}</span>
         </div>
       )}
     </div>

--- a/lib/data/dataArrayOfObjects.tsx
+++ b/lib/data/dataArrayOfObjects.tsx
@@ -1,5 +1,5 @@
-import { TypesIDB, TypesNotification, TypesPathnameImage, TypesSidebarMenu } from 'lib/types';
-import { IDB, IDB_STORE, IDB_VERSION, NOTIFICATION, PATHNAME } from './dataTypesConst';
+import { TypesIDB, TypesNotification, TypesPathnameImage, TypesSidebarMenu, TypesSvgLogo } from 'lib/types';
+import { IDB, IDB_STORE, IDB_VERSION, NOTIFICATION, PATHNAME, SVG_LOGO } from './dataTypesConst';
 import {
   ICON_DELETE,
   ICON_DONE_ALL,
@@ -197,5 +197,62 @@ export const DATA_PATHNAME_IMAGE: TypesPathnameImage[] = [
     alt: 'Placeholder image of label',
     title: 'Your labeled todos',
     description: 'Organize your todos by using labels to keep track of your progress and priorities.',
+  },
+];
+
+export const DATA_SVG_LOGO: TypesSvgLogo[] = [
+  {
+    name: SVG_LOGO['google'],
+    viewBox: '0 0 32 32',
+    className:
+      'flex w-full flex-row items-center justify-center rounded-lg border border-slate-100 p-2 shadow-md shadow-slate-300 text-slate-800 transition-all hover:shadow-lg',
+    path: (
+      <>
+        <path
+          fill='#00ac47'
+          d='M23.75,16A7.7446,7.7446,0,0,1,8.7177,18.6259L4.2849,22.1721A13.244,13.244,0,0,0,29.25,16'
+        />
+        <path
+          fill='#4285f4'
+          d='M23.75,16a7.7387,7.7387,0,0,1-3.2516,6.2987l4.3824,3.5059A13.2042,13.2042,0,0,0,29.25,16'
+        />
+        <path
+          fill='#ffba00'
+          d='M8.25,16a7.698,7.698,0,0,1,.4677-2.6259L4.2849,9.8279a13.177,13.177,0,0,0,0,12.3442l4.4328-3.5462A7.698,7.698,0,0,1,8.25,16Z'
+        />
+        <polygon
+          fill='#2ab2db'
+          points='8.718 13.374 8.718 13.374 8.718 13.374 8.718 13.374'
+        />
+        <path
+          fill='#ea4435'
+          d='M16,8.25a7.699,7.699,0,0,1,4.558,1.4958l4.06-3.7893A13.2152,13.2152,0,0,0,4.2849,9.8279l4.4328,3.5462A7.756,7.756,0,0,1,16,8.25Z'
+        />
+        <polygon
+          fill='#2ab2db'
+          points='8.718 18.626 8.718 18.626 8.718 18.626 8.718 18.626'
+        />
+        <path
+          fill='#4285f4'
+          d='M29.25,15v1L27,19.5H16.5V14H28.25A1,1,0,0,1,29.25,15Z'
+        />
+      </>
+    ),
+  },
+  {
+    name: SVG_LOGO['github'],
+    className:
+      'flex w-full flex-row items-center justify-center rounded-lg border border-slate-800 p-2 bg-gray-800 shadow-lg shadow-slate-500 hover:shadow-slate-600 transition-all text-white',
+    viewBox: '0 0 24 24',
+    path: (
+      <>
+        <path
+          id='Path'
+          fill='#ffffff'
+          stroke='none'
+          d='M 12 2.2467 C 7.095412 2.246902 2.914784 5.803928 2.129133 10.645183 C 1.343482 15.486437 4.184698 20.182985 8.83752 21.73419 C 9.33752 21.821711 9.52502 21.521721 9.52502 21.25919 C 9.52502 21.0217 9.51251 20.23419 9.51251 19.3967 C 7 19.85919 6.35 18.784229 6.15 18.221729 C 5.928076 17.674654 5.576275 17.189846 5.125 16.8092 C 4.775 16.6217 4.275 16.159201 5.11249 16.146721 C 5.761497 16.217144 6.335357 16.599705 6.65 17.17169 C 6.926231 17.667921 7.388598 18.033815 7.935032 18.188601 C 8.481467 18.343386 9.067038 18.274334 9.56248 17.996691 C 9.605771 17.488312 9.832339 17.012993 10.2 16.659229 C 7.975 16.409229 5.65 15.54669 5.65 11.72173 C 5.635948 10.727876 6.002686 9.766307 6.675 9.03423 C 6.369282 8.170449 6.405053 7.222513 6.775 6.38423 C 6.775 6.38423 7.61247 6.121719 9.525 7.409229 C 11.161288 6.959204 12.888712 6.959204 14.525 7.409229 C 16.437481 6.10923 17.275 6.38423 17.275 6.38423 C 17.644997 7.222502 17.680769 8.170457 17.375 9.03423 C 18.049339 9.765055 18.416397 10.727462 18.4 11.72173 C 18.4 15.5592 16.062481 16.409229 13.8375 16.659229 C 14.320393 17.148668 14.56673 17.823814 14.5125 18.50923 C 14.5125 19.84675 14.49999 20.921709 14.49999 21.25923 C 14.49999 21.52174 14.68749 21.83423 15.18749 21.73423 C 19.831736 20.170498 22.659912 15.473108 21.868879 10.636937 C 21.077848 5.800766 16.900436 2.24925 12 2.2467 Z'
+        />
+      </>
+    ),
   },
 ];

--- a/lib/data/dataTypesConst.tsx
+++ b/lib/data/dataTypesConst.tsx
@@ -186,3 +186,9 @@ export const ERROR_TYPE = {
   server: 'server',
   client: 'client',
 };
+
+export type SVG_LOGO = (typeof SVG_LOGO)[keyof typeof SVG_LOGO];
+export const SVG_LOGO = {
+  google: 'Google',
+  github: 'GitHub',
+};

--- a/lib/data/stylePreset.tsx
+++ b/lib/data/stylePreset.tsx
@@ -5,7 +5,7 @@ import { classNames } from '@states/utils';
  */
 // Base
 export const STYLE_BUTTON_BASE =
-  'inline-flex items-center justify-center rounded-lg border leading-4 shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2';
+  'transition-all inline-flex items-center justify-center rounded-lg border leading-4 shadow-lg shadow-blue-100 hover:shadow-blue-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2';
 export const STYLE_BUTTON_SIZE_NORMAL = 'py-[0.6rem] px-6 text-sm';
 export const STYLE_BUTTON_SIZE_LARGE = 'py-[0.6rem] px-14 text-sm';
 export const STYLE_BUTTON_SIZE_FULL = 'py-[0.7rem] px-14 text-base';

--- a/lib/models/User/index.ts
+++ b/lib/models/User/index.ts
@@ -1,28 +1,24 @@
 import mongoose from 'mongoose';
 
-const UserSchema = new mongoose.Schema(
-  {
-    email: {
-      type: String,
-      required: true,
-      trim: true,
-      lowercase: true,
-      unique: true,
-    },
-    password: {
-      type: String,
-      required: true,
-      trim: true,
-      unique: true,
-      minLength: 8,
-      maxLength: 100,
-    },
+const UserSchema = new mongoose.Schema({
+  email: {
+    type: String,
+    required: true,
+    trim: true,
+    lowercase: true,
+    unique: true,
   },
-  {
-    timestamps: true,
+  name: {
+    type: String,
+    required: false,
   },
-);
+  image: {
+    type: String,
+    required: false,
+  },
+});
 
-UserSchema.index({ email: 'text' });
+// next-auth is already indexing the user's information. Additional indexing such
+// as `UserSchema.index({email: text})` will cause issue with login.
 
 export default mongoose.models.User || mongoose.model('User', UserSchema);

--- a/lib/states/users/hooks.tsx
+++ b/lib/states/users/hooks.tsx
@@ -26,16 +26,20 @@ export const useUserAuthFormSubmit = (isError: Types['isError']) => {
 
   return async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (isError) setClientError(true);
+    if (isError) {
+      setClientError(true);
+      return;
+    }
     if (isClientError || isServerError) return;
-    const userEmailSent = async () => {
-      return await signIn('email', {
-        redirect: false,
-        email: user.email,
-      });
-    };
 
     try {
+      const userEmailSent = async () => {
+        return await signIn('email', {
+          redirect: false,
+          email: user.email,
+        });
+      };
+
       const response = await userEmailSent();
       if (response && !response.error) {
         setIsVerificationRequested(true);

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -11,6 +11,7 @@ import {
   POSITION_X,
   POSITION_Y,
   PRIORITY_LEVEL,
+  SVG_LOGO,
   VIEWBOX,
 } from '@data/dataTypesConst';
 import { Placement } from '@popperjs/core';
@@ -169,6 +170,12 @@ export interface TypesPathnameImage {
   description: string;
 }
 
+export interface TypesSvgLogo {
+  name: SVG_LOGO;
+  className: Types['className'];
+  viewBox: string;
+  path: ReactElement;
+}
 /**
  * Types MISC.
  */

--- a/pages/api/v1/auth/[...nextauth].tsx
+++ b/pages/api/v1/auth/[...nextauth].tsx
@@ -3,6 +3,8 @@ import { MongoDBAdapter } from '@next-auth/mongodb-adapter';
 import type { NextAuthOptions } from 'next-auth';
 import NextAuth from 'next-auth';
 import EmailProvider from 'next-auth/providers/email';
+import GoogleProvider from 'next-auth/providers/google';
+import GitHubProvider from 'next-auth/providers/github';
 
 export const authOptions: NextAuthOptions = {
   providers: [
@@ -16,6 +18,14 @@ export const authOptions: NextAuthOptions = {
         },
       },
       from: process.env.EMAIL_FROM,
+    }),
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID as string,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
+    }),
+    GitHubProvider({
+      clientId: process.env.GITHUB_CLIENT_ID as string,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET as string,
     }),
   ],
   callbacks: {


### PR DESCRIPTION
Add OAuth login for Google and Github. The sign-in process now includes the OAuth login for these providers as well as magic link email login.

The custom SvgLogoButton component was added to enable the OAuth login. This component renders a list of OAuth logins using an array of objects. Currently, the data set only includes Google and Github.