### PR TITLE
feat: add custom server-side error handling to nextauth

### DIFF
--- a/components/auth/authErrorMessage.tsx
+++ b/components/auth/authErrorMessage.tsx
@@ -1,23 +1,42 @@
 import { SvgIcon } from '@components/icons/svgIcon';
+import { DATA_NEXTAUTH_ERROR } from '@data/dataArrayOfObjects';
 import { ICON_ERROR_FILL } from '@data/materialSymbols';
 import { TypesOptionsAuthErrorMessage } from '@lib/types/typesOptions';
+import { atomUserErrorMessage } from '@states/users';
 import { classNames } from '@states/utils';
+import { useNextQuery } from '@states/utils/hooks';
+import { useEffect } from 'react';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
-type Props = { options: TypesOptionsAuthErrorMessage };
+type Props = { options?: TypesOptionsAuthErrorMessage };
 
 export const AuthErrorMessage = ({ options }: Props) => {
+  const errorId = useNextQuery({ key: 'error' })?.toLowerCase();
+  const serverError = DATA_NEXTAUTH_ERROR.find((error) => error._id === errorId);
+  const clientErrorMessage = useRecoilValue(atomUserErrorMessage);
+  const setClientErrorMessage = useSetRecoilState(atomUserErrorMessage);
+
+  useEffect(() => {
+    const errorMessage = serverError ? serverError.message : '';
+    setClientErrorMessage(errorMessage as string);
+  }, [serverError, setClientErrorMessage]);
+
   return (
-    <span className='mt-1 ml-1 flex flex-row items-start'>
+    <span
+      className={classNames(
+        'mt-1 ml-1 flex flex-row items-start',
+        clientErrorMessage ? 'mb-5 rounded-xl bg-red-100 p-2' : 'mb-0',
+      )}>
       <span className='h-full pr-1'>
         <SvgIcon
           options={{
-            path: options.isError ? ICON_ERROR_FILL : '',
-            className: classNames('w-[1.2rem] h-[1.2rem] mr-1', options.isError && 'fill-red-600'),
+            path: clientErrorMessage ? ICON_ERROR_FILL : '',
+            className: classNames('w-[1.2rem] h-[1.2rem] mr-1', clientErrorMessage && 'fill-red-600'),
           }}
         />
       </span>
-      <p className={classNames('text-sm', options.isError && 'text-red-600')}>
-        {options.isError ? options.errorMessage : options.defaultMessage}
+      <p className={classNames('text-sm', clientErrorMessage && 'text-red-600')}>
+        {clientErrorMessage ? clientErrorMessage : options?.defaultMessage}
       </p>
     </span>
   );

--- a/components/auth/authForm.tsx
+++ b/components/auth/authForm.tsx
@@ -2,74 +2,65 @@ import { Button } from '@buttons/button';
 import { SvgLogoButton } from '@buttons/button/svgLogoButton';
 import { LoadingSpinner } from '@components/loadable/loadingSpinner';
 import { optionsFloatingLabelsEmail } from '@data/dataOptions';
-import { ERROR_TYPE, SPINNER, USER } from '@data/dataTypesConst';
+import { SPINNER, USER } from '@data/dataTypesConst';
 import { STYLE_BUTTON_FULL_BLUE } from '@data/stylePreset';
 import { FloatingLabelInput } from '@inputs/floatingLabelInput';
 import { atomLoadingSpinner } from '@states/misc';
-import { atomUserError, atomUser } from '@states/users';
+import { atomUser, atomUserErrorMessage } from '@states/users';
+import { ClientErrorMessageEffect } from '@states/users/clientErrorMessageEffect';
 import { useUserAuthFormSubmit, useUserValueUpdate } from '@states/users/hooks';
 import { classNames, validateEmailFormat } from '@states/utils';
 import { Divider } from '@ui/dividers/divider';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { Fragment } from 'react';
+import { useRecoilValue } from 'recoil';
 import { AuthErrorMessage } from './authErrorMessage';
 
 export const AuthForm = () => {
-  const isServerError = useRecoilValue(atomUserError(ERROR_TYPE['server']));
-  const isClientError = useRecoilValue(atomUserError(ERROR_TYPE['client']));
-  const setClientError = useSetRecoilState(atomUserError(ERROR_TYPE['client']));
-  const isError = isServerError || isClientError;
+  const clientErrorMessage = useRecoilValue(atomUserErrorMessage);
   const user = useRecoilValue(atomUser);
-  const updateUser = useUserValueUpdate();
   const isEmailInValidated = !validateEmailFormat(user.email);
+  const updateUser = useUserValueUpdate();
   const onSubmitHandler = useUserAuthFormSubmit(isEmailInValidated);
-  const isLoadingSpinner = useRecoilValue(atomLoadingSpinner(SPINNER['authFrom']));
+  const isLoadingSpinner = useRecoilValue(atomLoadingSpinner(SPINNER['authForm']));
+  const isError = clientErrorMessage !== '';
 
   return (
-    <div className='absolute right-0 left-0 top-[5%] bottom-[50%] m-auto h-fit w-full sm:top-[30%] sm:w-fit'>
-      <section className='border-slate-150 px-5 py-14 sm:w-[30rem] sm:rounded-xl sm:border sm:px-10 sm:shadow-2xl sm:shadow-slate-300'>
-        <div className='mb-8 flex flex-col items-center justify-center'>
-          <h1 className='mb-4 flex flex-row items-center justify-center text-2xl text-slate-700'>Sign in</h1>
-          <h2 className='flex flex-row items-center justify-center text-lg text-slate-600'>
-            Use your email to sign in
-          </h2>
-        </div>
-        <form
-          onSubmit={onSubmitHandler}
-          noValidate>
-          <div className={classNames(isError ? 'mb-4' : 'mb-1')}>
-            <FloatingLabelInput
-              options={optionsFloatingLabelsEmail(isError)}
-              inputValue={user.email}
-              onChange={(event) => {
-                updateUser(USER['email'], event.target.value);
-                !isEmailInValidated && setClientError(false);
-              }}
-            />
-            <AuthErrorMessage
-              options={{
-                isError: isError,
-                errorMessage: isClientError
-                  ? 'Please enter a valid email address'
-                  : isServerError
-                  ? 'Something went wrong. Please try again'
-                  : '',
-              }}
-            />
+    <Fragment>
+      <ClientErrorMessageEffect />
+      <div className='absolute right-0 left-0 top-[5%] bottom-[50%] m-auto h-fit w-full sm:top-[30%] sm:w-fit'>
+        <section className='border-slate-150 px-5 py-14 sm:w-[30rem] sm:rounded-xl sm:border sm:px-10 sm:shadow-2xl sm:shadow-slate-300'>
+          <div className='mb-5 flex flex-col items-center justify-center'>
+            <h1 className='mb-4 flex flex-row items-center justify-center text-2xl text-slate-700'>Sign in</h1>
+            <h2 className='flex flex-row items-center justify-center text-lg text-slate-600'>
+              Use your email to sign in
+            </h2>
           </div>
-          <Button
-            options={{
-              type: 'submit',
-              className: classNames(STYLE_BUTTON_FULL_BLUE, 'w-full flex flex-row justify-center'),
-              isDisabled: isClientError || isLoadingSpinner,
-            }}>
-            <LoadingSpinner spinnerId={SPINNER['authFrom']} />
-            <div>Sign in with email</div>
-          </Button>
-          <div className='mb-5' />
-          <Divider margin='mb-5'>or</Divider>
-          <SvgLogoButton />
-        </form>
-      </section>
-    </div>
+          <AuthErrorMessage />
+          <form
+            onSubmit={onSubmitHandler}
+            noValidate>
+            <div className='mb-4'>
+              <FloatingLabelInput
+                options={optionsFloatingLabelsEmail(isError)}
+                inputValue={user.email}
+                onChange={(event) => updateUser(USER['email'], event.target.value)}
+              />
+            </div>
+            <Button
+              options={{
+                type: 'submit',
+                className: classNames(STYLE_BUTTON_FULL_BLUE, 'w-full flex flex-row justify-center'),
+                isDisabled: isError || isLoadingSpinner,
+              }}>
+              <LoadingSpinner spinnerId={SPINNER['authForm']} />
+              <div>Sign in with email</div>
+            </Button>
+            <div className='mb-5' />
+            <Divider margin='mb-5'>or</Divider>
+            <SvgLogoButton />
+          </form>
+        </section>
+      </div>
+    </Fragment>
   );
 };

--- a/components/labels/labelItem.tsx
+++ b/components/labels/labelItem.tsx
@@ -8,7 +8,7 @@ import { Types } from '@lib/types';
 import { useSidebarOpen } from '@states/layouts/hooks';
 import { atomMediaQuery } from '@states/misc';
 import { classNames, paths } from '@states/utils';
-import { useNextQuerySlug } from '@states/utils/hooks';
+import { useNextQuery } from '@states/utils/hooks';
 import dynamic from 'next/dynamic';
 import { Fragment, Fragment as LabelModalFragment } from 'react';
 import { useRecoilValue } from 'recoil';
@@ -22,7 +22,7 @@ const DeleteLabelConfirmModal = dynamic(() =>
 );
 
 export const LabelItem = ({ label }: Pick<Types, 'label'>) => {
-  const slug = useNextQuerySlug('/app/label');
+  const slug = useNextQuery({ path: '/app/label' });
   const matchedSlug = slug === label._id;
   const isBreakpointMd = useRecoilValue(atomMediaQuery(BREAKPOINT['md']));
   const setSideBarOpen = useSidebarOpen();

--- a/components/ui/buttons/button/svgLogoButton.tsx
+++ b/components/ui/buttons/button/svgLogoButton.tsx
@@ -1,11 +1,23 @@
 import { DATA_SVG_LOGO } from '@data/dataArrayOfObjects';
+import { TypesSvgLogo } from '@lib/types';
 import { TypesOptionsSvg } from '@lib/types/typesOptions';
 import { signIn } from 'next-auth/react';
+import { useRouter } from 'next-router-mock';
 import { Button } from '.';
 
 type Props = { options?: TypesOptionsSvg };
 
 export const SvgLogoButton = ({ options = {} }: Props) => {
+  const router = useRouter();
+
+  const oAuthSignIn = async (logo: TypesSvgLogo) => {
+    const response = await signIn(logo.name.toLowerCase(), { redirect: false });
+    if (response && !response.error) {
+      router.replace('/');
+      return;
+    }
+  };
+
   return (
     <>
       {DATA_SVG_LOGO.map((logo) => (
@@ -17,7 +29,7 @@ export const SvgLogoButton = ({ options = {} }: Props) => {
               type: 'button',
               className: logo.className,
             }}
-            onClick={() => signIn(logo.name.toLowerCase())}>
+            onClick={() => oAuthSignIn(logo)}>
             <span className='pr-2'>
               <svg
                 xmlns='http://www.w3.org/2000/svg'

--- a/lib/data/dataArrayOfObjects.tsx
+++ b/lib/data/dataArrayOfObjects.tsx
@@ -1,4 +1,11 @@
-import { TypesIDB, TypesNotification, TypesPathnameImage, TypesSidebarMenu, TypesSvgLogo } from 'lib/types';
+import {
+  TypesIDB,
+  TypesNextAuthError,
+  TypesNotification,
+  TypesPathnameImage,
+  TypesSidebarMenu,
+  TypesSvgLogo,
+} from 'lib/types';
 import { IDB, IDB_STORE, IDB_VERSION, NOTIFICATION, PATHNAME, SVG_LOGO } from './dataTypesConst';
 import {
   ICON_DELETE,
@@ -254,5 +261,52 @@ export const DATA_SVG_LOGO: TypesSvgLogo[] = [
         />
       </>
     ),
+  },
+];
+
+export const DATA_NEXTAUTH_ERROR: TypesNextAuthError[] = [
+  {
+    _id: 'default',
+    message: 'Unable to sign in.',
+  },
+  {
+    _id: 'signin',
+    message: 'Try signing in with a different account.',
+  },
+  {
+    _id: 'oauthsignin',
+    message: 'Try signing in with a different account.',
+  },
+  {
+    _id: 'oauthcallback',
+    message: 'Try signing in with a different account.',
+  },
+  {
+    _id: 'oauthcreateaccount',
+    message: 'Try signing in with a different account.',
+  },
+  {
+    _id: 'emailcreateaccount',
+    message: 'Try signing in with a different account.',
+  },
+  {
+    _id: 'callback',
+    message: 'Try signing in with a different account.',
+  },
+  {
+    _id: 'oauthaccountnotlinked',
+    message: 'To confirm your identity, sign in with the same account you used originally.',
+  },
+  {
+    _id: 'emailsignin',
+    message: 'The e-mail could not be sent.',
+  },
+  {
+    _id: 'credentialssignin',
+    message: 'Sign in failed. Check the details you provided are correct.',
+  },
+  {
+    _id: 'sessionrequired',
+    message: 'Please sign in to access this page.',
   },
 ];

--- a/lib/data/dataTypesConst.tsx
+++ b/lib/data/dataTypesConst.tsx
@@ -181,12 +181,6 @@ export const VIEWBOX = {
   96: '0 96 960 960',
 } as const;
 
-export type ERROR_TYPE = (typeof ERROR_TYPE)[keyof typeof ERROR_TYPE];
-export const ERROR_TYPE = {
-  server: 'server',
-  client: 'client',
-};
-
 export type SVG_LOGO = (typeof SVG_LOGO)[keyof typeof SVG_LOGO];
 export const SVG_LOGO = {
   google: 'Google',
@@ -195,6 +189,6 @@ export const SVG_LOGO = {
 
 export type SPINNER = (typeof SPINNER)[keyof typeof SPINNER];
 export const SPINNER = {
-  authFrom: 'authForm',
+  authForm: 'authForm',
   verificationConfirm: 'verificationConfirm',
 };

--- a/lib/states/todos/filterTodoIdsEffect.tsx
+++ b/lib/states/todos/filterTodoIdsEffect.tsx
@@ -3,14 +3,14 @@ import { Labels } from '@lib/types';
 import { atomLabelQuerySlug } from '@states/labels';
 import { atomQueryLabels } from '@states/labels/atomQueries';
 import { atomHtmlTitleTag, atomPathnameImage } from '@states/misc';
-import { useNextQuerySlug } from '@states/utils/hooks';
+import { useNextQuery } from '@states/utils/hooks';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { useRecoilCallback, useRecoilValue } from 'recoil';
 import { atomFilterTodoIds } from '.';
 
 export const FilterTodoIdsEffect = () => {
-  const labelId = useNextQuerySlug('/app/label');
+  const labelId = useNextQuery({ path: '/app/label' });
   const { asPath } = useRouter();
   const labels = useRecoilCallback(({ snapshot }) => () => {
     return snapshot.getLoadable(atomQueryLabels).getValue();

--- a/lib/states/users/clientErrorMessageEffect.tsx
+++ b/lib/states/users/clientErrorMessageEffect.tsx
@@ -1,0 +1,16 @@
+import { validateEmailFormat } from '@states/utils';
+import { useEffect } from 'react';
+import { useRecoilValue, useResetRecoilState } from 'recoil';
+import { atomUser, atomUserErrorMessage } from '.';
+
+export const ClientErrorMessageEffect = () => {
+  const user = useRecoilValue(atomUser);
+  const isEmailInValidated = !validateEmailFormat(user.email);
+  const resetClientErrorMessage = useResetRecoilState(atomUserErrorMessage);
+
+  useEffect(() => {
+    !isEmailInValidated && resetClientErrorMessage();
+  }, [isEmailInValidated, resetClientErrorMessage]);
+
+  return null;
+};

--- a/lib/states/users/hooks.tsx
+++ b/lib/states/users/hooks.tsx
@@ -1,10 +1,9 @@
-import { ERROR_TYPE, SPINNER, USER } from '@data/dataTypesConst';
-import { Types } from '@lib/types';
+import { SPINNER, USER } from '@data/dataTypesConst';
 import { atomLoadingSpinner } from '@states/misc';
 import { signIn } from 'next-auth/react';
 import { FormEvent } from 'react';
 import { RecoilValue, useRecoilCallback, useRecoilValue, useSetRecoilState } from 'recoil';
-import { atomUserError, atomUser, atomUserVerificationRequest } from '.';
+import { atomUser, atomUserErrorMessage, atomUserVerificationRequest } from '.';
 
 export const useUserValueUpdate = () => {
   return useRecoilCallback(({ set, snapshot }) => (targetName: USER, content: string) => {
@@ -17,22 +16,18 @@ export const useUserValueUpdate = () => {
   });
 };
 
-export const useUserAuthFormSubmit = (isError: Types['isError']) => {
+export const useUserAuthFormSubmit = (isEmailInValidated: boolean) => {
   const user = useRecoilValue(atomUser);
-  const setServerError = useSetRecoilState(atomUserError(ERROR_TYPE['server']));
-  const setClientError = useSetRecoilState(atomUserError(ERROR_TYPE['client']));
-  const isServerError = useRecoilValue(atomUserError(ERROR_TYPE['server']));
-  const isClientError = useRecoilValue(atomUserError(ERROR_TYPE['client']));
+  const setClientErrorMessage = useSetRecoilState(atomUserErrorMessage);
   const setIsVerificationRequested = useSetRecoilState(atomUserVerificationRequest);
-  const setLoadingSpinner = useSetRecoilState(atomLoadingSpinner(SPINNER['authFrom']));
+  const setLoadingSpinner = useSetRecoilState(atomLoadingSpinner(SPINNER['authForm']));
 
   return async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (isError) {
-      setClientError(true);
+    if (isEmailInValidated) {
+      setClientErrorMessage('Please enter a valid email address.');
       return;
     }
-    if (isClientError || isServerError) return;
 
     try {
       const userEmailSent = async () => {
@@ -49,7 +44,7 @@ export const useUserAuthFormSubmit = (isError: Types['isError']) => {
         return;
       }
     } catch (error) {
-      setServerError(true);
+      setClientErrorMessage('something went wrong. Please try again!');
     }
   };
 };

--- a/lib/states/users/index.tsx
+++ b/lib/states/users/index.tsx
@@ -1,7 +1,7 @@
 import { STORAGE_KEY } from '@data/dataTypesConst';
 import { sessionStorageEffect } from '@effects/atomEffects';
 import { Users } from '@lib/types';
-import { atom, atomFamily } from 'recoil';
+import { atom } from 'recoil';
 
 export const atomUser = atom<Users>({
   key: 'atomUser',
@@ -18,9 +18,9 @@ export const atomIDBUserSession = atom<boolean>({
   ],
 });
 
-export const atomUserError = atomFamily<boolean, string>({
-  key: 'atomUserError',
-  default: false,
+export const atomUserErrorMessage = atom<string>({
+  key: 'atomUserErrorMessage',
+  default: '',
 });
 
 export const atomUserVerificationRequest = atom({

--- a/lib/states/utils/hooks.tsx
+++ b/lib/states/utils/hooks.tsx
@@ -63,14 +63,18 @@ export const RecoilObserver = <T,>({ node, onChange }: { node: RecoilState<T>; o
   return null;
 };
 
-export const useNextQuerySlug = (path: string): string | undefined => {
+export const useNextQuery = ({ path, key }: { path?: string; key?: string }) => {
+  if ((path && key) || (!path && !key)) throw new Error('Only "path" or "key" can be provided');
   const router = useRouter();
+  const pathRegex = path && `${path}/(.*)(&|$)`;
+  const keyRegex = key && `[&?]${key}=(.*?)(&|$)`;
+  const pathOrKey = (pathRegex || keyRegex) as string;
 
   const value = useMemo(() => {
-    const match = router.asPath.match(new RegExp(`${path}/(.*)(&|$)`));
+    const match = router.asPath.match(new RegExp(pathOrKey));
     if (!match) return undefined;
     return decodeURIComponent(match[1]);
-  }, [path, router]);
+  }, [pathOrKey, router.asPath]);
 
   return value;
 };

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -176,6 +176,11 @@ export interface TypesSvgLogo {
   viewBox: string;
   path: ReactElement;
 }
+
+export interface TypesNextAuthError {
+  _id: string;
+  message: string;
+}
 /**
  * Types MISC.
  */

--- a/pages/api/v1/auth/[...nextauth].tsx
+++ b/pages/api/v1/auth/[...nextauth].tsx
@@ -10,14 +10,14 @@ export const authOptions: NextAuthOptions = {
   providers: [
     EmailProvider({
       server: {
-        host: process.env.EMAIL_SERVER_HOST,
-        port: process.env.EMAIL_SERVER_PORT,
+        host: process.env.GCR_EMAIL_SERVER_HOST,
+        port: process.env.GCR_EMAIL_SERVER_PORT,
         auth: {
           user: process.env.EMAIL_SERVER_USER,
           pass: process.env.EMAIL_SERVER_PASSWORD,
         },
       },
-      from: process.env.EMAIL_FROM,
+      from: process.env.GCR_EMAIL_FROM,
     }),
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID as string,
@@ -54,6 +54,7 @@ export const authOptions: NextAuthOptions = {
   pages: {
     signIn: '/auth',
     signOut: '/app',
+    error: '/auth',
   },
   adapter: MongoDBAdapter(clientPromise),
   session: {


### PR DESCRIPTION
Add the custom server-side error handling to NextAuth to render errors on the client when authentication fails, including for OAuth and email magic links.

The implementation removes unnecessary code, including state management for server-side errors, as NextAuth already provides an `errorId` that is
  ready to use to cover error cases.