### PR TITLE
fix: fix issue with slate throwing error upon regaining focus

### DIFF
--- a/lib/states/editors/editorAutoFocusEffect.tsx
+++ b/lib/states/editors/editorAutoFocusEffect.tsx
@@ -24,10 +24,8 @@ export const EditorAutoFocusEffect = ({
 
     if (!isAutoFocus || isCatchConfirmModal || completedPath) return;
 
-    setTimeout(() => {
-      ReactEditor.focus(editor);
-      Transforms.select(editor, Editor.end(editor, []));
-    }, 100);
+    ReactEditor.focus(editor);
+    Transforms.select(editor, Editor.end(editor, []));
   }, [isAutoFocus, completedPath, editor, isCatchConfirmModal]);
 
   return null;


### PR DESCRIPTION
The previous workaround to mitigate a focusing bug caused by the Slate editor included a setTimeout function, but this was found to be causing the issue. Removing the setTimeout function resolves the problem.