### PR TITLE
fix: manage modifier keys  and disable kbd on mobile devices

### DIFF
--- a/components/ui/dropdowns/v1/todoItemDropdown.tsx
+++ b/components/ui/dropdowns/v1/todoItemDropdown.tsx
@@ -4,7 +4,7 @@ import {
   optionsPriorityDropdownImportant,
   optionsPriorityDropdownUrgent,
 } from '@data/dataOptions';
-import { PRIORITY_LEVEL } from '@data/dataTypesConst';
+import { MODIFIER_KBD, PRIORITY_LEVEL } from '@data/dataTypesConst';
 import { ICON_DELETE, ICON_MORE_VERT } from '@data/materialSymbols';
 import { TypesOptionsDropdown } from '@lib/types/typesOptions';
 import { useCalUpdateDataItem } from '@states/calendars/hooks';
@@ -70,7 +70,7 @@ export const TodoItemDropdown = ({ todo, children, options }: Props) => {
             shouldKeepOpeningOnClick: false,
             tooltip: 'Delete',
             path: ICON_DELETE,
-            kbd: '⌘ + Delete',
+            kbd: MODIFIER_KBD['modifier + Delete'],
           }}
           onClick={() => removeTodo()}>
           Delete

--- a/components/ui/inputs/checkbox.tsx
+++ b/components/ui/inputs/checkbox.tsx
@@ -1,3 +1,4 @@
+import { MODIFIER_KBD } from '@data/dataTypesConst';
 import { classNames } from '@states/utils';
 import { useConditionCompareTodoItemsEqual } from '@states/utils/hooks';
 import { Types, TypesTodo } from 'lib/types';
@@ -25,7 +26,7 @@ export const CheckBox = ({
         checkedColor,
       )}
       tooltip={!todoItem.completed ? 'Complete' : 'Undo Complete'}
-      kbd='⌘ + Enter'
+      kbd={MODIFIER_KBD['modifier + Enter']}
       isChecked={isChecked}
       onChange={onChange}
       isDisabled={!conditionalDisable && !todoItem.completed}

--- a/components/ui/modals/todoModals/todoModal/todoModalHeaderButtons.tsx
+++ b/components/ui/modals/todoModals/todoModal/todoModalHeaderButtons.tsx
@@ -3,16 +3,15 @@ import {
   IconButton as ExpandReversibleIconButton,
   IconButton as MinimizeIconButton,
 } from '@buttons/iconButton';
-import { optionsButtonTodoModalMinimize, optionsButtonTodoModalClose } from '@data/dataOptions';
-import { BREAKPOINT } from '@data/dataTypesConst';
+import { optionsButtonTodoModalClose, optionsButtonTodoModalMinimize } from '@data/dataOptions';
+import { BREAKPOINT, MODIFIER_KBD } from '@data/dataTypesConst';
 import { ICON_CLOSE_FULL_SCREEN, ICON_OPEN_IN_FULL } from '@data/materialSymbols';
 import { TodoItemDropdown } from '@dropdowns/v1/todoItemDropdown';
 import { Types } from '@lib/types';
 import { atomMediaQuery } from '@states/misc';
 import { atomTodoModalMax } from '@states/modals';
-import { useTodoModalStateMinimize, useTodoModalStateExpand, useTodoModalStateClose } from '@states/modals/hooks';
-import { Fragment as ContainerFragment, Fragment as HeaderFragment, Fragment as HeaderButtonFragment } from 'react';
-import { isMacOs } from 'react-device-detect';
+import { useTodoModalStateClose, useTodoModalStateExpand, useTodoModalStateMinimize } from '@states/modals/hooks';
+import { Fragment as ContainerFragment, Fragment as HeaderButtonFragment, Fragment as HeaderFragment } from 'react';
 import { useRecoilValue } from 'recoil';
 
 type Props = Partial<Pick<Types, 'todo'>>;
@@ -46,7 +45,7 @@ export const TodoModalHeaderButtons = ({ todo }: Props) => {
               options={{
                 path: !isTodoModalMax ? ICON_OPEN_IN_FULL : ICON_CLOSE_FULL_SCREEN,
                 tooltip: !isTodoModalMax ? 'Expand' : 'Exit expand',
-                kbd: isMacOs ? '⌘ E' : 'Ctrl E',
+                kbd: MODIFIER_KBD['modifier + E'],
               }}
             />
           </HeaderButtonFragment>

--- a/components/ui/tooltips/tooltips/index.tsx
+++ b/components/ui/tooltips/tooltips/index.tsx
@@ -3,6 +3,7 @@ import { classNames } from '@states/utils';
 import { TypesTooltipAttributes, Types } from 'lib/types';
 import React, { Fragment as TooltipFragment, memo } from 'react';
 import { usePopperTooltip } from 'react-popper-tooltip';
+import { isMobile } from 'react-device-detect';
 
 type Props = { options: Partial<TypesTooltipAttributes & Pick<Types, 'container'>> } & Pick<Types, 'children'>;
 
@@ -35,13 +36,15 @@ export const Tooltip = memo(({ options, children }: Props) => {
                 'z-50 max-w-[15rem] truncate whitespace-nowrap rounded-lg bg-gray-700 p-2 text-xs text-white opacity-90',
             )}>
             <span>{options.tooltip}</span>
-            <kbd
-              className={classNames(
-                options.kbd &&
-                  'ml-2 h-6 rounded border-x border-y py-px px-1.5 font-sans tracking-normal subpixel-antialiased',
-              )}>
-              {options.kbd}
-            </kbd>
+            {!isMobile && (
+              <kbd
+                className={classNames(
+                  options.kbd &&
+                    'ml-2 h-6 rounded border-x border-y py-px px-1.5 font-sans tracking-normal subpixel-antialiased',
+                )}>
+                {options.kbd}
+              </kbd>
+            )}
           </div>
         </Portal>
       )}

--- a/lib/data/dataOptions.tsx
+++ b/lib/data/dataOptions.tsx
@@ -10,8 +10,7 @@ import {
   TypesOptionsSvg,
 } from '@lib/types/typesOptions';
 import { classNames } from '@states/utils';
-import { isMacOs } from 'react-device-detect';
-import { POSITION_X, POSITION_Y, PRIORITY_LEVEL } from './dataTypesConst';
+import { MODIFIER_KBD, POSITION_X, POSITION_Y, PRIORITY_LEVEL } from './dataTypesConst';
 import {
   ICON_CHEVRON_LEFT,
   ICON_CHEVRON_RIGHT,
@@ -33,10 +32,10 @@ import {
   ICON_WARNING,
 } from './materialSymbols';
 import {
+  STYLE_BUTTON_LARGE_BLUE,
   STYLE_BUTTON_NORMAL_BLUE,
   STYLE_BUTTON_NORMAL_RED,
   STYLE_BUTTON_NORMAL_WHITE,
-  STYLE_BUTTON_LARGE_BLUE,
   STYLE_HOVER_ENABLED_SLATE_DARK,
 } from './stylePreset';
 
@@ -163,14 +162,14 @@ export const optionsButtonConfirmModalCancel: TypesOptionsButton = {
 export const optionsButtonMiniModalMaximize: TypesOptionsButton = {
   path: ICON_MAXIMIZE,
   tooltip: 'Exit minimize',
-  kbd: isMacOs ? '⌘ M' : 'Ctrl M',
+  kbd: MODIFIER_KBD['modifier + M'],
   margin: '-mr-2 ml-2 -my-1',
 };
 
 export const optionsButtonMiniModalOpenFull: TypesOptionsButton = {
   path: ICON_OPEN_IN_FULL,
   tooltip: 'Expand',
-  kbd: isMacOs ? '⌘ E' : 'Ctrl E',
+  kbd: MODIFIER_KBD['modifier + E'],
   margin: '-mr-2 ml-2 -my-1',
 };
 
@@ -184,7 +183,7 @@ export const optionsButtonTodoModalAddTodo: TypesOptionsButton = {
 export const optionsButtonTodoModalMinimize: TypesOptionsButton = {
   path: ICON_MINIMIZE,
   tooltip: 'Minimize',
-  kbd: isMacOs ? '⌘ M' : 'Ctrl M',
+  kbd: MODIFIER_KBD['modifier + M'],
 };
 
 export const optionsButtonTodoModalClose: TypesOptionsButton = {

--- a/lib/data/dataTypesConst.tsx
+++ b/lib/data/dataTypesConst.tsx
@@ -1,4 +1,5 @@
 import ObjectID from 'bson-objectid';
+import { isMacOs } from 'react-device-detect';
 
 export type CATCH = (typeof CATCH)[keyof typeof CATCH];
 export const CATCH = {
@@ -193,4 +194,13 @@ export type SPINNER = (typeof SPINNER)[keyof typeof SPINNER];
 export const SPINNER = {
   authForm: 'authForm',
   verificationConfirm: 'verificationConfirm',
+};
+
+export type MODIFIER_KBD = (typeof MODIFIER_KBD)[keyof typeof MODIFIER_KBD];
+export const MODIFIER_KBD = {
+  'modifier + E': isMacOs ? '⌘ + E' : 'ctrl + E',
+  'modifier + M': isMacOs ? '⌘ + M' : 'ctrl + M',
+  'modifier + Enter': isMacOs ? '⌘ + Enter' : 'ctrl + Enter',
+  'modifier + Escape': isMacOs ? '⌘ + Escape' : 'ctrl + Escape',
+  'modifier + Delete': isMacOs ? '⌘ + Delete' : 'ctrl + Delete',
 };


### PR DESCRIPTION
With this fix, the kbd showing on the tooltip no longer displays on i mobile devices (including mobile and tablets), improving the user experience for mobile users.

Additionally, modifier keys (such as "Ctrl" and "Command") are now managed with typesConsts as `MODIFIER_KBD`, centralizing the management of keybinds and making it easier to maintain in the future.