### PR TITLE
fix: fix atomquerylabels from fetching data on initial  load

### DIFF
--- a/configs/securityHeaders.js
+++ b/configs/securityHeaders.js
@@ -1,7 +1,7 @@
 const ContentSecurityPolicy = `
   default-src 'self'; connect-src 'self'; 
   child-src 'self' youtube.com;
-  font-src 'self' ;
+  font-src 'self';
   img-src 'self' ${process.env.NEXT_PUBLIC_IMAGE_DOMAIN} data:;
   ${process.env.NODE_ENV !== 'production' ? `style-src 'self' 'unsafe-inline' 'unsafe-eval'` : `style-src 'self'`};
   ${

--- a/lib/states/effects/queryEffects.tsx
+++ b/lib/states/effects/queryEffects.tsx
@@ -25,8 +25,8 @@ export const queryEffect: TypesRefetchEffect =
     const hasFiveMinTimePast = lastUpdateTime && hasTimePast(lastUpdateTime); // 5 min is default time. You can number as argument for custom time. ex)  hasTimePast(lastUpdateTime, 20) 20 min custom time
     const offSession = sessionStorage.getItem(STORAGE_KEY['session']);
 
+    if (typeof demoFunction === 'undefined') return;
     if (offSession) {
-      if (typeof demoFunction === 'undefined') return;
       const demoData = async () => {
         const data = demoFunction && (await demoFunction());
         return data as DefaultValue;


### PR DESCRIPTION
Resolved the issue where atomQueryLabels would fetch data on initial page load due to atomEffect's callback being executed faster than retrieving data from sessionStorage. The fix prioritizes demoFunction's condition check to prevent this behavior.

Additionally, remove the whitespace from contentSecurityPolicy.