### PR TITLE
fix: resolve demo fetching issue with session handling

### DIFF
--- a/components/layouts/layoutApp/layout/layoutHeader/headerUser.tsx
+++ b/components/layouts/layoutApp/layout/layoutHeader/headerUser.tsx
@@ -4,20 +4,20 @@ import { STYLE_BUTTON_NORMAL_BLUE } from '@data/stylePreset';
 import { UserDropdown } from '@dropdowns/v2/userDropdown';
 import { atomIDBUserSession } from '@states/users';
 import { UserSessionEffect } from '@states/users/userSessionEffect';
-import { classNames } from '@states/utils';
+import { classNames, getSessionStorage } from '@states/utils';
 import { signIn } from 'next-auth/react';
 import { Fragment } from 'react';
 import { useRecoilValue } from 'recoil';
 
 export const HeaderUser = () => {
   const isSession = useRecoilValue(atomIDBUserSession);
-  const offSession = sessionStorage.getItem(STORAGE_KEY['session']);
+  const session = getSessionStorage(STORAGE_KEY['session']);
   // add additional condition to prevent the flickering of user avatar
 
   return (
     <Fragment>
       <UserSessionEffect />
-      {!offSession && isSession ? (
+      {session && isSession ? (
         <UserDropdown />
       ) : (
         <Button

--- a/lib/dataConnections/indexedDB.ts
+++ b/lib/dataConnections/indexedDB.ts
@@ -1,6 +1,7 @@
 import { DATA_IDB } from '@data/dataArrayOfObjects';
 import { IDB, IDB_VERSION, STORAGE_KEY } from '@data/dataTypesConst';
 import { Types, TypesIDB } from '@lib/types';
+import { getSessionStorage } from '@states/utils';
 import { deleteDB, openDB } from 'idb';
 
 // this will create new database per object store. This is easier to modify
@@ -10,9 +11,9 @@ const dbPromise = async (storeName: Types['storeName'], dbVersion?: Types['dbVer
   const currentIDBName = idb && idb.dbName + 'v' + idb.currentVersion;
   const previousVersions = Array.from({ length: IDB_VERSION['current'] }, (_, i) => i);
   const oldIDBNames = previousVersions.map((version) => idb && idb.dbName + 'v' + version);
-  const offSession = sessionStorage.getItem(STORAGE_KEY['session']);
+  const session = getSessionStorage(STORAGE_KEY['session']);
 
-  if (offSession) return;
+  if (!session) return;
 
   const db = await openDB(currentIDBName as IDB, dbVersion || 1, {
     // To auto upgrade indexedDB, update the IDB_VERSION's previous and current.

--- a/lib/states/effects/atomEffects.tsx
+++ b/lib/states/effects/atomEffects.tsx
@@ -1,4 +1,6 @@
+import { STORAGE_KEY } from '@data/dataTypesConst';
 import { TypesAtomEffect, TypesMediaQueryEffect, TypesSessionStorageEffect } from '@lib/types';
+import { delSessionStorage, getSessionStorage, setSessionStorage } from '@states/utils';
 
 /**
  * Media Queries
@@ -41,20 +43,20 @@ export const networkStatusEffect: TypesAtomEffect<boolean> = ({ setSelf }) => {
 export const sessionEffect: TypesSessionStorageEffect =
   ({ queryKey, shouldGet, isSessionSetEnabled, isSessionResetEnabled }) =>
   ({ onSet, resetSelf, setSelf, trigger }) => {
-    const session = sessionStorage.getItem(queryKey);
-    const offSession = session && JSON.parse(session) ? false : true;
+    const storageKey = queryKey as STORAGE_KEY;
+    const session = getSessionStorage(storageKey);
 
     if (trigger === 'get' && (shouldGet ?? true)) {
-      setSelf(offSession);
+      setSelf(session);
     }
 
     onSet((newValue, _, isReset) => {
       if (isReset) {
         resetSelf();
-        isSessionResetEnabled && sessionStorage.removeItem(queryKey);
+        isSessionResetEnabled && delSessionStorage(storageKey);
         return;
       }
       setSelf(newValue);
-      isSessionSetEnabled && sessionStorage.setItem(queryKey, JSON.stringify(newValue));
+      isSessionSetEnabled && setSessionStorage(storageKey, newValue);
     });
   };

--- a/lib/states/effects/queryEffects.tsx
+++ b/lib/states/effects/queryEffects.tsx
@@ -1,7 +1,7 @@
 import { IDB_KEY, IDB_KEY_STORE, IDB_STORE, STORAGE_KEY } from '@data/dataTypesConst';
 import { del, get, set } from '@lib/dataConnections/indexedDB';
 import { TypesRefetchEffect } from '@lib/types';
-import { hasTimePast } from '@states/utils';
+import { getSessionStorage, hasTimePast } from '@states/utils';
 import { DefaultValue } from 'recoil';
 
 export const queryEffect: TypesRefetchEffect =
@@ -23,10 +23,10 @@ export const queryEffect: TypesRefetchEffect =
     const isIdMapQueryKey = queryKey === IDB_KEY['labels'] || queryKey === IDB_KEY['todoIds'];
     const lastUpdateTime = isIdMapQueryKey && Number(JSON.parse(localStorage.getItem(STORAGE_KEY[queryKey]) || '0'));
     const hasFiveMinTimePast = lastUpdateTime && hasTimePast(lastUpdateTime); // 5 min is default time. You can number as argument for custom time. ex)  hasTimePast(lastUpdateTime, 20) 20 min custom time
-    const offSession = sessionStorage.getItem(STORAGE_KEY['session']);
+    const session = getSessionStorage(STORAGE_KEY['session']);
 
-    if (typeof demoFunction === 'undefined') return;
-    if (offSession) {
+    if (!session) {
+      if (typeof demoFunction === 'undefined') return;
       const demoData = async () => {
         const data = demoFunction && (await demoFunction());
         return data as DefaultValue;

--- a/lib/states/users/sessionDeactivateEffect.tsx
+++ b/lib/states/users/sessionDeactivateEffect.tsx
@@ -1,12 +1,17 @@
 import { STORAGE_KEY } from '@data/dataTypesConst';
+import { setSessionStorage } from '@states/utils';
 import { useCallback, useEffect } from 'react';
 
 export const SessionDeactivateEffect = () => {
   const deactivateSession = useCallback(() => {
-    sessionStorage.removeItem(STORAGE_KEY['session']);
+    setSessionStorage(STORAGE_KEY['session'], 'pending');
   }, []);
   useEffect(() => {
     deactivateSession();
+    window.addEventListener('storage', deactivateSession);
+    return () => {
+      window.removeEventListener('storage', deactivateSession);
+    };
   }, [deactivateSession]);
 
   return null;

--- a/lib/states/utils/index.tsx
+++ b/lib/states/utils/index.tsx
@@ -1,4 +1,4 @@
-import { CATCH } from '@data/dataTypesConst';
+import { CATCH, STORAGE_KEY } from '@data/dataTypesConst';
 import { render, RenderOptions } from '@testing-library/react';
 import React, { FC, ReactElement } from 'react';
 import { atom, atomFamily, RecoilRoot } from 'recoil';
@@ -75,3 +75,10 @@ export const validateEmailFormat = (email: string) => {
   return emailFormat.test(email);
 };
 
+export const getSessionStorage = (queryKey: STORAGE_KEY) => {
+  const session = sessionStorage.getItem(queryKey);
+  return session && JSON.parse(session);
+};
+export const setSessionStorage = (queryKey: STORAGE_KEY, value: unknown) =>
+  sessionStorage.setItem(queryKey, JSON.stringify(value));
+export const delSessionStorage = (queryKey: STORAGE_KEY) => sessionStorage.removeItem(queryKey);


### PR DESCRIPTION
This commit addresses an issue with the demo session triggering, which was caused by the `queryEffect` running before the session was set in sessionStorage. As a result, a null session value allowed `queryEffect` to bypass the expected condition.

The solution involves explicitly setting the session in sessionStorage and ensuring it persists between the user's offSession and actual session.

Additionally, to prevent users from deleting the session value in sessionStorage, the new session value is automatically set when the user removes it.

This approach improves session handling and resolves the demo fetching issue.