### PR TITLE
refactor: improve off position of floating input label

### DIFF
--- a/components/ui/inputs/floatingLabelInput.tsx
+++ b/components/ui/inputs/floatingLabelInput.tsx
@@ -36,7 +36,7 @@ export const FloatingLabelInput = forwardRef<HTMLInputElement, Props>(
             <label
               htmlFor={options.name}
               className={classNames(
-                'absolute left-2.5 -top-2 block cursor-text select-none bg-slate-50 px-1 text-xs font-medium transition-all peer-placeholder-shown:top-3.5 peer-placeholder-shown:bg-transparent peer-placeholder-shown:text-base peer-placeholder-shown:text-gray-400 peer-focus:left-2.5 peer-focus:-top-2 peer-focus:bg-slate-50 peer-focus:px-1 peer-focus:text-xs',
+                'absolute left-2.5 -top-2 block cursor-text select-none bg-slate-50 px-1 text-xs font-medium transition-all peer-placeholder-shown:top-[0.8rem] peer-placeholder-shown:bg-transparent peer-placeholder-shown:text-base peer-placeholder-shown:text-gray-400 peer-focus:left-2.5 peer-focus:-top-2 peer-focus:bg-slate-50 peer-focus:px-1 peer-focus:text-xs',
                 options.isError ? 'text-red-600 peer-focus:text-red-500' : 'text-gray-400 peer-focus:text-blue-500',
               )}>
               {options.placeholder}


### PR DESCRIPTION
Add minor improvement to the balance of the floating input label. The label, which serves as the placeholder, was not centered correctly within the input, resulting in a subtle imbalance.

To address this, the label was repositioned slightly to improve its alignment with the input. Although the issue was subtle, this change helps improve the overall visual consistency of the input and ensures that the label is aligned properly.