### PR TITLE
feat: refactor queryEffect and introduce demoAtoms

### DIFF
--- a/lib/states/effects/queryEffects.tsx
+++ b/lib/states/effects/queryEffects.tsx
@@ -1,7 +1,6 @@
 import { IDB_KEY, IDB_KEY_STORE, IDB_STORE, STORAGE_KEY } from '@data/dataTypesConst';
 import { del, get, set } from '@lib/dataConnections/indexedDB';
 import { TypesRefetchEffect } from '@lib/types';
-import { atomUserOffSession } from '@states/users';
 import { hasTimePast } from '@states/utils';
 import { DefaultValue } from 'recoil';
 
@@ -16,25 +15,13 @@ export const queryEffect: TypesRefetchEffect =
     isRefetchingOnFocus,
     isRefetchingOnBlur,
     refetchInterval,
-    demoFunction,
   }) =>
-  ({ setSelf, onSet, trigger, getLoadable }) => {
+  ({ setSelf, onSet, trigger }) => {
     if (typeof window === 'undefined' || typeof queryFunction === 'undefined') return;
     const onIndexedDB = isIndexedDBEnabled || typeof isIndexedDBEnabled === 'undefined';
     const isIdMapQueryKey = queryKey === IDB_KEY['labels'] || queryKey === IDB_KEY['todoIds'];
     const lastUpdateTime = isIdMapQueryKey && Number(JSON.parse(localStorage.getItem(STORAGE_KEY[queryKey]) || '0'));
     const hasFiveMinTimePast = lastUpdateTime && hasTimePast(lastUpdateTime); // 5 min is default time. You can number as argument for custom time. ex)  hasTimePast(lastUpdateTime, 20) 20 min custom time
-    const offSession = getLoadable(atomUserOffSession).getValue();
-
-    if (offSession) {
-      if (typeof demoFunction === 'undefined') return;
-      const demoData = async () => {
-        const data = demoFunction && (await demoFunction());
-        return data as DefaultValue;
-      };
-      setSelf(demoData());
-      return;
-    }
 
     //concat indexedDB with data if data is in array
     const concatDataWithIndexedDB = async (data: unknown) => {

--- a/lib/states/labels/atomQueries.tsx
+++ b/lib/states/labels/atomQueries.tsx
@@ -10,7 +10,7 @@ import { atom, selector } from 'recoil';
  **/
 export const atomQueryLabels = atom<Labels[]>({
   key: 'atomQueryLabels',
-  default: DATA_DEMO_LABELS,
+  default: [],
   effects: [
     queryEffect({
       storeName: IDB_STORE['idMaps'],
@@ -19,6 +19,11 @@ export const atomQueryLabels = atom<Labels[]>({
       isRefetchingOnMutation: true, // fetching the list of labels is too expensive.
     }),
   ],
+});
+
+export const atomDemoLabels = atom<Labels[]>({
+  key: 'atomDemoLabels',
+  default: DATA_DEMO_LABELS,
 });
 
 export const atomSelectorLabels = atom({

--- a/lib/states/todos/atomQueries.tsx
+++ b/lib/states/todos/atomQueries.tsx
@@ -12,7 +12,7 @@ import { atom, atomFamily, selectorFamily } from 'recoil';
 
 export const atomQueryTodoIds = atom<TodoIds[]>({
   key: 'atomQueryTodoIds',
-  default: DATA_DEMO_TODOIDS,
+  default: [],
   effects: [
     queryEffect({
       storeName: IDB_STORE['idMaps'],
@@ -24,6 +24,11 @@ export const atomQueryTodoIds = atom<TodoIds[]>({
   ],
 });
 
+export const atomDemoTodoIds = atom<TodoIds[]>({
+  key: 'atomDemoTodoIds',
+  default: DATA_DEMO_TODOIDS,
+});
+
 export const atomQueryTodoItem = atomFamily<Todos, Todos['_id']>({
   key: 'atomQueryTodoItem',
   default: {} as Todos,
@@ -33,13 +38,25 @@ export const atomQueryTodoItem = atomFamily<Todos, Todos['_id']>({
       storeName: IDB_STORE['todoItems'],
       queryKey: todoId!.toString(),
       queryFunction: () => getDataTodoItem({ _id: todoId }),
-      demoFunction: () => getDemoTodoItem({ _id: todoId }),
       isRefetchingOnMutation: true,
       refetchDelayOnMutation: 800,
       isRefetchingOnFocus: true,
     }),
   ],
 });
+
+export const atomDemoTodoItem = atomFamily<Todos, Todos['_id']>({
+  key: 'atomDemoTodoItem',
+  default: {} as Todos,
+  effects: (todoId) => [
+    ({ setSelf }) => {
+      const demoFunction = async () => await getDemoTodoItem({ _id: todoId });
+      setSelf(demoFunction());
+    },
+  ],
+});
+
+
 
 /**
  * Derived Query Todos

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -27,7 +27,7 @@ import {
   RefObject,
 } from 'react';
 import { TriggerType } from 'react-popper-tooltip';
-import { AtomEffect, DefaultValue } from 'recoil';
+import { AtomEffect } from 'recoil';
 import { Descendant } from 'slate';
 import { ReactEditor } from 'slate-react';
 
@@ -368,7 +368,6 @@ export interface TypesEffects {
   shouldGet: boolean;
   isSessionSetEnabled: boolean;
   isSessionResetEnabled: boolean;
-  demoFunction(): unknown | DefaultValue;
   // Refetch Effect
   queryKey: string;
   queryFunction<T>(): Promise<{ data: T }>;
@@ -401,7 +400,6 @@ export type TypesRefetchEffect = <T>({
   isRefetchingOnFocus,
   isRefetchingOnBlur,
   refetchInterval,
-  demoFunction,
 }: Partial<
   Pick<
     Types,
@@ -412,7 +410,6 @@ export type TypesRefetchEffect = <T>({
     | 'isRefetchingOnBlur'
     | 'refetchInterval'
     | 'depQueryFunction'
-    | 'demoFunction'
   >
 > &
   Pick<Types, 'queryFunction' | 'queryKey' | 'storeName'>) => AtomEffect<T>;


### PR DESCRIPTION
Remove demoFunctions from queryEffect to simplify its implementation and decouple demo-related logic from the session state. The session state now only deals with atoms and selectors with the 'query' suffix, such as `atomQueryTodoIds`.

Introduce demoAtoms to lay the foundation for a revamped demo-session. The demo-session will have a fully isolated state, ensuring seamless operation when no user session is available.