### PR TITLE
feat: refactor atomUserSession and UserSessionEffect

### DIFF
--- a/components/layouts/layoutApp/layout/layoutHeader/headerUser.tsx
+++ b/components/layouts/layoutApp/layout/layoutHeader/headerUser.tsx
@@ -2,7 +2,7 @@ import { Button } from '@buttons/button';
 import { STORAGE_KEY } from '@data/dataTypesConst';
 import { STYLE_BUTTON_NORMAL_BLUE } from '@data/stylePreset';
 import { UserDropdown } from '@dropdowns/v2/userDropdown';
-import { atomUserOffSession } from '@states/users';
+import { atomUserSession } from '@states/users';
 import { UserSessionResetEffect } from '@states/users/userSessionResetEffect';
 import { classNames, getSessionStorage } from '@states/utils';
 import { signIn } from 'next-auth/react';
@@ -10,13 +10,13 @@ import { Fragment } from 'react';
 import { useRecoilValue } from 'recoil';
 
 export const HeaderUser = () => {
-  const isSession = useRecoilValue(atomUserOffSession);
+  const isSession = useRecoilValue(atomUserSession);
   const session = getSessionStorage(STORAGE_KEY['offSession']);
 
   return (
     <Fragment>
       <UserSessionResetEffect />
-      {!session && !isSession ? (
+      {!session && isSession ? (
         <UserDropdown />
       ) : (
         <Button

--- a/lib/states/users/index.tsx
+++ b/lib/states/users/index.tsx
@@ -16,7 +16,7 @@ export const atomUserVerificationRequest = atom({
   default: false,
 });
 
-export const atomUserOffSession = atom({
-  key: 'atomUserOffSession',
-  // default must be empty to persist the pending state on session's loading state.
+export const atomUserSession = atom({
+  key: 'atomUserSession',
+  default: false,
 });

--- a/lib/states/users/userSessionEffect.tsx
+++ b/lib/states/users/userSessionEffect.tsx
@@ -1,32 +1,26 @@
 import { STORAGE_KEY } from '@data/dataTypesConst';
-import { delSessionStorage, getSessionStorage, setSessionStorage } from '@states/utils';
+import { delSessionStorage, setSessionStorage } from '@states/utils';
 import { useSession } from 'next-auth/react';
 import { useEffect } from 'react';
 import { useRecoilCallback } from 'recoil';
-import { atomUserOffSession } from '.';
+import { atomUserSession } from '.';
 
 export const UserSessionEffect = () => {
-  const { status } = useSession();
+  const { data: session } = useSession();
 
-  const session = useRecoilCallback(({ set }) => () => {
-    if (status === 'unauthenticated') {
-      set(atomUserOffSession, true);
-      setSessionStorage(STORAGE_KEY['offSession'], true);
-      return;
-    }
-    if (status === 'authenticated') {
-      set(atomUserOffSession, false);
+  const sessionHandler = useRecoilCallback(({ set, reset }) => () => {
+    if (session) {
+      set(atomUserSession, true);
       delSessionStorage(STORAGE_KEY['offSession']);
       return;
     }
-    if (status === 'loading' && !getSessionStorage(STORAGE_KEY['offSession'])) {
-      set(atomUserOffSession, false);
-    }
+    reset(atomUserSession);
+    setSessionStorage(STORAGE_KEY['offSession'], true);
   });
 
   useEffect(() => {
-    session();
-  }, [session, status]);
+    sessionHandler();
+  }, [sessionHandler]);
 
   return null;
 };

--- a/lib/states/utils/index.tsx
+++ b/lib/states/utils/index.tsx
@@ -76,9 +76,9 @@ export const validateEmailFormat = (email: string) => {
 };
 
 export const getSessionStorage = (queryKey: STORAGE_KEY) => {
-  const session = localStorage.getItem(queryKey);
+  const session = sessionStorage.getItem(queryKey);
   return session && JSON.parse(session);
 };
 export const setSessionStorage = (queryKey: STORAGE_KEY, value: unknown) =>
-  localStorage.setItem(queryKey, JSON.stringify(value));
-export const delSessionStorage = (queryKey: STORAGE_KEY) => localStorage.removeItem(queryKey);
+  sessionStorage.setItem(queryKey, JSON.stringify(value));
+export const delSessionStorage = (queryKey: STORAGE_KEY) => sessionStorage.removeItem(queryKey);

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,9 @@ import type { AppProps } from 'next/app';
 import { ReactElement, ReactNode } from 'react';
 import { RecoilRoot } from 'recoil';
 import '../styles/globals.css';
+import dynamic from 'next/dynamic';
+
+const UserSessionEffect = dynamic(() => import('@states/users/userSessionEffect').then((mod) => mod.UserSessionEffect));
 
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
   getLayout?: (page: ReactElement) => ReactNode;
@@ -23,6 +26,7 @@ const MyApp = ({ Component, pageProps: { session, ...pageProps } }: AppPropsWith
         basePath={process.env.NEXT_PUBLIC_NEXTAUTH_BASE_PATH}
         refetchOnWindowFocus={false}>
         {getLayout(<Component {...pageProps} />)}
+        <UserSessionEffect />
       </SessionProvider>
     </RecoilRoot>
   );


### PR DESCRIPTION
Rename atomUserOffSession to atomUserSession to better represent the current user session. Update sessionStorage function to use sessionStorage instead of localStorageusage by for better consistency.

Refactor headerUser to accurately display the user's avatar. Restructure UserSessionEffect and move it to the `_app` component to receive the session state as early as possible.