### PR TITLE
feat: implement new session selectors for todos and labels

### DIFF
--- a/components/editors/editorComposer/index.tsx
+++ b/components/editors/editorComposer/index.tsx
@@ -3,7 +3,7 @@ import { Types } from '@lib/types';
 import { EditorAutoFocusEffect } from '@states/editors/editorAutoFocusEffect';
 import { useEditorInitialValue, useEditorChangeHandler } from '@states/editors/hooks';
 import { useKeyWithEditor } from '@states/keybinds/hooks';
-import { atomQueryTodoItem } from '@states/todos/atomQueries';
+import { selectorSessionTodoItem } from '@states/todos/atomQueries';
 import { useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
 import { createEditor } from 'slate';
@@ -27,7 +27,7 @@ export const EditorComposer = ({ isAutoFocus, todo, titleName, ...props }: Props
   const renderPlaceholderWithProps = (props: RenderPlaceholderProps) =>
     renderPlaceholder({ titleName: titleName, ...props });
   const completed =
-    typeof todo !== 'undefined' && useRecoilValue(atomQueryTodoItem(todo?._id)).completed;
+    typeof todo !== 'undefined' && useRecoilValue(selectorSessionTodoItem(todo?._id)).completed;
   const renderCustomElementWithProps = (props: RenderElementProps) =>
     renderCustomElement({
       titleName: titleName,

--- a/components/editors/todoEditor.tsx
+++ b/components/editors/todoEditor.tsx
@@ -1,5 +1,5 @@
 import { Types } from '@lib/types';
-import { atomQueryTodoItem } from '@states/todos/atomQueries';
+import { selectorSessionTodoItem } from '@states/todos/atomQueries';
 import { classNames } from '@states/utils';
 import dynamic from 'next/dynamic';
 import { useRecoilCallback } from 'recoil';
@@ -10,7 +10,7 @@ const EditorComposer = dynamic(() => import('./editorComposer').then((mod) => mo
 
 export const TodoEditors = ({ todo }: Props) => {
   const isTodoCompleted = useRecoilCallback(({ snapshot }) => () => {
-    return typeof todo !== 'undefined' && snapshot.getLoadable(atomQueryTodoItem(todo._id)).getValue().completed;
+    return typeof todo !== 'undefined' && snapshot.getLoadable(selectorSessionTodoItem(todo._id)).getValue().completed;
   });
 
   return (

--- a/components/labels/labelList.tsx
+++ b/components/labels/labelList.tsx
@@ -1,13 +1,13 @@
 import { IconButton } from '@buttons/iconButton';
 import { optionsButtonLabelAddMore } from '@data/dataOptions';
-import { atomQueryLabels } from '@states/labels/atomQueries';
+import { selectorSessionLabels } from '@states/labels/atomQueries';
 import { useLabelModalStateOpen } from '@states/modals/hooks';
 import { Fragment } from 'react';
 import { useRecoilValue } from 'recoil';
 import { LabelItem } from './labelItem';
 
 export const LabelList = () => {
-  const labelList = useRecoilValue(atomQueryLabels);
+  const labelList = useRecoilValue(selectorSessionLabels);
   const labelModalOpen = useLabelModalStateOpen(undefined);
 
   return (

--- a/components/layouts/layoutApp/index.tsx
+++ b/components/layouts/layoutApp/index.tsx
@@ -19,7 +19,6 @@ const WindowBeforeunloadEffect = dynamic(() =>
   import('@states/misc/windowBeforeunloadEffect').then((mod) => mod.WindowBeforeunloadEffect),
 );
 const Layout = dynamic(() => import('./layout').then((mod) => mod.Layout));
-const UserSessionEffect = dynamic(() => import('@states/users/userSessionEffect').then((mod) => mod.UserSessionEffect));
 
 type Props = Pick<Types, 'children'>;
 
@@ -29,7 +28,6 @@ export const LayoutApp = ({ children }: Props) => {
 
   return (
     <LayoutAppFragment>
-      <UserSessionEffect />
       <Head>
         <title>{'My Todo App: ' + slug}</title>
       </Head>

--- a/components/todos/todo/todoItem.tsx
+++ b/components/todos/todo/todoItem.tsx
@@ -6,7 +6,7 @@ import { CheckBox } from '@inputs/checkbox';
 import { TypesTodo } from '@lib/types';
 import { selectorSelectedQueryLabels } from '@states/labels';
 import { useTodoModalStateOpen } from '@states/modals/hooks';
-import { atomQueryTodoItem } from '@states/todos/atomQueries';
+import { selectorSessionTodoItem } from '@states/todos/atomQueries';
 import { useTodoCompleteItem } from '@states/todos/hooks';
 import { atomCatch, classNames } from '@states/utils';
 import { format } from 'date-fns';
@@ -18,7 +18,7 @@ type Props = Pick<TypesTodo, 'todo'>;
 export const TodoItem = ({ todo }: Props) => {
   const openModal = useTodoModalStateOpen(todo._id);
   const completeTodo = useTodoCompleteItem(todo._id);
-  const todoItem = useRecoilValue(atomQueryTodoItem(todo._id));
+  const todoItem = useRecoilValue(selectorSessionTodoItem(todo._id));
   const important = todoItem.priorityLevel === PRIORITY_LEVEL['important'];
   const urgent = todoItem.priorityLevel === PRIORITY_LEVEL['urgent'];
   const selectedQueryLabels = useRecoilValue(selectorSelectedQueryLabels(todo._id));

--- a/components/ui/buttons/iconButton/priorityButton.tsx
+++ b/components/ui/buttons/iconButton/priorityButton.tsx
@@ -5,7 +5,7 @@ import { ICON_FLAG, ICON_FLAG_FILL, ICON_LABEL_IMPORTANT, ICON_LABEL_IMPORTANT_F
 import { Types } from '@lib/types';
 import { TypesOptionsPriority } from '@lib/types/typesOptions';
 import { atomTodoNew } from '@states/todos';
-import { atomQueryTodoItem, atomSelectorTodoItem } from '@states/todos/atomQueries';
+import { selectorSessionTodoItem, atomSelectorTodoItem } from '@states/todos/atomQueries';
 import { classNames } from '@states/utils';
 import { Fragment, Fragment as TodoPriorityFragment } from 'react';
 import { useRecoilCallback, useRecoilValue } from 'recoil';
@@ -38,7 +38,7 @@ export const PriorityButton = ({ todo, options, onClick }: Props) => {
   );
 
   const isTodoCompleted = useRecoilCallback(({ snapshot }) => () => {
-    return typeof todo !== 'undefined' && snapshot.getLoadable(atomQueryTodoItem(todo?._id)).getValue().completed;
+    return typeof todo !== 'undefined' && snapshot.getLoadable(selectorSessionTodoItem(todo?._id)).getValue().completed;
   });
 
   return (

--- a/components/ui/dropdowns/v1/calendarDropdown.tsx
+++ b/components/ui/dropdowns/v1/calendarDropdown.tsx
@@ -11,7 +11,7 @@ import { Menu } from '@headlessui/react';
 import { TypesOptionsDropdown } from '@lib/types/typesOptions';
 import { useCalResetDateAll, useCalResetDateItemOnly, useCalResetDayUpdater } from '@states/calendars/hooks';
 import { atomTodoNew } from '@states/todos';
-import { atomQueryTodoItem, atomSelectorTodoItem } from '@states/todos/atomQueries';
+import { selectorSessionTodoItem, atomSelectorTodoItem } from '@states/todos/atomQueries';
 import { classNames } from '@states/utils';
 import { Calendar } from '@ui/calendars/calendar';
 import { format } from 'date-fns';
@@ -31,7 +31,7 @@ export const CalendarDropdown = ({ todo, onClickConfirm, options }: Props) => {
   const noDaySelected = todoItem.dueDate == null;
   const renderDueDate = noDaySelected ? 'Due date' : format(new Date(todoItem.dueDate as Date), 'MMM dd, yy');
   const isTodoCompleted = useRecoilCallback(({ snapshot }) => () => {
-    return typeof todo !== 'undefined' && snapshot.getLoadable(atomQueryTodoItem(todo?._id)).getValue().completed;
+    return typeof todo !== 'undefined' && snapshot.getLoadable(selectorSessionTodoItem(todo?._id)).getValue().completed;
   });
 
   return (

--- a/components/ui/dropdowns/v1/labelComboBoxDropdown.tsx
+++ b/components/ui/dropdowns/v1/labelComboBoxDropdown.tsx
@@ -7,7 +7,7 @@ import { selectorSelectedLabels } from '@states/labels';
 import { useLabelRemoveItemTitleId } from '@states/labels/hooks';
 import { useTodoModalStateClose } from '@states/modals/hooks';
 import { atomTodoNew } from '@states/todos';
-import { atomQueryTodoItem } from '@states/todos/atomQueries';
+import { selectorSessionTodoItem } from '@states/todos/atomQueries';
 import { classNames, paths } from '@states/utils';
 import { LabelComboBox } from '@ui/comboBoxes/labelComboBox';
 import { LabelsHorizontalGradients } from '@ui/gradients/labelsHorizontalGradients';
@@ -23,9 +23,9 @@ export const LabelComboBoxDropdown = ({ todo, selectedQueryLabels, container }: 
   const scrollRef = useRef<HTMLDivElement>(null);
   const selectedLabels = selectedQueryLabels ? selectedQueryLabels : useRecoilValue(selectorSelectedLabels(todo?._id));
   const isTodoCompleted = useRecoilCallback(({ snapshot }) => () => {
-    return typeof todo !== 'undefined' && snapshot.getLoadable(atomQueryTodoItem(todo?._id)).getValue().completed;
+    return typeof todo !== 'undefined' && snapshot.getLoadable(selectorSessionTodoItem(todo?._id)).getValue().completed;
   });
-  const todoItem = useRecoilValue(typeof todo !== 'undefined' ? atomQueryTodoItem(todo?._id) : atomTodoNew);
+  const todoItem = useRecoilValue(typeof todo !== 'undefined' ? selectorSessionTodoItem(todo?._id) : atomTodoNew);
   const important = todoItem.priorityLevel === PRIORITY_LEVEL['important'];
   const urgent = todoItem.priorityLevel === PRIORITY_LEVEL['urgent'];
   const priority = important || urgent;

--- a/components/ui/dropdowns/v1/todoItemDropdown.tsx
+++ b/components/ui/dropdowns/v1/todoItemDropdown.tsx
@@ -10,7 +10,7 @@ import { TypesOptionsDropdown } from '@lib/types/typesOptions';
 import { useCalUpdateDataItem } from '@states/calendars/hooks';
 import { ActiveDropdownMenuItemEffect } from '@states/misc/activeDropdownMenuItemEffect';
 import { usePriorityUpdate, usePriorityUpdateData } from '@states/priorities/hooks';
-import { atomQueryTodoItem } from '@states/todos/atomQueries';
+import { selectorSessionTodoItem } from '@states/todos/atomQueries';
 import { useTodoRemoveItem } from '@states/todos/hooks';
 import { Types } from 'lib/types';
 import { useRecoilValue } from 'recoil';
@@ -24,7 +24,7 @@ export const TodoItemDropdown = ({ todo, children, options }: Props) => {
   const removeTodo = useTodoRemoveItem(todo?._id);
   const updateCalendarDataItem = useCalUpdateDataItem(todo?._id);
   const setPriority = typeof todo === 'undefined' ? usePriorityUpdate(undefined) : usePriorityUpdateData(todo?._id);
-  const todoItem = useRecoilValue(atomQueryTodoItem(todo?._id));
+  const todoItem = useRecoilValue(selectorSessionTodoItem(todo?._id));
 
   return (
     <Dropdown

--- a/components/ui/modals/confirmModal/deleteConfirmModal/deleteLabelConfirmModal.tsx
+++ b/components/ui/modals/confirmModal/deleteConfirmModal/deleteLabelConfirmModal.tsx
@@ -1,5 +1,5 @@
 import { Labels, Types } from '@lib/types';
-import { atomQueryLabels } from '@states/labels/atomQueries';
+import { selectorSessionLabels } from '@states/labels/atomQueries';
 import { atomConfirmModalDelete } from '@states/modals';
 import { useLabelModalConfirmStateDelete } from '@states/modals/hooks';
 import dynamic from 'next/dynamic';
@@ -13,7 +13,7 @@ type Props = Pick<Types, 'label'>;
 export const DeleteLabelConfirmModal = ({ label }: Props) => {
   const deleteConfirmModal = useLabelModalConfirmStateDelete(label._id);
   const isConfirmModalOpen = useRecoilValue(atomConfirmModalDelete(label._id));
-  const labelItem = useRecoilValue(atomQueryLabels).find((item) => item._id === label._id) || ({} as Labels);
+  const labelItem = useRecoilValue(selectorSessionLabels).find((item) => item._id === label._id) || ({} as Labels);
 
   return (
     <Fragment>

--- a/components/ui/modals/confirmModal/deleteConfirmModal/deleteTodoConfirmModal.tsx
+++ b/components/ui/modals/confirmModal/deleteConfirmModal/deleteTodoConfirmModal.tsx
@@ -1,7 +1,7 @@
 import { Types } from '@lib/types';
 import { atomConfirmModalDelete } from '@states/modals';
 import { useTodoModalConfirmStateDelete } from '@states/modals/hooks';
-import { atomQueryTodoItem } from '@states/todos/atomQueries';
+import { selectorSessionTodoItem } from '@states/todos/atomQueries';
 import dynamic from 'next/dynamic';
 import { Fragment } from 'react';
 import { useRecoilValue } from 'recoil';
@@ -13,7 +13,7 @@ type Props = Pick<Types, 'todo'>;
 export const DeleteTodoConfirmModal = ({ todo }: Props) => {
   const deleteConfirmModal = useTodoModalConfirmStateDelete(todo?._id);
   const isConfirmModalOpen = useRecoilValue(atomConfirmModalDelete(todo?._id));
-  const todoItem = useRecoilValue(atomQueryTodoItem(todo?._id));
+  const todoItem = useRecoilValue(selectorSessionTodoItem(todo?._id));
 
   return (
     <Fragment>

--- a/components/ui/modals/todoModals/itemTodoModal.tsx
+++ b/components/ui/modals/todoModals/itemTodoModal.tsx
@@ -6,7 +6,7 @@ import { Types } from '@lib/types';
 import { KeysWithItemModalEffect } from '@states/keybinds/KeysWithItemModalEffect';
 import { KeysWithTodoModalEffect } from '@states/keybinds/keysWithTodoModalEffect';
 import { atomPriority } from '@states/priorities';
-import { atomQueryTodoItem } from '@states/todos/atomQueries';
+import { selectorSessionTodoItem } from '@states/todos/atomQueries';
 import { useTodoCompleteItem, useTodoUpdateItem } from '@states/todos/hooks';
 import { classNames } from '@states/utils';
 import { useConditionCompareTodoItemsEqual } from '@states/utils/hooks';
@@ -18,7 +18,7 @@ const TodoModal = dynamic(() => import('@modals/todoModals/todoModal').then((mod
 export const ItemTodoModal = ({ todo }: Pick<Types, 'todo'>) => {
   const updateTodo = useTodoUpdateItem(todo._id);
   const completeTodo = useTodoCompleteItem(todo._id);
-  const todoItem = useRecoilValue(atomQueryTodoItem(todo._id));
+  const todoItem = useRecoilValue(selectorSessionTodoItem(todo._id));
   const currentPriority = useRecoilValue(atomPriority(todo._id));
   const condition = useConditionCompareTodoItemsEqual(todo._id);
 
@@ -46,13 +46,11 @@ export const ItemTodoModal = ({ todo }: Pick<Types, 'todo'>) => {
           <DisableButton
             options={optionsButtonItemModalUpdate}
             isConditionalRendering={condition}
-            onClick={() => updateTodo()}
-          >
+            onClick={() => updateTodo()}>
             Update
           </DisableButton>
         </FooterButtonsFragment>
-      }
-    >
+      }>
       <KeysWithTodoModalEffect todo={todo} />
       <KeysWithItemModalEffect todo={todo} />
     </TodoModal>

--- a/components/ui/modals/todoModals/todoModal/index.tsx
+++ b/components/ui/modals/todoModals/todoModal/index.tsx
@@ -12,7 +12,7 @@ import { KeysWithTodoModalEffect } from '@states/keybinds/keysWithTodoModalEffec
 import { DisableScrollEffect } from '@states/misc/disableScrollEffect';
 import { atomTodoModalMax, atomTodoModalOpen } from '@states/modals';
 import { useTodoModalStateClose } from '@states/modals/hooks';
-import { atomQueryTodoItem } from '@states/todos/atomQueries';
+import { selectorSessionTodoItem } from '@states/todos/atomQueries';
 import { useTodoAdd } from '@states/todos/hooks';
 import { classNames } from '@states/utils';
 import { useConditionCheckTodoTitleEmpty } from '@states/utils/hooks';
@@ -36,7 +36,7 @@ export const TodoModal = ({ todo, menuButtonContent, headerButtons, footerButton
   const addTodo = useTodoAdd();
   const condition = useConditionCheckTodoTitleEmpty();
   const isTodoCompleted = useRecoilCallback(({ snapshot }) => () => {
-    return typeof todo !== 'undefined' && snapshot.getLoadable(atomQueryTodoItem(todo._id)).getValue().completed;
+    return typeof todo !== 'undefined' && snapshot.getLoadable(selectorSessionTodoItem(todo._id)).getValue().completed;
   });
 
   return (

--- a/components/ui/modals/todoModals/todoModal/todoModalHeaderContents.tsx
+++ b/components/ui/modals/todoModals/todoModal/todoModalHeaderContents.tsx
@@ -4,7 +4,7 @@ import { PRIORITY_LEVEL } from '@data/dataTypesConst';
 import { Types } from '@lib/types';
 import { HeaderDescription } from '@modals/modal/modalHeaders/headerDescription';
 import { usePriorityUpdate } from '@states/priorities/hooks';
-import { atomQueryTodoItem } from '@states/todos/atomQueries';
+import { selectorSessionTodoItem } from '@states/todos/atomQueries';
 import { useRecoilCallback } from 'recoil';
 
 type Props = Pick<Types, 'children'> & Partial<Pick<Types, 'todo'>>;
@@ -12,7 +12,7 @@ type Props = Pick<Types, 'children'> & Partial<Pick<Types, 'todo'>>;
 export const TodoModalHeaderContents = ({ todo, children }: Props) => {
   const setPriority = usePriorityUpdate(todo?._id);
   const isTodoCompleted = useRecoilCallback(({ snapshot }) => () => {
-    return typeof todo !== 'undefined' && snapshot.getLoadable(atomQueryTodoItem(todo._id)).getValue().completed;
+    return typeof todo !== 'undefined' && snapshot.getLoadable(selectorSessionTodoItem(todo._id)).getValue().completed;
   });
   const disabledStyle = isTodoCompleted() ? 'cursor-not-allowed opacity-50 select-none' : '';
   const conditionalHeaderDescription = isTodoCompleted() ? 'Completed todo' : 'Update todo';

--- a/lib/queries/queryTodos.ts
+++ b/lib/queries/queryTodos.ts
@@ -5,8 +5,8 @@ import { fetchWithRetry, queries } from '@states/utils';
 
 const apiTodos = process.env.NEXT_PUBLIC_API_ENDPOINT_TODOS as string;
 
-export const getDemoTodoItem = async ({ _id }: Pick<Types, '_id'>) => {
-  const data = await Promise.resolve(DATA_DEMO.find((todo) => todo._id === _id) || ({} as Todos));
+export const getDemoTodoItem = ({ _id }: Pick<Types, '_id'>) => {
+  const data = DATA_DEMO.find((todo) => todo._id === _id) || ({} as Todos);
   return data;
 };
 

--- a/lib/states/calendars/hooks.tsx
+++ b/lib/states/calendars/hooks.tsx
@@ -4,7 +4,7 @@ import { Todos } from '@lib/types';
 import { useNotificationState } from '@states/notifications/hooks';
 import { usePriorityRankScore } from '@states/priorities/hooks';
 import { atomTodoNew } from '@states/todos';
-import { atomQueryTodoItem, atomSelectorTodoItem } from '@states/todos/atomQueries';
+import { selectorSessionTodoItem, atomSelectorTodoItem } from '@states/todos/atomQueries';
 import { useGetWithRecoilCallback } from '@states/utils/hooks';
 import {
   parse,
@@ -141,7 +141,7 @@ export const useCalUpdateDataItem = (todoId: Todos['_id']) => {
   const setNotification = useNotificationState();
   const updateCalQueryItem = useRecoilCallback(({ snapshot, set, reset }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
-    set(atomQueryTodoItem(todoId), get(atomSelectorTodoItem(todoId)));
+    set(selectorSessionTodoItem(todoId), get(atomSelectorTodoItem(todoId)));
 
     status === 'authenticated' &&
       updateDataCalendarTodo(
@@ -155,7 +155,7 @@ export const useCalUpdateDataItem = (todoId: Todos['_id']) => {
   return () => {
     updateCalItem();
     updatePriorityRankScore();
-    if (equal(get(atomQueryTodoItem(todoId)).dueDate, get(atomSelectorTodoItem(todoId)).dueDate)) return;
+    if (equal(get(selectorSessionTodoItem(todoId)).dueDate, get(atomSelectorTodoItem(todoId)).dueDate)) return;
     get(atomSelectorTodoItem(todoId)).dueDate
       ? setNotification(NOTIFICATION['updatedDueDate'])
       : setNotification(NOTIFICATION['removedDueDate']);

--- a/lib/states/focus/hooks.tsx
+++ b/lib/states/focus/hooks.tsx
@@ -2,7 +2,7 @@ import { FOCUS } from '@data/dataTypesConst';
 import { Todos, Types } from '@lib/types';
 import { atomTodoModalMini } from '@states/modals';
 import { useTodoModalStateOpen } from '@states/modals/hooks';
-import { atomQueryTodoItem } from '@states/todos/atomQueries';
+import { selectorSessionTodoItem } from '@states/todos/atomQueries';
 import { useRecoilCallback, RecoilValue } from 'recoil';
 import { atomOnFocus, atomCurrentFocus } from '.';
 
@@ -16,7 +16,7 @@ export const useFocusState = (_id: Todos['_id']) => {
 
     switch (state) {
       case FOCUS['openTodoModalOnFocus']:
-        !get(atomQueryTodoItem(_id))?.completed && openModal();
+        !get(selectorSessionTodoItem(_id))?.completed && openModal();
         break;
       case FOCUS['returnOnNoFocus']:
         if (!get(atomOnFocus)) return;

--- a/lib/states/keybinds/KeysWithNavigateEffect.tsx
+++ b/lib/states/keybinds/KeysWithNavigateEffect.tsx
@@ -4,7 +4,7 @@ import { atomCurrentFocus, atomOnBlur } from '@states/focus';
 import { useFocusState } from '@states/focus/hooks';
 import { useKeyWithNavigate } from '@states/keybinds/hooks';
 import { atomTodoModalOpen } from '@states/modals';
-import { atomQueryTodoItem } from '@states/todos/atomQueries';
+import { selectorSessionTodoItem } from '@states/todos/atomQueries';
 import { atomCatch } from '@states/utils';
 import { useEffect } from 'react';
 import { RecoilValue, useRecoilCallback, useRecoilValue } from 'recoil';
@@ -30,7 +30,7 @@ export const KeysWithNavigationEffect = ({ index, divFocus, todo }: Props) => {
       return;
     }
     if (isTodoModalOpen || isConfirmModalOpen || isLabelModalOpen || isComboBoxOpen) return;
-    if (isOnBlur || (get(atomTodoModalOpen(todo._id)) && get(atomQueryTodoItem(todo._id)).completed)) {
+    if (isOnBlur || (get(atomTodoModalOpen(todo._id)) && get(selectorSessionTodoItem(todo._id)).completed)) {
       isOnBlur && reset(atomOnBlur);
       setFocus(FOCUS['resetFocus']);
       divFocus.current?.blur();

--- a/lib/states/keybinds/hooks.tsx
+++ b/lib/states/keybinds/hooks.tsx
@@ -13,7 +13,7 @@ import {
   useTodoModalStateMinimize,
   useTodoModalStateMaximize,
 } from '@states/modals/hooks';
-import { atomQueryTodoItem } from '@states/todos/atomQueries';
+import { selectorSessionTodoItem } from '@states/todos/atomQueries';
 import { useTodoCompleteItem, useTodoRemoveItem, useTodoAdd, useTodoUpdateItem } from '@states/todos/hooks';
 import { atomCatch } from '@states/utils';
 import { useConditionCheckLabelTitleEmpty } from '@states/utils/hooks';
@@ -69,7 +69,7 @@ export const useKeyWithFocus = (_id: Todos['_id']) => {
         openModal();
         break;
       case event.key === 'Escape':
-        if (get(atomQueryTodoItem(_id)).completed && get(atomTodoModalOpen(_id))) return;
+        if (get(selectorSessionTodoItem(_id)).completed && get(atomTodoModalOpen(_id))) return;
         event.preventDefault();
         !get(atomTodoModalMini(_id)) && reset(atomOnFocus);
         reset(atomCurrentFocus);

--- a/lib/states/labels/atomQueries.tsx
+++ b/lib/states/labels/atomQueries.tsx
@@ -3,6 +3,7 @@ import { IDB_KEY, IDB_STORE } from '@data/dataTypesConst';
 import { queryEffect } from '@effects/queryEffects';
 import { getDataLabels } from '@lib/queries/queryLabels';
 import { Labels } from '@lib/types';
+import { atomUserSession } from '@states/users';
 import { atom, selector } from 'recoil';
 
 /**
@@ -26,11 +27,23 @@ export const atomDemoLabels = atom<Labels[]>({
   default: DATA_DEMO_LABELS,
 });
 
+export const selectorSessionLabels = selector<Labels[]>({
+  key: 'selectorSessionLabels',
+  get: ({ get }) => {
+    const session = get(atomUserSession);
+    return session ? get(atomQueryLabels) : get(atomDemoLabels);
+  },
+  set: ({ get, set }, newValue) => {
+    const session = get(atomUserSession);
+    return session ? set(atomQueryLabels, newValue) : set(atomDemoLabels, newValue);
+  },
+});
+
 export const atomSelectorLabels = atom({
   key: 'atomSelectorLabels',
   default: selector({
     key: 'selectorAtomSelectorLabels',
-    get: ({ get }) => get(atomQueryLabels),
+    get: ({ get }) => get(selectorSessionLabels),
     cachePolicy_UNSTABLE: {
       eviction: 'most-recent',
     },

--- a/lib/states/labels/hooks.tsx
+++ b/lib/states/labels/hooks.tsx
@@ -17,7 +17,7 @@ import ObjectID from 'bson-objectid';
 import { useSession } from 'next-auth/react';
 import { RecoilValue, useRecoilCallback } from 'recoil';
 import { atomLabelNew, atomSelectorLabelItem } from '.';
-import { atomQueryLabels, atomSelectorLabels } from './atomQueries';
+import { selectorSessionLabels, atomSelectorLabels } from './atomQueries';
 
 /**
  * Hooks
@@ -45,7 +45,7 @@ export const useLabelAdd = () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
 
     set(atomSelectorLabels, [...get(atomSelectorLabels), { ...get(atomLabelNew) }]);
-    set(atomQueryLabels, [...get(atomQueryLabels), { ...get(atomLabelNew) }]);
+    set(selectorSessionLabels, [...get(selectorSessionLabels), { ...get(atomLabelNew) }]);
 
     status === 'authenticated' && createDataNewLabel(get(atomLabelNew));
     reset(atomLabelNew);
@@ -62,12 +62,12 @@ export const useLabelUpdateItem = (_id: Labels['_id']) => {
   return useRecoilCallback(({ snapshot, set, reset }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
 
-    const updateLabels = get(atomQueryLabels).map((label) => ({
+    const updateLabels = get(selectorSessionLabels).map((label) => ({
       ...label,
       name: label._id === _id ? get(atomSelectorLabelItem(label._id)).name : label.name,
     }));
 
-    set(atomQueryLabels, updateLabels);
+    set(selectorSessionLabels, updateLabels);
     status === 'authenticated' && updateDataLabelItem(_id, get(atomSelectorLabelItem(_id)));
 
     reset(atomLabelModalOpen(_id));
@@ -90,7 +90,7 @@ export const useLabelRemoveItem = (_id: Labels['_id']) => {
     }
 
     const removeLabel = get(atomSelectorLabels).filter((label) => label._id !== _id);
-    set(atomQueryLabels, removeLabel);
+    set(selectorSessionLabels, removeLabel);
     status === 'authenticated' && deleteDataLabelItem(_id);
     setNotification(NOTIFICATION['deleteLabel']);
     get(atomCatch(CATCH.labelModal)) && reset(atomCatch(CATCH.labelModal));
@@ -142,7 +142,7 @@ export const useLabelUpdateDataItem = () => {
     const updatedLabels = get(atomSelectorLabels);
     const filteredLabels = compareLabelsToQueryLabel(get(atomSelectorLabels));
 
-    set(atomQueryLabels, updatedLabels);
+    set(selectorSessionLabels, updatedLabels);
     if (filteredLabels.length === 0) return;
     status === 'authenticated' && updateDataLabels(filteredLabels);
     reset(atomSelectorLabels);
@@ -154,7 +154,7 @@ export const useLabelChangeHandler = (_id: Todos['_id']) => {
   return useRecoilCallback(({ set, snapshot }) => (selected: Labels[]) => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
     const todoId = _id ? _id! : get(atomTodoNew)._id!;
-    const labels = get(atomQueryLabels);
+    const labels = get(selectorSessionLabels);
     const isTodoModalOpen = get(atomCatch(CATCH['todoModal']));
 
     const labelsUpdatedChanges = [...labels].map((label) => {

--- a/lib/states/labels/index.tsx
+++ b/lib/states/labels/index.tsx
@@ -2,7 +2,7 @@ import { Labels, Todos } from '@lib/types';
 import { atomComboBoxQuery, atomFilterSelected } from '@states/comboBoxes';
 import { atomTodoNew } from '@states/todos';
 import { atom, atomFamily, selectorFamily } from 'recoil';
-import { atomQueryLabels, atomSelectorLabels } from './atomQueries';
+import { selectorSessionLabels, atomSelectorLabels } from './atomQueries';
 
 /*
  * Atom
@@ -25,7 +25,7 @@ export const atomSelectorLabelItem = atomFamily<Labels, Labels['_id']>({
     get:
       (label_id) =>
       ({ get }) =>
-        get(atomQueryLabels).find((label) => label._id === label_id) || ({} as Labels),
+        get(selectorSessionLabels).find((label) => label._id === label_id) || ({} as Labels),
   }),
 });
 
@@ -56,7 +56,7 @@ export const selectorSelectedQueryLabels = selectorFamily<Labels[], Todos['_id']
     (_id) =>
     ({ get }) => {
       const todoId = _id ? _id! : get(atomTodoNew)._id!;
-      return get(atomQueryLabels).filter((label) => label.title_id && label.title_id.includes(todoId));
+      return get(selectorSessionLabels).filter((label) => label.title_id && label.title_id.includes(todoId));
     },
   cachePolicy_UNSTABLE: {
     eviction: 'most-recent',

--- a/lib/states/priorities/hooks.tsx
+++ b/lib/states/priorities/hooks.tsx
@@ -2,7 +2,7 @@ import { PRIORITY_LEVEL } from '@data/dataTypesConst';
 import { updateDataPriorityTodo } from '@lib/queries/queryTodos';
 import { Todos } from '@lib/types';
 import { atomTodoNew } from '@states/todos';
-import { atomQueryTodoIds, atomQueryTodoItem, atomSelectorTodoItem } from '@states/todos/atomQueries';
+import { selectorSessionTodoIds, selectorSessionTodoItem, atomSelectorTodoItem } from '@states/todos/atomQueries';
 import { useSession } from 'next-auth/react';
 import { RecoilValue, useRecoilCallback } from 'recoil';
 import { atomPriority, selectorPriorityRankScore } from '.';
@@ -67,18 +67,18 @@ export const usePriorityUpdateData = (todoId: Todos['_id']) => {
   const updatePriorityDataItem = useRecoilCallback(({ snapshot, set, reset }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
 
-    set(atomQueryTodoItem(todoId), {
-      ...get(atomQueryTodoItem(todoId)),
+    set(selectorSessionTodoItem(todoId), {
+      ...get(selectorSessionTodoItem(todoId)),
       priorityLevel: get(atomSelectorTodoItem(todoId)).priorityLevel,
       priorityRankScore: get(atomSelectorTodoItem(todoId)).priorityRankScore,
     });
 
     set(
-      atomQueryTodoIds,
-      get(atomQueryTodoIds).map((todo) => {
+      selectorSessionTodoIds,
+      get(selectorSessionTodoIds).map((todo) => {
         return {
           ...todo,
-          priorityLevel: todo._id === todoId ? get(atomQueryTodoItem(todoId)).priorityLevel : todo.priorityLevel,
+          priorityLevel: todo._id === todoId ? get(selectorSessionTodoItem(todoId)).priorityLevel : todo.priorityLevel,
         };
       }),
     );

--- a/lib/states/priorities/index.tsx
+++ b/lib/states/priorities/index.tsx
@@ -1,7 +1,7 @@
 import { PRIORITY_LEVEL } from '@data/dataTypesConst';
 import { Todos } from '@lib/types';
 import { selectorDynamicTodoItem } from '@states/todos';
-import { atomQueryTodoIds } from '@states/todos/atomQueries';
+import { selectorSessionTodoIds } from '@states/todos/atomQueries';
 import { subDays, differenceInDays } from 'date-fns';
 import { atomFamily, selectorFamily, selector } from 'recoil';
 
@@ -37,13 +37,13 @@ export const selectorFilterPriorityRankScore = selector({
   key: 'selectorFilterPriorityRankScore',
   get: ({ get }) => {
     const taskCapacity = get(selectorTaskCompleteCapacity);
-    const prsUrgentFiltered = get(atomQueryTodoIds).filter(
+    const prsUrgentFiltered = get(selectorSessionTodoIds).filter(
       (todo) => !todo.completed && todo.priorityLevel === PRIORITY_LEVEL['urgent'],
     );
-    const prsImportantFiltered = get(atomQueryTodoIds).filter(
+    const prsImportantFiltered = get(selectorSessionTodoIds).filter(
       (todo) => !todo.completed && todo.priorityLevel === PRIORITY_LEVEL['important'],
     );
-    const prsNormalFiltered = get(atomQueryTodoIds).filter(
+    const prsNormalFiltered = get(selectorSessionTodoIds).filter(
       (todo) =>
         !todo.completed &&
         todo.priorityLevel !== PRIORITY_LEVEL['urgent'] &&
@@ -90,7 +90,7 @@ export const selectorTaskCompleteCapacity = selector({
   key: 'selectorTaskCompleteCapacity',
   get: ({ get }) => {
     const fiveDaysFromToday = subDays(new Date(), 5);
-    const todoIdsCompletedLastFiveDays = get(atomQueryTodoIds).filter((todo) => {
+    const todoIdsCompletedLastFiveDays = get(selectorSessionTodoIds).filter((todo) => {
       const fiveDaysFromTodayCompleted = new Date(todo.completedDate!) > fiveDaysFromToday;
       return todo.completed && fiveDaysFromTodayCompleted;
     });
@@ -110,7 +110,7 @@ export const selectorPrsDueDate = selectorFamily<number, Todos['_id']>({
       const taskCapacityPerDay = get(selectorTaskCompleteCapacity);
       const todoItem = get(selectorDynamicTodoItem(todoId));
       const priority = get(selectorDynamicPriority(todoId)) as PRIORITY_LEVEL;
-      const totalUncompletedTodos = get(atomQueryTodoIds).filter((todo) => !todo.completed).length;
+      const totalUncompletedTodos = get(selectorSessionTodoIds).filter((todo) => !todo.completed).length;
       const dueDate = todoItem.dueDate != null && todoItem.dueDate;
       const daysToDueDate = differenceInDays(new Date(dueDate as Date), new Date()) + 1;
       const overDueFactor = Math.abs(daysToDueDate) * 200;

--- a/lib/states/todos/filterTodoIdsEffect.tsx
+++ b/lib/states/todos/filterTodoIdsEffect.tsx
@@ -1,7 +1,7 @@
 import { PATHNAME, PATHNAME_IMAGE } from '@data/dataTypesConst';
 import { Labels } from '@lib/types';
 import { atomLabelQuerySlug } from '@states/labels';
-import { atomQueryLabels } from '@states/labels/atomQueries';
+import { selectorSessionLabels } from '@states/labels/atomQueries';
 import { atomHtmlTitleTag, atomPathnameImage } from '@states/misc';
 import { useNextQuery } from '@states/utils/hooks';
 import { useRouter } from 'next/router';
@@ -12,7 +12,7 @@ import { atomFilterTodoIds } from '.';
 export const FilterTodoIdsEffect = () => {
   const labelId = useNextQuery({ path: PATHNAME['label'] });
   const { asPath } = useRouter();
-  const labels = useRecoilValue(atomQueryLabels);
+  const labels = useRecoilValue(selectorSessionLabels);
   const label_id = useRecoilValue(atomLabelQuerySlug);
   const label = labels.find((label) => label._id === label_id) || ({} as Labels);
 

--- a/lib/states/todos/index.tsx
+++ b/lib/states/todos/index.tsx
@@ -1,10 +1,10 @@
 import { PATHNAME, PRIORITY_LEVEL, OBJECT_ID } from '@data/dataTypesConst';
 import { Labels, TodoIds, Todos, Types } from '@lib/types';
 import { atomLabelQuerySlug } from '@states/labels';
-import { atomQueryLabels } from '@states/labels/atomQueries';
+import { selectorSessionLabels } from '@states/labels/atomQueries';
 import { selectorFilterPriorityRankScore } from '@states/priorities';
 import { atom, selector, selectorFamily } from 'recoil';
-import { atomQueryTodoIds, atomSelectorTodoItem } from './atomQueries';
+import { selectorSessionTodoIds, atomSelectorTodoItem } from './atomQueries';
 
 /**
  * atoms
@@ -58,7 +58,7 @@ export const selectorFilterTodoIds = selector({
       case 'label':
         return get(selectorFilterTodoIdsByPathname(PATHNAME['label']));
       default:
-        return get(atomQueryTodoIds).filter((todo) => !todo.completed);
+        return get(selectorSessionTodoIds).filter((todo) => !todo.completed);
     }
   },
   cachePolicy_UNSTABLE: {
@@ -75,22 +75,22 @@ export const selectorFilterTodoIdsByPathname = selectorFamily<TodoIds[], PATHNAM
         case PATHNAME['app']:
           return get(selectorFilterPriorityRankScore);
         case PATHNAME['urgent']:
-          return get(atomQueryTodoIds).filter(
+          return get(selectorSessionTodoIds).filter(
             (todo) => !todo.completed && todo.priorityLevel === PRIORITY_LEVEL['urgent'],
           );
         case PATHNAME['important']:
-          return get(atomQueryTodoIds).filter(
+          return get(selectorSessionTodoIds).filter(
             (todo) => !todo.completed && todo.priorityLevel === PRIORITY_LEVEL['important'],
           );
         case PATHNAME['showAll']:
-          return get(atomQueryTodoIds).filter((todo) => !todo.completed);
+          return get(selectorSessionTodoIds).filter((todo) => !todo.completed);
         case PATHNAME['completed']:
-          return get(atomQueryTodoIds).filter((todo) => todo.completed);
+          return get(selectorSessionTodoIds).filter((todo) => todo.completed);
         case PATHNAME['label']:
-          const titleIdsByCurrentLabel = get(atomQueryLabels).filter(
+          const titleIdsByCurrentLabel = get(selectorSessionLabels).filter(
             (label) => label._id === get(atomLabelQuerySlug),
           )[0]?.title_id;
-          return get(atomQueryTodoIds).filter((todo) => {
+          return get(selectorSessionTodoIds).filter((todo) => {
             const todoId = todo._id as OBJECT_ID;
             return !todo.completed && titleIdsByCurrentLabel && titleIdsByCurrentLabel.includes(todoId);
           });
@@ -106,8 +106,8 @@ export const selectorFilterTodoIdsByLabelQueryId = selectorFamily<TodoIds[], Lab
   get:
     (labelId) =>
     ({ get }) => {
-      const titleIdsByCurrentLabel = get(atomQueryLabels).filter((label) => label._id === labelId)[0]?.title_id;
-      return get(atomQueryTodoIds).filter((todo) => {
+      const titleIdsByCurrentLabel = get(selectorSessionLabels).filter((label) => label._id === labelId)[0]?.title_id;
+      return get(selectorSessionTodoIds).filter((todo) => {
         const todoId = todo._id as OBJECT_ID;
         return !todo.completed && titleIdsByCurrentLabel && titleIdsByCurrentLabel.includes(todoId);
       });
@@ -125,9 +125,9 @@ export const selectorTodosCount = selectorFamily<
   get:
     ({ labelId, pathname }) =>
     ({ get }) => {
-      const labels = get(atomQueryLabels);
+      const labels = get(selectorSessionLabels);
       if (labelId) {
-        const todos = get(atomQueryTodoIds);
+        const todos = get(selectorSessionTodoIds);
         const titleIds = labels.filter((item) => item._id === labelId)[0]?.title_id;
         const todoIds = todos.filter((todo) => !todo.completed && titleIds && titleIds.includes(todo._id as OBJECT_ID));
         return todoIds.length;

--- a/lib/states/users/userSessionResetEffect.tsx
+++ b/lib/states/users/userSessionResetEffect.tsx
@@ -1,6 +1,6 @@
 import { STORAGE_KEY } from '@data/dataTypesConst';
-import { atomQueryLabels } from '@states/labels/atomQueries';
-import { atomQueryTodoIds } from '@states/todos/atomQueries';
+import { selectorSessionLabels } from '@states/labels/atomQueries';
+import { selectorSessionTodoIds } from '@states/todos/atomQueries';
 import { getSessionStorage, setSessionStorage } from '@states/utils';
 import { deleteDB } from 'idb';
 import { useSession } from 'next-auth/react';
@@ -18,8 +18,8 @@ export const UserSessionResetEffect = () => {
 
   const userSession = useRecoilCallback(({ reset }) => () => {
     if (offSession) {
-      reset(atomQueryTodoIds);
-      reset(atomQueryLabels);
+      reset(selectorSessionTodoIds);
+      reset(selectorSessionLabels);
       localStorage.removeItem(STORAGE_KEY['labels']);
       localStorage.removeItem(STORAGE_KEY['todoIds']);
       clearIndexedDB();

--- a/lib/states/utils/hooks.tsx
+++ b/lib/states/utils/hooks.tsx
@@ -1,9 +1,9 @@
 import { Labels, Todos } from '@lib/types';
 import { atomLabelNew, atomSelectorLabelItem } from '@states/labels';
-import { atomQueryLabels } from '@states/labels/atomQueries';
+import { selectorSessionLabels } from '@states/labels/atomQueries';
 import { atomTodoModalMini, atomTodoModalOpen } from '@states/modals';
 import { atomTodoNew } from '@states/todos';
-import { atomQueryTodoItem, atomSelectorTodoItem } from '@states/todos/atomQueries';
+import { selectorSessionTodoItem, atomSelectorTodoItem } from '@states/todos/atomQueries';
 import equal from 'fast-deep-equal/react';
 import { useRouter } from 'next/router';
 import { RefObject, useEffect, useMemo, useState } from 'react';
@@ -41,7 +41,7 @@ export const useConditionCheckLabelTitleEmpty = () => {
 
 export const useConditionCompareTodoItemsEqual = (_id: Todos['_id']) => {
   if (typeof _id === 'undefined') return;
-  const todoItem = useRecoilValue(atomQueryTodoItem(_id));
+  const todoItem = useRecoilValue(selectorSessionTodoItem(_id));
   const selectorTodoItem = useRecoilValue(atomSelectorTodoItem(_id));
   const todoItemCompletedEqual = equal(todoItem.completed, selectorTodoItem.completed);
   // Disable update button if completed
@@ -50,7 +50,7 @@ export const useConditionCompareTodoItemsEqual = (_id: Todos['_id']) => {
 
 export const useConditionCompareLabelItemsEqual = (_id: Labels['_id']) => {
   if (typeof _id === 'undefined') return;
-  const labels = useRecoilValue(atomQueryLabels);
+  const labels = useRecoilValue(selectorSessionLabels);
   const labelItem = labels.find((label) => label._id === _id) || ({} as Labels);
   const labelItemCompare = useRecoilValue(atomSelectorLabelItem(_id));
   return equal(labelItem, labelItemCompare);
@@ -117,7 +117,7 @@ export const useCompareToQueryLabels = () => {
   return useRecoilCallback(({ snapshot }) => (compare: Labels[]) => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
     return compare.filter((label) => {
-      return !get(atomQueryLabels).find((queryLabel) => equal(label, queryLabel));
+      return !get(selectorSessionLabels).find((queryLabel) => equal(label, queryLabel));
     });
   });
 };

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,10 +1,10 @@
 import { NextPage } from 'next';
 import { SessionProvider } from 'next-auth/react';
 import type { AppProps } from 'next/app';
+import dynamic from 'next/dynamic';
 import { ReactElement, ReactNode } from 'react';
 import { RecoilRoot } from 'recoil';
 import '../styles/globals.css';
-import dynamic from 'next/dynamic';
 
 const UserSessionEffect = dynamic(() => import('@states/users/userSessionEffect').then((mod) => mod.UserSessionEffect));
 


### PR DESCRIPTION
Introduce session selectors, which return state atoms based on the user's session. These selectors enable different behavior for authenticated (`atomQueryTodoIds`) and unauthenticated (`atomDemoTodoIds`) users.

Replace all instances of selectors, atoms, and hooks that previously used atomQueries

Add UserSessionEffect to the `_app` file to handle session-related side effects