### PR TITLE
feat: optimize rendering by suppressing flickering

### DIFF
--- a/lib/states/users/index.tsx
+++ b/lib/states/users/index.tsx
@@ -18,5 +18,4 @@ export const atomUserVerificationRequest = atom({
 
 export const atomUserSession = atom({
   key: 'atomUserSession',
-  default: false,
 });

--- a/lib/states/users/userSessionEffect.tsx
+++ b/lib/states/users/userSessionEffect.tsx
@@ -7,15 +7,20 @@ import { atomUserSession } from '.';
 
 export const UserSessionEffect = () => {
   const { data: session } = useSession();
+  const offSession = session === null && typeof session !== 'undefined';
 
-  const sessionHandler = useRecoilCallback(({ set, reset }) => () => {
+  const sessionHandler = useRecoilCallback(({ set }) => async () => {
+    if (typeof session === 'undefined') return;
+    if (offSession) {
+      set(atomUserSession, false);
+      setSessionStorage(STORAGE_KEY['offSession'], true);
+      return;
+    }
     if (session) {
       set(atomUserSession, true);
       delSessionStorage(STORAGE_KEY['offSession']);
       return;
     }
-    reset(atomUserSession);
-    setSessionStorage(STORAGE_KEY['offSession'], true);
   });
 
   useEffect(() => {

--- a/lib/states/users/userSessionResetEffect.tsx
+++ b/lib/states/users/userSessionResetEffect.tsx
@@ -20,8 +20,7 @@ export const UserSessionResetEffect = () => {
     if (offSession) {
       reset(selectorSessionTodoIds);
       reset(selectorSessionLabels);
-      localStorage.removeItem(STORAGE_KEY['labels']);
-      localStorage.removeItem(STORAGE_KEY['todoIds']);
+      localStorage.clear();
       clearIndexedDB();
       return;
     }


### PR DESCRIPTION
Update the `atomUserSession` atom to initially return a pending state instead of a default value. This provides two benefits:
- Prevents the atom from returning a false value when the session is undefined
- Reduces flickering caused by state changes, as many other atoms depend on the boolean value of `atomUserSession`, which gets its value from Next-Auth's session