### PR TITLE
feat: add server-side retention policy

### DIFF
--- a/lib/data/dataTypesConst.tsx
+++ b/lib/data/dataTypesConst.tsx
@@ -212,3 +212,8 @@ export const GRADIENT_POSITION = {
   top: 'top',
   bottom: 'bottom',
 } as const;
+
+export type RETENTION = (typeof RETENTION)[keyof typeof RETENTION];
+export const RETENTION = {
+  7: 7,
+};

--- a/lib/models/Label/index.ts
+++ b/lib/models/Label/index.ts
@@ -25,7 +25,6 @@ const LabelSchema = new mongoose.Schema({
   ],
   update: {
     type: Number,
-    default: Date.now,
     required: false,
   },
   deleted: {
@@ -37,8 +36,12 @@ const LabelSchema = new mongoose.Schema({
     type: mongoose.Types.ObjectId,
     required: false,
   },
+  expireAt: {
+    type: Date,
+  },
 });
 LabelSchema.index({ deleted: 1, update: 1, title_id: 1, user_id: -1 }, { unique: true });
 LabelSchema.index({ name: 'text' });
+LabelSchema.index({ expireAt: 1 }, { expireAfterSeconds: 0 });
 
 export default mongoose.models['Labels'] || mongoose.model('Labels', LabelSchema);

--- a/lib/models/Todo/TodoItems.ts
+++ b/lib/models/Todo/TodoItems.ts
@@ -40,7 +40,6 @@ const TodoItemSchema = new mongoose.Schema({
   },
   update: {
     type: Number,
-    default: Date.now,
     required: false,
   },
   deleted: {
@@ -52,8 +51,12 @@ const TodoItemSchema = new mongoose.Schema({
     type: mongoose.Types.ObjectId,
     required: true,
   },
+  expireAt: {
+    type: Date,
+  },
 });
 TodoItemSchema.index({ deleted: 1, update: 1, user_id: -1 }, { unique: true });
 TodoItemSchema.index({ title: 'text' });
+TodoItemSchema.index({ expireAt: 1 }, { expireAfterSeconds: 0 });
 
 export default mongoose.models['Todo-Items'] || mongoose.model('Todo-Items', TodoItemSchema);

--- a/lib/models/Todo/TodoNotes.ts
+++ b/lib/models/Todo/TodoNotes.ts
@@ -13,7 +13,6 @@ const TodoNoteSchema = new mongoose.Schema({
   },
   update: {
     type: Number,
-    default: Date.now,
     required: false,
   },
   deleted: {
@@ -25,9 +24,13 @@ const TodoNoteSchema = new mongoose.Schema({
     type: mongoose.Types.ObjectId,
     required: true,
   },
+  expireAt: {
+    type: Date,
+  },
 });
 
 TodoNoteSchema.index({ deleted: 1, update: 1, title_id: 1, user_id: -1 }, { unique: true });
 TodoNoteSchema.index({ note: 'text' });
+TodoNoteSchema.index({ expireAt: 1 }, { expireAfterSeconds: 0 });
 
 export default mongoose.models['Todo-Notes'] || mongoose.model('Todo-Notes', TodoNoteSchema);

--- a/lib/models/User/index.ts
+++ b/lib/models/User/index.ts
@@ -16,9 +16,14 @@ const UserSchema = new mongoose.Schema({
     type: String,
     required: false,
   },
+  expireAt: {
+    type: Date,
+  },
 });
 
 // next-auth is already indexing the user's information. Additional indexing such
 // as `UserSchema.index({email: text})` will cause issue with login.
+
+UserSchema.index({ expireAt: 1 }, { expireAfterSeconds: 0 });
 
 export default mongoose.models.User || mongoose.model('User', UserSchema);

--- a/lib/states/utils/index.tsx
+++ b/lib/states/utils/index.tsx
@@ -82,3 +82,12 @@ export const getSessionStorage = (queryKey: STORAGE_KEY) => {
 export const setSessionStorage = (queryKey: STORAGE_KEY, value: unknown) =>
   sessionStorage.setItem(queryKey, JSON.stringify(value));
 export const delSessionStorage = (queryKey: STORAGE_KEY) => sessionStorage.removeItem(queryKey);
+
+export const retentionPolicy = ({ day }: { day: number }) => {
+  //set 0 to set to 5 second as immediate action or set day to set day
+  const now = (time?: number) => new Date(Date.now() + 1000 * (time ?? 5));
+  if (day === 0) {
+    return now();
+  }
+  return now(60 * 60 * 24 * day);
+};

--- a/pages/api/v1/labels/[labelId].tsx
+++ b/pages/api/v1/labels/[labelId].tsx
@@ -1,10 +1,11 @@
-import { OBJECT_ID } from '@data/dataTypesConst';
+import { OBJECT_ID, RETENTION } from '@data/dataTypesConst';
 import { databaseConnect } from '@lib/dataConnections/databaseConnection';
 import Label from '@lib/models/Label';
 import { Labels } from '@lib/types';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '../auth/[...nextauth]';
+import { retentionPolicy } from '@states/utils';
 
 const LabelById = async (req: NextApiRequest, res: NextApiResponse) => {
   await databaseConnect();
@@ -57,8 +58,13 @@ const LabelById = async (req: NextApiRequest, res: NextApiResponse) => {
         const deleteLabelById = await Label.findByIdAndUpdate(
           labelId,
           {
+            // later deleted value can be passed through DELETE request with body to create the trashcan.
+            // example:
+            // deleted: deleted
+            // expireAt: deleted ? retentionPolicy({ day: RETENTION['7'] }) : undefined
             update: Date.now(),
             deleted: true,
+            expireAt: retentionPolicy({ day: RETENTION['7'] }),
           },
           {
             new: true,

--- a/pages/api/v1/todos/[todoId].tsx
+++ b/pages/api/v1/todos/[todoId].tsx
@@ -1,4 +1,4 @@
-import { OBJECT_ID, SCHEMA_TODO } from '@data/dataTypesConst';
+import { OBJECT_ID, RETENTION, SCHEMA_TODO } from '@data/dataTypesConst';
 import { aggregatedTodoItem } from '@lib/dataConnections/aggregationPipeline';
 import { databaseConnect } from '@lib/dataConnections/databaseConnection';
 import Label from '@lib/models/Label';
@@ -9,6 +9,7 @@ import mongoose from 'mongoose';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '../auth/[...nextauth]';
+import { retentionPolicy } from '@states/utils';
 
 const TodosById = async (req: NextApiRequest, res: NextApiResponse) => {
   await databaseConnect();
@@ -152,12 +153,20 @@ const TodosById = async (req: NextApiRequest, res: NextApiResponse) => {
       sessionDelete.startTransaction();
       const deleteItem = await TodoItem.findOneAndUpdate(
         filter(SCHEMA_TODO['todoItem']),
-        { deleted: true, update: Date.now() },
+        {
+          deleted: true,
+          update: Date.now(),
+          expireAt: retentionPolicy({ day: RETENTION['7'] }),
+        },
         { session: sessionDelete, new: true, runValidators: true },
       );
       const deleteNote = await TodoNote.findOneAndUpdate(
         filter(SCHEMA_TODO['todoNote']),
-        { update: Date.now(), deleted: true },
+        {
+          update: Date.now(),
+          deleted: true,
+          expireAt: retentionPolicy({ day: RETENTION['7'] }),
+        },
         { session: sessionDelete, new: true, runValidators: true },
       );
 


### PR DESCRIPTION
Implement a server-side retention policy at the API endpoint, with a default value of 7 days. When a user deletes an item (either a todo or a label), the item will be soft deleted and a retention policy will be applied. The item will then be completely removed from the database after 7 days.

This functionality can later be utilized to create a trashcan module, allowing users to set custom retention policies.