### PR TITLE
fix: fix the label update issue

### DIFF
--- a/lib/models/Label/index.ts
+++ b/lib/models/Label/index.ts
@@ -41,7 +41,6 @@ const LabelSchema = new mongoose.Schema({
   },
 });
 LabelSchema.index({ deleted: 1, update: 1, title_id: 1, user_id: -1 }, { unique: true });
-LabelSchema.index({ name: 'text' });
 LabelSchema.index({ expireAt: 1 }, { expireAfterSeconds: 0 });
 
 export default mongoose.models['Labels'] || mongoose.model('Labels', LabelSchema);

--- a/lib/models/Todo/TodoItems.ts
+++ b/lib/models/Todo/TodoItems.ts
@@ -56,7 +56,6 @@ const TodoItemSchema = new mongoose.Schema({
   },
 });
 TodoItemSchema.index({ deleted: 1, update: 1, user_id: -1 }, { unique: true });
-TodoItemSchema.index({ title: 'text' });
 TodoItemSchema.index({ expireAt: 1 }, { expireAfterSeconds: 0 });
 
 export default mongoose.models['Todo-Items'] || mongoose.model('Todo-Items', TodoItemSchema);

--- a/lib/models/Todo/TodoNotes.ts
+++ b/lib/models/Todo/TodoNotes.ts
@@ -30,7 +30,6 @@ const TodoNoteSchema = new mongoose.Schema({
 });
 
 TodoNoteSchema.index({ deleted: 1, update: 1, title_id: 1, user_id: -1 }, { unique: true });
-TodoNoteSchema.index({ note: 'text' });
 TodoNoteSchema.index({ expireAt: 1 }, { expireAfterSeconds: 0 });
 
 export default mongoose.models['Todo-Notes'] || mongoose.model('Todo-Notes', TodoNoteSchema);


### PR DESCRIPTION
This commit addresses the issue where label updates would randomly fail
during PUT requests. The root cause was determined to be a database
conflict caused by indexing on the label's name through the `text`
field. By removing the index for the `text` field, the issue has been
resolved.

## Fix:
- fix: resolve label update failure on PUT requests (#422)