### PR TITLE
fix: resolve random label update failures

### DIFF
--- a/lib/models/Label/index.ts
+++ b/lib/models/Label/index.ts
@@ -17,12 +17,10 @@ const LabelSchema = new mongoose.Schema({
     type: String,
     required: false,
   },
-  title_id: [
-    {
-      type: mongoose.Types.ObjectId,
-      required: false,
-    },
-  ],
+  title_id: {
+    type: [mongoose.Types.ObjectId],
+    required: false,
+  },
   update: {
     type: Number,
     required: false,

--- a/lib/queries/queryLabels.ts
+++ b/lib/queries/queryLabels.ts
@@ -42,7 +42,7 @@ export const updateDataLabels = async (data: Labels[]) => {
 
 export const updateDataLabelItem = async (_id: Labels['_id'], data: Labels) => {
   const response = await fetchWithRetry(`${apiLabels}/${_id}`, {
-    method: 'PUT',
+    method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   });

--- a/lib/sanitizers/sanitizedSchemas.tsx
+++ b/lib/sanitizers/sanitizedSchemas.tsx
@@ -22,10 +22,10 @@ export const sanitizedUserTodoNote = (data: Todos) => {
   };
 };
 
-export const sanitizedUserLabels = (data: Todos) => {
+export const sanitizedUserLabels = (data: Todos['labelItem'] | Labels[]) => {
   return (
-    data.labelItem &&
-    (data.labelItem.map((labelItem) => {
+    data &&
+    (data.map((labelItem) => {
       const sanitizedLabelItem = sanitizeObject(labelItem);
       const sanitizedTitleIds = labelItem.title_id?.map((id) => sanitize(id as string)) as OBJECT_ID[];
       return {

--- a/pages/api/v1/labels/[labelId].tsx
+++ b/pages/api/v1/labels/[labelId].tsx
@@ -18,10 +18,10 @@ const LabelById = async (req: NextApiRequest, res: NextApiResponse) => {
     query: { labelId },
   } = req;
 
-  const data: Labels = body;
+  const dataPatch: Labels = body;
 
+  const sanitizedData = sanitizeObject(dataPatch) as Labels;
   const sanitizedLabelId = labelId ? sanitize(labelId as string) : undefined;
-  const sanitizedData = sanitizeObject(data) as Labels;
 
   const filter: Partial<Labels> = {
     _id: sanitizedLabelId as OBJECT_ID,
@@ -40,7 +40,7 @@ const LabelById = async (req: NextApiRequest, res: NextApiResponse) => {
         res.status(400).json({ success: false });
       }
       break;
-    case 'PUT':
+    case 'PATCH':
       if (!session) return res.status(401).json({ success: false, message: 'unauthorized access' });
 
       try {

--- a/pages/api/v1/labels/index.tsx
+++ b/pages/api/v1/labels/index.tsx
@@ -1,5 +1,6 @@
 import { databaseConnect } from '@lib/dataConnections/databaseConnection';
 import Label from '@lib/models/Label';
+import { sanitizedUserLabels } from '@lib/sanitizers/sanitizedSchemas';
 import { Labels } from '@lib/types';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth';
@@ -15,8 +16,6 @@ const Labels = async (req: NextApiRequest, res: NextApiResponse) => {
     body,
     query: { update: lastUpdate },
   } = req;
-
-  const data: Labels = body;
 
   const filter: Partial<Labels> = {
     user_id: userId,
@@ -43,7 +42,9 @@ const Labels = async (req: NextApiRequest, res: NextApiResponse) => {
     case 'POST':
       if (!session) return res.status(401).json({ success: false, message: 'unauthorized access' });
 
-      const { _id, parent_id, title_id, name, color } = data;
+      const dataPost: Labels = body;
+
+      const { _id, parent_id, title_id, name, color } = dataPost;
       const labelItem = { _id, parent_id, title_id, name, color, update: Date.now(), user_id: userId };
       try {
         const createLabel = await Label.create(labelItem);
@@ -55,27 +56,27 @@ const Labels = async (req: NextApiRequest, res: NextApiResponse) => {
     case 'PUT':
       if (!session) return res.status(401).json({ success: false, message: 'unauthorized access' });
 
-      const arrayObjectData: Labels[] = body;
+      const dataPut: Labels[] = body;
+      const sanitizedLabels = sanitizedUserLabels(dataPut);
+
       try {
-        const updateLabel = await Promise.all(
-          arrayObjectData.map(async (label: Labels) => {
-            const updatedLabel = {
-              ...label,
-              update: Date.now(),
-            };
-            return await Label.updateMany(
-              { _id: label._id },
-              { $set: updatedLabel },
-              { upsert: true, new: true, runValidators: true },
-            );
-          }),
+        const sanitizedUpdateLabel = sanitizedLabels.map((label) => {
+          return {
+            ...label,
+            update: Date.now(),
+          };
+        });
+
+        const updateLabel = sanitizedUpdateLabel.map((label) =>
+          Label.updateMany({ _id: label._id }, { $set: label }, { upsert: true, runValidators: true }),
         );
-        if (!updateLabel) return res.status(400).json({ success: false });
-        res.status(200).json({ success: true, data: updateLabel });
+
+        const updatedLabel = await Promise.all(updateLabel);
+
+        res.status(200).json({ success: true, data: updatedLabel });
       } catch (error) {
         res.status(400).json({ success: false });
       }
-
       break;
     default:
       res.status(400).json({ success: false });


### PR DESCRIPTION
The primary cause of the issue was related to how data processing was handled on the server. Updating labels often involves an array of objects containing multiple values. Previously, updating each document with Promise.all() would randomly fail during the update process. The refactored code now utilizes updateMany() to correctly update multiple documents at once, resolving the issue.