### PR TITLE
fix: resolve deployment error when VPC_CONNECTOR is empty

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -66,4 +66,6 @@ for env_var_name in "${secret_env_vars[@]}"; do
   SECRET_FLAG="$SECRET_FLAG --update-secrets $env_var_name=$secret_name:latest"
 done
 
-gcloud_run_deploy $VPC_FLAG $SECRET_FLAG
+gcloud_run_deploy 
+
+


### PR DESCRIPTION
Resolve the deployment error caused by empty or unset VPC_CONNECTOR and VPC_REGION values in the .env.local file. The issue originated from the deploy.sh script always running with the VPC_FLAG. By removing the VPC_FLAG from the gcloud_run_deploy function call in deploy.sh, the issue is resolved, and deployments can proceed without errors when VPC_CONNECTOR and VPC_REGION are not provided.

Note: This issue was only occuring when deploying with deploy.sh command