### PR TITLE
fix: resolve label update failure due to index duplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ yarn-error.log*
 
 
 # env files
-.env*.local
+.env.*
 
 # github
 .github/

--- a/lib/models/Label/index.ts
+++ b/lib/models/Label/index.ts
@@ -38,7 +38,7 @@ const LabelSchema = new mongoose.Schema({
     type: Date,
   },
 });
-LabelSchema.index({ deleted: 1, update: 1, title_id: 1, user_id: -1 }, { unique: true });
+LabelSchema.index({ deleted: 1, title_id: 1, user_id: -1 }, { unique: true });
 LabelSchema.index({ expireAt: 1 }, { expireAfterSeconds: 0 });
 
 export default mongoose.models['Labels'] || mongoose.model('Labels', LabelSchema);

--- a/lib/models/Todo/TodoItems.ts
+++ b/lib/models/Todo/TodoItems.ts
@@ -55,7 +55,7 @@ const TodoItemSchema = new mongoose.Schema({
     type: Date,
   },
 });
-TodoItemSchema.index({ deleted: 1, update: 1, user_id: -1 }, { unique: true });
+TodoItemSchema.index({ deleted: 1, user_id: -1 }, { unique: true });
 TodoItemSchema.index({ expireAt: 1 }, { expireAfterSeconds: 0 });
 
 export default mongoose.models['Todo-Items'] || mongoose.model('Todo-Items', TodoItemSchema);

--- a/lib/models/Todo/TodoNotes.ts
+++ b/lib/models/Todo/TodoNotes.ts
@@ -29,7 +29,7 @@ const TodoNoteSchema = new mongoose.Schema({
   },
 });
 
-TodoNoteSchema.index({ deleted: 1, update: 1, title_id: 1, user_id: -1 }, { unique: true });
+TodoNoteSchema.index({ deleted: 1, title_id: 1, user_id: -1 }, { unique: true });
 TodoNoteSchema.index({ expireAt: 1 }, { expireAfterSeconds: 0 });
 
 export default mongoose.models['Todo-Notes'] || mongoose.model('Todo-Notes', TodoNoteSchema);

--- a/pages/api/v1/labels/[labelId].tsx
+++ b/pages/api/v1/labels/[labelId].tsx
@@ -52,7 +52,7 @@ const LabelById = async (req: NextApiRequest, res: NextApiResponse) => {
         if (!updateLabelById) return res.status(400).json({ success: false });
         res.status(200).json({ success: true, data: updateLabelById });
       } catch (error) {
-        res.status(400).json({ success: false });
+        error instanceof Error && res.status(400).json({ success: false, message: error.message });
       }
       break;
     case 'DELETE':
@@ -78,7 +78,7 @@ const LabelById = async (req: NextApiRequest, res: NextApiResponse) => {
         if (!deleteLabelById) return res.status(400).json({ success: false });
         res.status(200).json({ success: true, data: deleteLabelById });
       } catch (error) {
-        res.status(400).json({ success: false });
+        error instanceof Error && res.status(400).json({ success: false, message: error.message });
       }
       break;
     default:

--- a/pages/api/v1/labels/index.tsx
+++ b/pages/api/v1/labels/index.tsx
@@ -36,7 +36,7 @@ const Labels = async (req: NextApiRequest, res: NextApiResponse) => {
           ? res.status(200).json({ success: true, data: getLabels }) // Don't update the client if there is update value. getTodo will return [] empty array
           : res.status(200).json({ success: true, update: Date.now().toString(), data: getLabels });
       } catch (error) {
-        res.status(400).json({ success: false });
+        error instanceof Error && res.status(400).json({ success: false, message: error.message });
       }
       break;
     case 'POST':
@@ -50,7 +50,7 @@ const Labels = async (req: NextApiRequest, res: NextApiResponse) => {
         const createLabel = await Label.create(labelItem);
         res.status(201).json({ success: true, data: createLabel });
       } catch (error) {
-        res.status(400).json({ success: false });
+        error instanceof Error && res.status(400).json({ success: false, message: error.message });
       }
       break;
     case 'PUT':
@@ -75,7 +75,7 @@ const Labels = async (req: NextApiRequest, res: NextApiResponse) => {
 
         res.status(200).json({ success: true, data: updatedLabel });
       } catch (error) {
-        res.status(400).json({ success: false });
+        error instanceof Error && res.status(400).json({ success: false, message: error.message });
       }
       break;
     default:

--- a/pages/api/v1/todos/[todoId].tsx
+++ b/pages/api/v1/todos/[todoId].tsx
@@ -55,7 +55,7 @@ const TodosById = async (req: NextApiRequest, res: NextApiResponse) => {
         }
         res.status(200).json({ success: true, data: getItem });
       } catch (error) {
-        res.status(400).json({ success: false });
+        error instanceof Error && res.status(400).json({ success: false, message: error.message });
       }
       break;
     case 'PUT':
@@ -109,7 +109,7 @@ const TodosById = async (req: NextApiRequest, res: NextApiResponse) => {
         res.status(200).json({ success: true, data: updatedTodo });
       } catch (error) {
         await sessionPut.abortTransaction();
-        res.status(400).json({ success: false });
+        error instanceof Error && res.status(400).json({ success: false, message: error.message });
       } finally {
         sessionPut.endSession();
       }
@@ -138,7 +138,7 @@ const TodosById = async (req: NextApiRequest, res: NextApiResponse) => {
         }
         res.status(200).json({ success: true, data: updateItem });
       } catch (error) {
-        res.status(400).json({ success: false });
+        error instanceof Error && res.status(400).json({ success: false, message: error.message });
       }
       break;
 
@@ -176,7 +176,7 @@ const TodosById = async (req: NextApiRequest, res: NextApiResponse) => {
         res.status(200).json({ success: true, data: deletedTodo });
       } catch (error) {
         await sessionDelete.abortTransaction();
-        res.status(400).json({ success: false });
+        error instanceof Error && res.status(400).json({ success: false, message: error.message });
       } finally {
         sessionDelete.endSession();
       }

--- a/pages/api/v1/todos/index.tsx
+++ b/pages/api/v1/todos/index.tsx
@@ -47,7 +47,7 @@ const Todos = async (req: NextApiRequest, res: NextApiResponse) => {
           ? res.status(200).json({ success: true, data: getTodo }) // Don't update the client if there is update value. getTodo will return [] empty array
           : res.status(200).json({ success: true, update: Date.now().toString(), data: getTodo });
       } catch (error) {
-        res.status(400).json({ success: false });
+        error instanceof Error && res.status(400).json({ success: false, message: error.message });
       }
       break;
 
@@ -103,7 +103,7 @@ const Todos = async (req: NextApiRequest, res: NextApiResponse) => {
         res.status(201).json({ success: true, data: data });
       } catch (error) {
         await sessionPost.abortTransaction();
-        res.status(400).json({ success: false });
+        error instanceof Error && res.status(400).json({ success: false, message: error.message });
       } finally {
         sessionPost.endSession();
       }


### PR DESCRIPTION
The issue occurred when updating multiple labels with the same value generated by `update.now()`, resulting in index key conflicts. To fix this, the index update has been removed from the schema, and the index was dropped manually using the MongoDB shell.