### PR TITLE
refactor: simplify mediaQueryEffect and adjust CSS

### DIFF
--- a/components/layouts/layoutHeader/index.tsx
+++ b/components/layouts/layoutHeader/index.tsx
@@ -26,7 +26,7 @@ export const LayoutHeader = ({ sidebarButton, children }: Props) => {
           </div>
         </LeftSideFragment>
         <RightSidebarFragment>
-          <div className='flex flex-1 flex-row items-center justify-end pl-2'>{children}</div>
+          <div className='flex flex-1 flex-row items-center justify-end pl-2 mr-3'>{children}</div>
         </RightSidebarFragment>
       </div>
     </LayoutHeaderFragment>

--- a/components/layouts/layoutHeader/user.tsx
+++ b/components/layouts/layoutHeader/user.tsx
@@ -14,7 +14,7 @@ export const User = () => {
   return (
     <Fragment>
       <UserSessionResetEffect />
-      <div className='ml-4 flex min-w-[2rem] items-center sm:pr-5 md:ml-6'>
+      <div className='ml-4 flex min-w-[2rem] items-center md:ml-6'>
         {!offSession && isSession ? <UserDropdown /> : <SignInButton />}
       </div>
     </Fragment>

--- a/lib/stateLogics/effects/atomEffects/atomEffects.tsx
+++ b/lib/stateLogics/effects/atomEffects/atomEffects.tsx
@@ -4,14 +4,12 @@ import { TypesAtomEffect, TypesMediaQueryEffect } from '@lib/types';
  * Media Queries
  */
 export const mediaQueryEffect: TypesMediaQueryEffect =
-  ({ breakpoint, isStateOverBreakpoint, isStateUnderBreakpoint }) =>
+  ({ breakpoint }) =>
   ({ setSelf }) => {
     if (typeof window === 'undefined') return;
     const windowMediaQueries = () => {
-      if (window.innerWidth >= breakpoint && typeof isStateOverBreakpoint !== 'undefined')
-        return setSelf(isStateOverBreakpoint);
-      if (window.innerWidth <= breakpoint && typeof isStateUnderBreakpoint !== 'undefined')
-        return setSelf(isStateUnderBreakpoint);
+      if (window.innerWidth >= breakpoint) return setSelf(true);
+      setSelf(false);
     };
 
     windowMediaQueries();

--- a/lib/stateLogics/states/layouts.tsx
+++ b/lib/stateLogics/states/layouts.tsx
@@ -9,13 +9,7 @@ import { atom, selector } from 'recoil';
 export const atomSidebarOpen = atom({
   key: 'atomSidebarOpen',
   default: true,
-  effects: [
-    mediaQueryEffect({
-      breakpoint: BREAKPOINT['md'],
-      isStateUnderBreakpoint: false,
-      isStateOverBreakpoint: true,
-    }),
-  ],
+  effects: [mediaQueryEffect({ breakpoint: BREAKPOINT['md'] })],
 });
 
 export const atomSidebarOpenMobile = atom({

--- a/lib/stateLogics/states/misc.tsx
+++ b/lib/stateLogics/states/misc.tsx
@@ -22,13 +22,7 @@ export const atomDisableScroll = atom<boolean>({
 export const atomMediaQuery = atomFamily<boolean, BREAKPOINT>({
   key: 'atomMediaQuery',
   default: false,
-  effects: (breakpoint) => [
-    mediaQueryEffect({
-      breakpoint: breakpoint,
-      isStateOverBreakpoint: true,
-      isStateUnderBreakpoint: false,
-    }),
-  ],
+  effects: (breakpoint) => [mediaQueryEffect({ breakpoint: breakpoint })],
 });
 
 // Network

--- a/lib/types/bases/effects.ts
+++ b/lib/types/bases/effects.ts
@@ -23,8 +23,6 @@ export interface TypesEffects {
   refetchInterval: number;
   // MediaQuery Effect
   breakpoint: BREAKPOINT;
-  isStateUnderBreakpoint: boolean;
-  isStateOverBreakpoint: boolean;
 }
 /**
  * Types Atom Effects - Recoil
@@ -64,13 +62,7 @@ export type TypesSessionStorageEffect = <T>({
 }: Pick<Types, 'queryKey'> &
   Partial<Pick<Types, 'shouldGet' | 'isSessionResetEnabled' | 'isSessionSetEnabled'>>) => AtomEffect<T | boolean>;
 
-export type TypesMediaQueryEffect = <T>({
-  breakpoint,
-  isStateUnderBreakpoint,
-  isStateOverBreakpoint,
-}: Pick<Types, 'breakpoint'> & Partial<Pick<Types, 'isStateUnderBreakpoint' | 'isStateOverBreakpoint'>>) => AtomEffect<
-  T | boolean
->;
+export type TypesMediaQueryEffect = <T>({ breakpoint }: Pick<Types, 'breakpoint'>) => AtomEffect<T | boolean>;
 
 export type TypesAtomEffect<T> = AtomEffect<T>;
 export type TypesAtomEffectWithParam<T, P> = (key: P) => AtomEffect<T>;


### PR DESCRIPTION
Simplify the mediaQueryEffect by removing unnecessary types and props while retaining its core functionality. The mediaQueryEffect now only accepts a 'breakpoint' prop and returns a boolean. It returns 'true' for values higher than the breakpoint and 'false' for values lower than the breakpoint.

Additionally, apply minor CSS adjustments without altering the core structure.