### PR TITLE
feat: update the sidebar initial state and effects

### DIFF
--- a/components/layouts/app/index.tsx
+++ b/components/layouts/app/index.tsx
@@ -16,6 +16,7 @@ import {
 } from 'react';
 import { useRecoilValue } from 'recoil';
 import { AppSidebarContent } from './appSidebarContent';
+import { SidebarInitialEffect } from '@effects/sidebarInitialEffect';
 const CreateTodoModal = dynamic(() => import('@modals/todoModals/todoModal').then((mod) => mod.TodoModal));
 const MinimizedModal = dynamic(() => import('@modals/minimizedModal').then((mod) => mod.MinimizedModal));
 const Notification = dynamic(() => import('components/notifications/notification').then((mod) => mod.Notification));
@@ -55,6 +56,7 @@ export const LayoutApp = ({ children }: Props) => {
         </div>
       </HeaderFragment>
       <FooterFragment>
+        <SidebarInitialEffect />
         <Notification />
         <WindowBeforeunloadEffect />
         <ModalActionsFragment>

--- a/components/layouts/layoutFooter/index.tsx
+++ b/components/layouts/layoutFooter/index.tsx
@@ -23,8 +23,6 @@ export const LayoutFooter = ({ options, children, footerSidebar }: Props) => {
           <Transition.Child
             appear={true}
             as={Fragment}
-            enter={classNames('transition transform ease-in-out', options?.enterDuration ?? 'duration-350')}
-            enterFrom={classNames('transform opacity-0', options?.transitionFrom ?? '-translate-x-24')}
             enterTo={classNames('transform opacity-100', options?.transitionTo ?? 'translate-x-0')}
             leave={classNames('transition ease-in-out', options?.leaveDuration ?? 'duration-350')}
             leaveFrom={classNames('transform opacity-100', options?.transitionTo ?? 'translate-x-0')}

--- a/lib/stateLogics/effects/sidebarInitialEffect.tsx
+++ b/lib/stateLogics/effects/sidebarInitialEffect.tsx
@@ -1,0 +1,15 @@
+import { atomSidebarInitialOpen } from '@states/layouts';
+import { useEffect } from 'react';
+import { useRecoilCallback } from 'recoil';
+
+export const SidebarInitialEffect = () => {
+  const sidebarInitialHandler = useRecoilCallback(({ set }) => () => {
+    set(atomSidebarInitialOpen, true);
+  });
+
+  useEffect(() => {
+    sidebarInitialHandler();
+  }, [sidebarInitialHandler]);
+
+  return null;
+};

--- a/lib/stateLogics/states/layouts.tsx
+++ b/lib/stateLogics/states/layouts.tsx
@@ -1,15 +1,13 @@
 import { BREAKPOINT } from '@constAssertions/ui';
-import { mediaQueryEffect } from '@lib/stateLogics/effects/atomEffects/atomEffects';
 import { atomMediaQuery } from '@states/misc';
 import { atom, selector } from 'recoil';
 
 /**
  * Atoms
  **/
-export const atomSidebarOpen = atom({
-  key: 'atomSidebarOpen',
-  default: true,
-  effects: [mediaQueryEffect({ breakpoint: BREAKPOINT['md'] })],
+export const atomSidebarInitialOpen = atom({
+  key: 'atomSidebarInitialOpen',
+  default: false,
 });
 
 export const atomSidebarOpenMobile = atom({
@@ -35,7 +33,7 @@ export const selectorSidebarOpen = selector({
   get: ({ get }) => {
     const breakpointMedium = get(atomMediaQuery(BREAKPOINT['md']));
     if (get(atomSidebarOpenSetting) && breakpointMedium) return get(atomSidebarOpenSetting) ? false : true;
-    return breakpointMedium ? get(atomSidebarOpen) : get(atomSidebarOpenMobile);
+    return breakpointMedium ? get(atomSidebarInitialOpen) : get(atomSidebarOpenMobile);
   },
   cachePolicy_UNSTABLE: {
     eviction: 'most-recent',


### PR DESCRIPTION
- Rename atomSidebarOpen to atomSidebarInitialOpen for a more concise name.
- Remove mediaQueryEffect from atomSidebarInitialOpen, as it is irrelevant.
- Set atomSidebarInitialOpen's initial state to false (sidebar initially closed).
- Add SidebarInitialEffect component to enable the initial state to open.