### PR TITLE
chore: update prettier settings

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -4,7 +4,7 @@ module.exports = {
   jsxSingleQuote: true,
   tabWidth: 2,
   semi: true,
-  printWidth: 120,
+  printWidth: 100,
   tailwindConfig: './tailwind.config.js',
   singleAttributePerLine: true,
   trailingComma: 'all',


### PR DESCRIPTION
Set `printWidth` to 100 instead of 120 for improved code structure readability.