### PR TITLE
feat: enhance performance and user experiences

### DIFF
--- a/components/labels/labelItem.tsx
+++ b/components/labels/labelItem.tsx
@@ -5,21 +5,26 @@ import { BREAKPOINT } from '@constAssertions/ui';
 import { STYLE_HOVER_ENABLED_SLATE_DARK } from '@data/stylePreset';
 import { useNavigationOpen } from '@hooks/layouts';
 import { useNextQuery } from '@hooks/misc';
-import { TodosCount } from '@layouts/app/todosCount';
 import { Types } from '@lib/types';
 import { optionsButtonLabelRouteMatched, optionsButtonLabelRouteUnmatched } from '@options/button';
 import { classNames, paths } from '@stateLogics/utils';
 import { atomMediaQuery } from '@states/misc';
 import dynamic from 'next/dynamic';
-import { Fragment, Fragment as LabelModalFragment } from 'react';
+import { Fragment, Fragment as LabelModalFragment, Suspense } from 'react';
 import { useRecoilValue } from 'recoil';
 
-const LabelItemDropdown = dynamic(() => import('@dropdowns/v1/labelItemDropdown').then((mod) => mod.LabelItemDropdown));
+const TodosCount = dynamic(() => import('@layouts/app/todosCount').then((mod) => mod.TodosCount));
+
+const LabelItemDropdown = dynamic(() =>
+  import('@dropdowns/v1/labelItemDropdown').then((mod) => mod.LabelItemDropdown),
+);
 const ItemLabelModal = dynamic(() =>
   import('@modals/labelModals/labelModal/itemLabelModal').then((mod) => mod.ItemLabelModal),
 );
 const DeleteLabelConfirmModal = dynamic(() =>
-  import('@modals/confirmModal/deleteConfirmModal/deleteLabelConfirmModal').then((mod) => mod.DeleteLabelConfirmModal),
+  import('@modals/confirmModal/deleteConfirmModal/deleteLabelConfirmModal').then(
+    (mod) => mod.DeleteLabelConfirmModal,
+  ),
 );
 
 export const LabelItem = ({ label }: Pick<Types, 'label'>) => {
@@ -33,7 +38,9 @@ export const LabelItem = ({ label }: Pick<Types, 'label'>) => {
       <div
         className={classNames(
           'group relative flex w-full cursor-pointer flex-row items-center justify-between rounded-lg pr-[0.20rem]',
-          matchedSlug ? 'bg-blue-100 font-semibold text-opacity-80' : 'hover:bg-slate-200 hover:bg-opacity-80 ',
+          matchedSlug
+            ? 'bg-blue-100 font-semibold text-opacity-80'
+            : 'hover:bg-slate-200 hover:bg-opacity-80 ',
         )}>
         <div className='mr-[0.5rem] inline-block w-full'>
           <PrefetchRouterButton
@@ -49,7 +56,9 @@ export const LabelItem = ({ label }: Pick<Types, 'label'>) => {
               ) : (
                 <SvgIcon options={optionsButtonLabelRouteUnmatched} />
               )}
-              <div className='max-w-[10.7rem] truncate pl-2 text-gray-600 group-hover:text-gray-900'>{label.name}</div>
+              <div className='max-w-[10.7rem] truncate pl-2 text-gray-600 group-hover:text-gray-900'>
+                {label.name}
+              </div>
             </div>
           </PrefetchRouterButton>
         </div>
@@ -57,11 +66,15 @@ export const LabelItem = ({ label }: Pick<Types, 'label'>) => {
           label={label}
           options={{
             isInitiallyVisible: false,
-            hoverBg: matchedSlug ? 'hover:bg-blue-900 hover:bg-opacity-[0.07]' : STYLE_HOVER_ENABLED_SLATE_DARK,
+            hoverBg: matchedSlug
+              ? 'hover:bg-blue-900 hover:bg-opacity-[0.07]'
+              : STYLE_HOVER_ENABLED_SLATE_DARK,
           }}
           menuContentOnClose={
             <span className='absolute right-[0.73rem] top-1/2 -translate-y-2/4 select-none text-xs tracking-tighter text-slate-400 group-hover:invisible'>
-              <TodosCount label={label} />
+              <Suspense>
+                <TodosCount label={label} />
+              </Suspense>
             </span>
           }
         />

--- a/components/layouts/app/appNavigation/appSidebarMenu.tsx
+++ b/components/layouts/app/appNavigation/appSidebarMenu.tsx
@@ -2,14 +2,20 @@ import { PrefetchRouterButton } from '@buttons/button/prefetchRouterButton';
 import { SvgIcon } from '@components/icons/svgIcon';
 import { STYLE_HOVER_SLATE_LIGHT } from '@data/stylePreset';
 import { useRouter } from 'next/router';
-import { Fragment as FooterSidebarMenuFragment, Fragment as TotalNumberTodos } from 'react';
+import {
+  Fragment as FooterSidebarMenuFragment,
+  Suspense,
+  Fragment as TotalNumberTodos,
+} from 'react';
 import { useRecoilValue } from 'recoil';
 import { DATA_SIDEBAR_MENU } from '@collections/sidebarMenu';
 import { BREAKPOINT } from '@constAssertions/ui';
 import { useNavigationOpen } from '@hooks/layouts';
 import { atomMediaQuery } from '@states/misc';
 import { classNames } from '@stateLogics/utils';
-import { TodosCount } from '../todosCount';
+import dynamic from 'next/dynamic';
+
+const TodosCount = dynamic(() => import('@layouts/app/todosCount').then((mod) => mod.TodosCount));
 
 export const AppSidebarMenu = () => {
   const router = useRouter();
@@ -46,7 +52,9 @@ export const AppSidebarMenu = () => {
               {item.name}
               <TotalNumberTodos>
                 <span className='absolute right-[0.87rem] top-1/2 -translate-y-2/4 select-none text-xs tracking-tighter text-slate-400'>
-                  <TodosCount pathname={item.path} />
+                  <Suspense>
+                    <TodosCount pathname={item.path} />
+                  </Suspense>
                 </span>
               </TotalNumberTodos>
             </PrefetchRouterButton>

--- a/components/layouts/app/appNavigation/index.tsx
+++ b/components/layouts/app/appNavigation/index.tsx
@@ -1,7 +1,6 @@
 import { DisableButton } from '@buttons/disableButton';
 import { IconButton } from '@buttons/iconButton';
 import { SvgIcon } from '@components/icons/svgIcon';
-import { LabelList } from '@components/labels/labelList';
 import { ICON_ADD_TASK } from '@data/materialSymbols';
 import { useNavigationOpen } from '@hooks/layouts';
 import { useConditionCheckCreateModalOpen } from '@hooks/misc';
@@ -10,10 +9,17 @@ import { Logo } from '@layouts/layoutHeader/logo';
 import { optionsButtonCreateTodo, optionsButtonSidebarToggle } from '@options/button';
 import { classNames } from '@stateLogics/utils';
 import { atomDisableScroll } from '@states/misc';
-import { Fragment as CreateTodoFragment, Fragment as LayoutLogoFragment } from 'react';
+import { Fragment as CreateTodoFragment, Fragment as LayoutLogoFragment, Suspense } from 'react';
 import { isChrome, isMobile } from 'react-device-detect';
 import { useRecoilValue } from 'recoil';
 import { AppSidebarMenu } from './appSidebarMenu';
+import dynamic from 'next/dynamic';
+import { LoadingLabels } from '@components/loadable/loadingStates/loadingLabels';
+
+const LabelList = dynamic(
+  () => import('@components/labels/labelList').then((mod) => mod.LabelList),
+  { ssr: false },
+);
 
 export const AppNavigation = () => {
   const isScrollDisabled = useRecoilValue(atomDisableScroll);
@@ -60,7 +66,9 @@ export const AppNavigation = () => {
         <div className='flex flex-grow flex-col'>
           <nav className={classNames('flex-1 space-y-1', isMobile && isChrome ? 'pb-36' : 'pb-10')}>
             <AppSidebarMenu />
-            <LabelList />
+            <Suspense fallback={<LoadingLabels />}>
+              <LabelList />
+            </Suspense>
           </nav>
         </div>
       </div>

--- a/components/layouts/app/index.tsx
+++ b/components/layouts/app/index.tsx
@@ -1,9 +1,6 @@
 import { CATCH } from '@constAssertions/misc';
 import { LayoutTypeEffect } from '@effects/layoutTypeEffect';
 import { NavigationInitialEffect } from '@effects/navigationInitialEffect';
-import { FooterBody } from '@layouts/layoutFooter/footerBody';
-import { LayoutHeader } from '@layouts/layoutHeader';
-import { SearchBar } from '@layouts/layoutHeader/searchBar';
 import { Types } from '@lib/types';
 import { atomCatch, atomHtmlTitleTag } from '@states/misc';
 import dynamic from 'next/dynamic';
@@ -16,17 +13,35 @@ import {
   Suspense,
 } from 'react';
 import { useRecoilValue } from 'recoil';
-const CreateTodoModal = dynamic(() => import('@modals/todoModals/todoModal').then((mod) => mod.TodoModal));
-const MinimizedModal = dynamic(() => import('@modals/minimizedModal').then((mod) => mod.MinimizedModal));
-const Notification = dynamic(() => import('components/notifications/notification').then((mod) => mod.Notification));
-const LabelModal = dynamic(() => import('@modals/labelModals/labelModal').then((mod) => mod.LabelModal));
+const CreateTodoModal = dynamic(() =>
+  import('@modals/todoModals/todoModal').then((mod) => mod.TodoModal),
+);
+const MinimizedModal = dynamic(() =>
+  import('@modals/minimizedModal').then((mod) => mod.MinimizedModal),
+);
+const Notification = dynamic(() =>
+  import('components/notifications/notification').then((mod) => mod.Notification),
+);
+const LabelModal = dynamic(() =>
+  import('@modals/labelModals/labelModal').then((mod) => mod.LabelModal),
+);
 const WindowBeforeunloadEffect = dynamic(() =>
   import('@effects/windowBeforeunloadEffect').then((mod) => mod.WindowBeforeunloadEffect),
 );
-const LayoutFooter = dynamic(() => import('@layouts/layoutFooter').then((mod) => mod.LayoutFooter), {
+const FooterBody = dynamic(() =>
+  import('@layouts/layoutFooter/footerBody').then((mod) => mod.FooterBody),
+);
+const LayoutHeader = dynamic(() => import('@layouts/layoutHeader').then((mod) => mod.LayoutHeader));
+const SearchBar = dynamic(() =>
+  import('@layouts/layoutHeader/searchBar').then((mod) => mod.SearchBar),
+);
+const LayoutFooter = dynamic(
+  () => import('@layouts/layoutFooter').then((mod) => mod.LayoutFooter),
+  { ssr: false },
+);
+const User = dynamic(() => import('@layouts/layoutHeader/user').then((mod) => mod.User), {
   ssr: false,
 });
-const User = dynamic(() => import('@layouts/layoutHeader/user').then((mod) => mod.User), { ssr: false });
 
 type Props = Pick<Types, 'children'>;
 
@@ -47,11 +62,9 @@ export const LayoutApp = ({ children }: Props) => {
               <User />
             </Suspense>
           </LayoutHeader>
-          <Suspense>
-            <LayoutFooter layoutType='app'>
-              <FooterBody>{children}</FooterBody>
-            </LayoutFooter>
-          </Suspense>
+          <LayoutFooter layoutType='app'>
+            <FooterBody>{children}</FooterBody>
+          </LayoutFooter>
         </div>
       </HeaderFragment>
       <EffectFragment>

--- a/components/layouts/home/index.tsx
+++ b/components/layouts/home/index.tsx
@@ -1,10 +1,14 @@
 import { LayoutTypeEffect } from '@effects/layoutTypeEffect';
 import { NavigationInitialEffect } from '@effects/navigationInitialEffect';
-import { LayoutFooter } from '@layouts/layoutFooter';
-import { LayoutHeader } from '@layouts/layoutHeader';
+import dynamic from 'next/dynamic';
 import Head from 'next/head';
 import { Fragment as EffectFragment, Fragment as LayoutFragment, ReactNode } from 'react';
-import { HomeNavigation } from './homeNavigation';
+
+const HomeNavigation = dynamic(() => import('./homeNavigation').then((mod) => mod.HomeNavigation));
+
+const LayoutHeader = dynamic(() => import('@layouts/layoutHeader').then((mod) => mod.LayoutHeader));
+
+const LayoutFooter = dynamic(() => import('@layouts/layoutFooter').then((mod) => mod.LayoutFooter));
 
 type Props = {
   children: ReactNode;

--- a/components/layouts/layoutHeader/index.tsx
+++ b/components/layouts/layoutHeader/index.tsx
@@ -2,11 +2,11 @@ import { Types } from '@lib/types';
 import { classNames } from '@stateLogics/utils';
 import dynamic from 'next/dynamic';
 import {
-    Fragment as LayoutHeaderFragment,
-    Fragment as LeftSideFragment,
-    Fragment as LogoFragment,
-    Fragment as NavigationButtonFragment,
-    Fragment as RightNavigationFragment,
+  Fragment as LayoutHeaderFragment,
+  Fragment as LeftSideFragment,
+  Fragment as LogoFragment,
+  Fragment as NavigationButtonFragment,
+  Fragment as RightNavigationFragment,
 } from 'react';
 import { Logo } from './logo';
 import { NavigationButton } from './navigationButton';

--- a/components/layouts/layoutHeader/user.tsx
+++ b/components/layouts/layoutHeader/user.tsx
@@ -1,24 +1,25 @@
-import { PATH_HOME } from '@constAssertions/data';
+import { PATH_APP, PATH_HOME } from '@constAssertions/data';
 import { STORAGE_KEY } from '@constAssertions/storage';
 import { UserDropdown } from '@dropdowns/v2/userDropdown';
 import { getSessionStorage } from '@stateLogics/utils';
-import { atomUserSession } from '@states/users';
 import { useRouter } from 'next/router';
 import { Fragment } from 'react';
-import { useRecoilValue } from 'recoil';
 import { SignInButton } from './signInButton';
+import { Types } from '@lib/types';
 
 export const User = () => {
-  const isSession = useRecoilValue(atomUserSession);
   const offSession = getSessionStorage(STORAGE_KEY['offSession']);
   const router = useRouter();
-  const demoSession = router.asPath === PATH_HOME['demo'];
-  const userOffSession = !isSession && offSession && demoSession;
+  const pathname = router.pathname as Types['pathname'];
+
+  const pathNameDemo = !!offSession && pathname === PATH_HOME['demo'];
+  const pathNameApp = !offSession && pathname === PATH_APP['app'];
 
   return (
     <Fragment>
       <div className='ml-4 flex min-w-[2rem] items-center md:ml-6'>
-        {userOffSession ? <SignInButton /> : <UserDropdown />}
+        {pathNameDemo && <SignInButton />}
+        {pathNameApp && <UserDropdown />}
       </div>
     </Fragment>
   );

--- a/lib/data/constAssertions/data.tsx
+++ b/lib/data/constAssertions/data.tsx
@@ -37,6 +37,7 @@ export const PATH_HOME = {
   implementations: '/implementations',
   pricing: 'pricing',
   demo: '/demo',
+  auth: '/auth',
 } as const;
 
 export type PATHNAME_IMAGE = (typeof PATHNAME_IMAGE)[keyof typeof PATHNAME_IMAGE];

--- a/lib/stateLogics/effects/userSessionEffect.tsx
+++ b/lib/stateLogics/effects/userSessionEffect.tsx
@@ -1,6 +1,8 @@
+import { PATH_HOME } from '@constAssertions/data';
 import { STORAGE_KEY } from '@constAssertions/storage';
+import { Types } from '@lib/types';
 import { delSessionStorage, getSessionStorage, setSessionStorage } from '@stateLogics/utils';
-import { atomUserSession } from '@states/users';
+import { atomPathname } from '@states/misc';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
@@ -10,20 +12,21 @@ export const UserSessionEffect = () => {
   const { data: session } = useSession();
   const offSession = session === null && typeof session !== 'undefined';
   const router = useRouter();
+  const pathname = router.pathname as Types['pathname'];
 
   const sessionHandler = useRecoilCallback(({ set }) => () => {
-    if (router.pathname === '/auth') {
+    set(atomPathname, pathname);
+
+    if (pathname === PATH_HOME['auth']) {
       !!getSessionStorage(STORAGE_KEY['offSession']) &&
         delSessionStorage(STORAGE_KEY['offSession']);
       return;
     }
     if (offSession) {
-      set(atomUserSession, false);
       setSessionStorage(STORAGE_KEY['offSession'], true);
       return;
     }
     if (session) {
-      set(atomUserSession, true);
       delSessionStorage(STORAGE_KEY['offSession']);
       return;
     }

--- a/lib/stateLogics/states/atomEffects/labels.tsx
+++ b/lib/stateLogics/states/atomEffects/labels.tsx
@@ -1,9 +1,10 @@
 import { DATA_DEMO_LABELS } from '@collections/demo';
-import { IDB_STORE, IDB_KEY } from '@constAssertions/storage';
+import { PATH_HOME } from '@constAssertions/data';
+import { IDB_KEY, IDB_STORE } from '@constAssertions/storage';
 import { getDataLabels } from '@lib/queries/queryLabels';
 import { queryEffect } from '@lib/stateLogics/effects/atomEffects/queryEffects';
 import { Labels } from '@lib/types';
-import { atomUserSession } from '@states/users';
+import { atomPathname } from '@states/misc';
 import { atom, selector } from 'recoil';
 
 /**
@@ -30,12 +31,14 @@ export const atomDemoLabels = atom<Labels[]>({
 export const selectorSessionLabels = selector<Labels[]>({
   key: 'selectorSessionLabels',
   get: ({ get }) => {
-    const session = get(atomUserSession);
-    return session ? get(atomQueryLabels) : get(atomDemoLabels);
+    const pathname = get(atomPathname);
+    return pathname === PATH_HOME['demo'] ? get(atomDemoLabels) : get(atomQueryLabels);
   },
   set: ({ get, set }, newValue) => {
-    const session = get(atomUserSession);
-    return session ? set(atomQueryLabels, newValue) : set(atomDemoLabels, newValue);
+    const pathname = get(atomPathname);
+    return pathname === PATH_HOME['demo']
+      ? set(atomDemoLabels, newValue)
+      : set(atomQueryLabels, newValue);
   },
 });
 

--- a/lib/stateLogics/states/atomEffects/todos.tsx
+++ b/lib/stateLogics/states/atomEffects/todos.tsx
@@ -1,9 +1,10 @@
 import { DATA_DEMO_TODOIDS } from '@collections/demo';
-import { IDB_STORE, IDB_KEY } from '@constAssertions/storage';
+import { PATH_HOME } from '@constAssertions/data';
+import { IDB_KEY, IDB_STORE } from '@constAssertions/storage';
 import { getDataTodoIds, getDataTodoItem, getDemoTodoItem } from '@lib/queries/queryTodos';
 import { queryEffect } from '@lib/stateLogics/effects/atomEffects/queryEffects';
 import { TodoIds, Todos } from '@lib/types';
-import { atomUserSession } from '@states/users';
+import { atomPathname } from '@states/misc';
 import { atom, atomFamily, selector, selectorFamily } from 'recoil';
 
 /**
@@ -33,12 +34,14 @@ export const atomDemoTodoIds = atom<TodoIds[]>({
 export const selectorSessionTodoIds = selector<TodoIds[]>({
   key: 'selectorSessionTodoIds',
   get: ({ get }) => {
-    const session = get(atomUserSession);
-    return session ? get(atomQueryTodoIds) : get(atomDemoTodoIds);
+    const pathname = get(atomPathname);
+    return pathname === PATH_HOME['demo'] ? get(atomDemoTodoIds) : get(atomQueryTodoIds);
   },
   set: ({ get, set }, newValue) => {
-    const session = get(atomUserSession);
-    return session ? set(atomQueryTodoIds, newValue) : set(atomDemoTodoIds, newValue);
+    const pathname = get(atomPathname);
+    return pathname === PATH_HOME['demo']
+      ? set(atomDemoTodoIds, newValue)
+      : set(atomQueryTodoIds, newValue);
   },
 });
 
@@ -74,14 +77,18 @@ export const selectorSessionTodoItem = selectorFamily<Todos, Todos['_id']>({
   get:
     (todoId) =>
     ({ get }) => {
-      const session = get(atomUserSession);
-      return session ? get(atomQueryTodoItem(todoId)) : get(atomDemoTodoItem(todoId));
+      const pathName = get(atomPathname);
+      return pathName === PATH_HOME['demo']
+        ? get(atomDemoTodoItem(todoId))
+        : get(atomQueryTodoItem(todoId));
     },
   set:
     (todoId) =>
     ({ get, set }, newValue) => {
-      const session = get(atomUserSession);
-      return session ? set(atomQueryTodoItem(todoId), newValue) : set(atomDemoTodoItem(todoId), newValue);
+      const pathName = get(atomPathname);
+      return pathName === PATH_HOME['demo']
+        ? set(atomDemoTodoItem(todoId), newValue)
+        : set(atomQueryTodoItem(todoId), newValue);
     },
 });
 

--- a/lib/stateLogics/states/misc.tsx
+++ b/lib/stateLogics/states/misc.tsx
@@ -1,7 +1,10 @@
-import { PATHNAME_IMAGE } from '@constAssertions/data';
+import { PATHNAME_IMAGE, PATH_APP, PATH_HOME } from '@constAssertions/data';
 import { CATCH } from '@constAssertions/misc';
 import { BREAKPOINT, SPINNER } from '@constAssertions/ui';
-import { mediaQueryEffect, networkStatusEffect } from '@lib/stateLogics/effects/atomEffects/atomEffects';
+import {
+  mediaQueryEffect,
+  networkStatusEffect,
+} from '@lib/stateLogics/effects/atomEffects/atomEffects';
 import { atom, atomFamily, selector } from 'recoil';
 
 /*
@@ -51,6 +54,11 @@ export const atomActiveMenuItem = atomFamily<boolean, string | null>({
 export const atomHtmlTitleTag = atom<string>({
   key: 'atomHtmlTitleTag',
   default: '',
+});
+
+export const atomPathname = atom<PATH_APP | PATH_HOME>({
+  key: 'atomPathname',
+  default: '/',
 });
 
 export const atomPathnameImage = atom<PATHNAME_IMAGE>({

--- a/lib/stateLogics/states/users.tsx
+++ b/lib/stateLogics/states/users.tsx
@@ -15,8 +15,3 @@ export const atomUserVerificationRequest = atom({
   key: 'atomUserVerificationRequest',
   default: false,
 });
-
-export const atomUserSession = atom({
-  key: 'atomUserSession',
-  default: true,
-});


### PR DESCRIPTION
Replace atomUserSession with atomPathname for better rendering performance. Previously, atomUserSession received session data from Next-Auth's useSession hook, which is asynchronous and could cause flickering during rendering. Switching to atomPathname, which receives data from Next.js's useRouter's pathname, offers a synchronous and faster solution for setting state.

Note. The protection of the page is handled by middleware.

Additionally, incorporate Suspense and dynamic imports to optimize initial loading time and improve overall user experience.