### PR TITLE
fix: resolve todoItem update issue when no label data provided

### DIFF
--- a/components/todos/todo/todoItemFocuser.tsx
+++ b/components/todos/todo/todoItemFocuser.tsx
@@ -1,4 +1,4 @@
-import { KeysWithNavigationEffect } from '@effects/KeysWithNavigateEffect';
+import { KeysWithNavigationEffect } from '@effects/keysWithNavigateEffect';
 import { useFocusOnClick } from '@hooks/focus';
 import { useKeyWithFocus } from '@hooks/keybindings';
 import { classNames } from '@stateLogics/utils';

--- a/components/ui/modals/labelModals/labelModal/index.tsx
+++ b/components/ui/modals/labelModals/labelModal/index.tsx
@@ -10,7 +10,7 @@ import {
   optionsButtonTodoModalCancel,
   optionsButtonLabelModalAddLabel,
 } from '@options/button';
-import { KeysWithLabelModalEffect } from '@effects/KeysWithLabelModalEffect';
+import { KeysWithLabelModalEffect } from '@effects/keysWithLabelModalEffect';
 import { useLabelValueUpdate, useLabelAdd } from '@hooks/labels';
 import { useConditionCheckLabelTitleEmpty } from '@hooks/misc';
 import { useLabelModalStateClose } from '@hooks/modals';

--- a/components/ui/modals/labelModals/labelModal/itemLabelModal.tsx
+++ b/components/ui/modals/labelModals/labelModal/itemLabelModal.tsx
@@ -3,7 +3,7 @@ import { Types } from '@lib/types';
 import { Fragment } from 'react';
 import { LabelModal } from '.';
 import { optionsButtonLabelModalUpdateLabel } from '@options/button';
-import { KeysWithLabelModalEffect } from '@effects/KeysWithLabelModalEffect';
+import { KeysWithLabelModalEffect } from '@effects/keysWithLabelModalEffect';
 import { useLabelUpdateItem } from '@hooks/labels';
 import { useConditionCompareLabelItemsEqual } from '@hooks/misc';
 

--- a/components/ui/modals/todoModals/itemTodoModal.tsx
+++ b/components/ui/modals/todoModals/itemTodoModal.tsx
@@ -1,6 +1,6 @@
 import { DisableButton } from '@buttons/disableButton';
 import { PRIORITY_LEVEL } from '@constAssertions/misc';
-import { KeysWithItemModalEffect } from '@effects/KeysWithItemModalEffect';
+import { KeysWithItemModalEffect } from '@effects/keysWithItemModalEffect';
 import { KeysWithTodoModalEffect } from '@effects/keysWithTodoModalEffect';
 import { useConditionCompareTodoItemsEqual } from '@hooks/misc';
 import { useTodoUpdateItem, useTodoCompleteItem } from '@hooks/todos';

--- a/pages/api/v1/todos/[todoId].tsx
+++ b/pages/api/v1/todos/[todoId].tsx
@@ -73,21 +73,23 @@ const TodosById = async (req: NextApiRequest, res: NextApiResponse) => {
           runValidators: true,
         });
 
-        const updatedTodoNote =
-          sanitizedTodoNote &&
-          (await TodoNote.findOneAndUpdate(filter(SCHEMA_TODO['todoNote']), sanitizedTodoNote, {
-            session: sessionPut,
-            upsert: true,
-            new: true,
-            runValidators: true,
-          }));
+        const updatedTodoNote = sanitizedTodoNote
+          ? await TodoNote.findOneAndUpdate(filter(SCHEMA_TODO['todoNote']), sanitizedTodoNote, {
+              session: sessionPut,
+              upsert: true,
+              new: true,
+              runValidators: true,
+            })
+          : [];
 
-        const sanitizedUpdateLabel = sanitizedLabels.map((label) => {
-          return {
-            ...label,
-            update: Date.now(),
-          };
-        });
+        const sanitizedUpdateLabel = sanitizedLabels
+          ? sanitizedLabels.map((label) => {
+              return {
+                ...label,
+                update: Date.now(),
+              };
+            })
+          : [];
 
         const updatedLabelPromises = sanitizedUpdateLabel.map((label) =>
           Label.updateMany(


### PR DESCRIPTION
This commit addresses a problem where the todoItem update would fail on the server when no label data was provided. The issue was caused by the session waiting for other data to be checked, resulting in undefined values being passed during the label update. The solution involved using a ternary operator to pass an empty array whenever no label data is provided, preventing undefined values from being passed and resolving the issue.