### PR TITLE
feat: add Contact page and refactor Divider component

### DIFF
--- a/components/auth/authForm.tsx
+++ b/components/auth/authForm.tsx
@@ -65,7 +65,7 @@ export const AuthForm = () => {
               <span>Sign in with email</span>
             </Button>
             <div className='mb-5' />
-            <DividerX margin='mb-5'>or</DividerX>
+            <DividerX options={{ margin: 'mb-5' }}>or</DividerX>
             <SvgLogoButton />
           </form>
         </section>

--- a/components/layouts/home/homeNavigation.tsx
+++ b/components/layouts/home/homeNavigation.tsx
@@ -5,6 +5,8 @@ import { STYLE_BUTTON_NORMAL_BLACK } from '@data/stylePreset';
 import { SignInButton } from '@layouts/layoutHeader/signInButton';
 import { Types } from '@lib/types';
 import { classNames } from '@stateLogics/utils';
+import { DividerX } from '@ui/dividers/dividerX';
+import { DividerY } from '@ui/dividers/dividerY';
 import Link from 'next/link';
 
 type Props = Pick<Types, 'layoutType'>;
@@ -12,6 +14,8 @@ type Props = Pick<Types, 'layoutType'>;
 export const HomeNavigation = ({ layoutType }: Props) => {
   const layoutApp = layoutType === 'app';
   const layoutHome = layoutType === 'home';
+  const linkClassName =
+    'block w-full rounded-lg transition-all hover:bg-slate-900 hover:bg-opacity-10 max-ml:px-5 max-ml:py-3 ml:px-2 lg:px-3 ml:py-2';
 
   return (
     <ul
@@ -19,18 +23,27 @@ export const HomeNavigation = ({ layoutType }: Props) => {
         'flex text-base tracking-wide text-slate-800',
         layoutApp && 'flex-row items-center space-x-10 pr-3 sm:pr-8',
         layoutHome &&
-          'flex-col bg-slate-50 max-ml:space-y-4 max-ml:rounded-b-xl max-ml:px-5 max-ml:pb-8 max-ml:pt-[6rem] ml:flex ml:flex-row ml:items-center ml:space-x-3 ml:pr-3',
+          'flex-col bg-slate-50 max-ml:space-y-4 max-ml:rounded-b-xl max-ml:px-5 max-ml:pb-8 max-ml:pt-[6rem] ml:flex ml:flex-row ml:items-center ml:space-x-3 ml:pr-0 lg:pr-3',
       )}>
       {DATA_HOME.map((path) => (
         <li key={path.name}>
           <Link
             href={path.path}
-            className='block w-full rounded-lg transition-all hover:bg-slate-900 hover:bg-opacity-10 max-ml:px-5 max-ml:py-3 ml:px-3 ml:py-2'>
+            className={classNames(linkClassName)}>
             {path.name}
           </Link>
         </li>
       ))}
-      <div className={classNames('pl-0 max-ml:pt-2 ml:pl-4')}>
+      {layoutHome && <DividerY options={{ hidden: 'max-ml:hidden' }} />}
+      <li>
+        <Link
+          href={PATH_HOME['contact']}
+          className={classNames(linkClassName)}>
+          Contact
+        </Link>
+      </li>
+      {layoutHome && <DividerX options={{ hidden: 'ml:hidden' }} />}
+      <div className={classNames('pl-0 max-ml:pt-2 ml:pl-2 lg:pl-4')}>
         <SignInButton />
         <PrefetchRouterButton
           options={{

--- a/components/ui/dividers/dividerX.tsx
+++ b/components/ui/dividers/dividerX.tsx
@@ -1,15 +1,20 @@
 import { Types } from '@lib/types';
 import { classNames } from '@stateLogics/utils';
 
-type Props = Partial<Pick<Types, 'children' | 'margin'>>;
+type optionTypeDivider = 'margin' | 'hidden' | 'width';
+type Props = { options?: Partial<Record<optionTypeDivider, string>> } & Partial<
+  Pick<Types, 'children'>
+>;
 
-export const DividerX = ({ children, margin }: Props) => {
+export const DividerX = ({ children, options }: Props) => {
+  const { margin, hidden, width = 'w-full' } = options || {};
+
   return (
-    <div className={classNames('relative', margin)}>
+    <div className={classNames('relative', margin, hidden)}>
       <div
-        className='absolute inset-0 flex items-center'
+        className='absolute inset-0 flex items-center justify-center'
         aria-hidden='true'>
-        <div className='w-full border-t border-gray-300' />
+        <div className={classNames('border-t border-gray-300', width)} />
       </div>
       {children && (
         <div className='relative flex justify-center'>

--- a/components/ui/dividers/dividerY.tsx
+++ b/components/ui/dividers/dividerY.tsx
@@ -1,16 +1,19 @@
 import { classNames } from '@stateLogics/utils';
 
-type Props = { options?: Partial<{ height: string; thickness: string; color: string }> };
+type Props = {
+  options?: Partial<{ height: string; thickness: string; color: string; hidden: string }>;
+};
 
 export const DividerY = ({ options }: Props) => {
   const {
     height = 'h-8/10',
     thickness = 'divide-x-2',
     color = 'divide-slate-800/10',
+    hidden,
   } = options || {};
 
   return (
-    <div className={classNames('grid w-4 grid-cols-2', height, thickness, color)}>
+    <div className={classNames('grid w-4 grid-cols-2', height, thickness, color, hidden)}>
       <div className='w-1' />
       <div className='w-1' />
     </div>

--- a/lib/data/constAssertions/data.tsx
+++ b/lib/data/constAssertions/data.tsx
@@ -37,6 +37,7 @@ export const PATH_HOME = {
   features: '/features',
   implementations: '/implementations',
   pricing: '/pricing',
+  contact: '/contact',
   auth: '/auth',
 } as const;
 

--- a/lib/stateLogics/hooks/layouts.tsx
+++ b/lib/stateLogics/hooks/layouts.tsx
@@ -51,6 +51,7 @@ export const useFilterPathHome = () => {
     if (path('pricing')) return setState('Pricing');
     if (path('features')) return setState('Features');
     if (path('implementations')) return setState('Implementations');
+    if (path('contact')) return setState('Contact');
   });
 };
 

--- a/pages/contact/index.tsx
+++ b/pages/contact/index.tsx
@@ -1,0 +1,12 @@
+import { LayoutHome } from '@layouts/home';
+import { ReactElement } from 'react';
+
+const Contact = () => {
+  return <>Contact</>;
+};
+
+Contact.getLayout = function getLayout(page: ReactElement) {
+  return <LayoutHome>{page}</LayoutHome>;
+};
+
+export default Contact;


### PR DESCRIPTION
Add the Contact page using LayoutHome without any content. Update PATH_HOME, Contact link, and contact's htmlTitleTag accordingly. Refactor the Divider component to enhance reusability without altering its core functionality.