### PR TITLE
feat: add glow animation to hero section

### DIFF
--- a/components/sections/hero.tsx
+++ b/components/sections/hero.tsx
@@ -1,8 +1,8 @@
 import { PATH_HOME, PATH_IMAGE_HOME } from '@constAssertions/data';
-import { STYLE_BUTTON_NORMAL_BLUE } from '@data/stylePreset';
+import { STYLE_BLUR_GRADIENT, STYLE_BUTTON_NORMAL_BLUE } from '@data/stylePreset';
 import { SignInButton } from '@layouts/layoutHeader/signInButton';
 import { TypesOptionsButton } from '@lib/types/options';
-import { nextImageLoader } from '@stateLogics/utils';
+import { classNames, nextImageLoader } from '@stateLogics/utils';
 import Image from 'next/image';
 import Link from 'next/link';
 
@@ -35,8 +35,14 @@ export const Hero = () => {
             </div>
           </div>
           <div className='flex justify-center'>
-            <div className='mt-16 flow-root sm:mt-24'>
-              <div className='-m-2 mx-auto flex w-full max-w-5xl flex-row items-center justify-center rounded-xl border-none ring-0 drop-shadow-2xl lg:-m-4 lg:rounded-2xl lg:p-4'>
+            <div className='group/image relative mt-16 flow-root sm:mt-24'>
+              <div
+                className={classNames(
+                  'absolute h-full w-full animate-glow rounded-xl',
+                  STYLE_BLUR_GRADIENT,
+                )}
+              />
+              <div className='mx-auto flex w-full max-w-5xl flex-row items-center justify-center rounded-xl border-none ring-0 lg:rounded-2xl'>
                 <Image
                   loader={nextImageLoader}
                   width={0}

--- a/lib/data/stylePreset.tsx
+++ b/lib/data/stylePreset.tsx
@@ -68,6 +68,10 @@ export const STYLE_BUTTON_NORMAL_GRAY = classNames(
   STYLE_BUTTON_COLOR_GRAY,
 );
 
+// gradient-wave-effect
+export const STYLE_BLUR_GRADIENT =
+  'bg-gradient-to-r from-pink-600 from-10% via-purple-600 via-20% to-blue-600 to-90% opacity-70 blur-md';
+
 // misc
 export const STYLE_BUTTON_ICON =
   'border-transparent bg-transparent text-gray-500 hover:enabled:bg-gray-700 hover:enabled:bg-opacity-10 hover:enabled:text-gray-700 focus-visible:ring-blue-500 ';

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -45,6 +45,15 @@ export default {
           },
         ],
       },
+      keyframes: {
+        glow: {
+          '0%, 100%': { opacity: '1' },
+          '50%': { opacity: '0.5' },
+        },
+      },
+      animation: {
+        glow: 'glow 8s ease-in-out infinite',
+      },
       opacity: {
         65: '0.65',
       },


### PR DESCRIPTION
Implement a custom glow animation for a slow glow effect when used with a blur effect.

Add a new style preset, STYLE_BLUR_GRADIENT, which accepts three different colors to render the gradient.