### PR TITLE
feat: Implement useVerticalScrollPosition custom hook

### DIFF
--- a/lib/stateLogics/hooks/misc.tsx
+++ b/lib/stateLogics/hooks/misc.tsx
@@ -145,6 +145,24 @@ export const useHorizontalScrollPosition = (ref: RefObject<HTMLDivElement>) => {
   return { leftPosition, rightPosition, isOverflow };
 };
 
+export const useVerticalScrollPosition = () => {
+  const [scrollPosition, setScrollPosition] = useState(0);
+
+  const handleScroll = () => {
+    const position = window.pageYOffset;
+    setScrollPosition(position);
+  };
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  return scrollPosition;
+};
+
 export const useCompareToQueryLabels = () => {
   return useRecoilCallback(({ snapshot }) => (compare: Labels[]) => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();


### PR DESCRIPTION
Add a new custom hook, useVerticalScrollPosition, to track the vertical scroll position as a numerical value. This hook enables dynamic style adjustments based on the scroll position within components.