### PR TITLE
fix: fix homeNavigation menu rendering on small screens

### DIFF
--- a/components/layouts/home/homeNavigation.tsx
+++ b/components/layouts/home/homeNavigation.tsx
@@ -21,7 +21,7 @@ export const HomeNavigation = ({ layoutType }: Props) => {
         'flex text-base tracking-wide text-slate-800',
         layoutApp && 'flex-row items-center space-x-10 pr-3 sm:pr-8',
         layoutHome &&
-          'flex-col bg-transparent max-ml:space-y-4 max-ml:rounded-b-xl max-ml:px-5 max-ml:pb-8 max-ml:pt-[6rem] ml:flex ml:flex-row ml:items-center ml:space-x-3 ml:pr-0 lg:pr-3',
+          'flex-col bg-slate-50 max-ml:space-y-4 max-ml:rounded-b-xl max-ml:px-5 max-ml:pb-8 max-ml:pt-[6rem] ml:flex ml:flex-row ml:items-center ml:space-x-3 ml:bg-transparent ml:pr-0 lg:pr-3',
       )}>
       {DATA_HOME.map((path) => (
         <li key={path.name}>

--- a/components/layouts/layoutHeader/index.tsx
+++ b/components/layouts/layoutHeader/index.tsx
@@ -1,13 +1,15 @@
 import { Types } from '@lib/types';
 import { classNames } from '@stateLogics/utils';
+import { atomNavigationOpenMobile } from '@states/layouts';
 import dynamic from 'next/dynamic';
 import {
-  Fragment as LayoutHeaderFragment,
-  Fragment as LeftSideFragment,
-  Fragment as LogoFragment,
-  Fragment as NavigationButtonFragment,
-  Fragment as RightNavigationFragment,
+    Fragment as LayoutHeaderFragment,
+    Fragment as LeftSideFragment,
+    Fragment as LogoFragment,
+    Fragment as NavigationButtonFragment,
+    Fragment as RightNavigationFragment,
 } from 'react';
+import { useRecoilValue } from 'recoil';
 import { Logo } from './logo';
 import { NavigationButton } from './navigationButton';
 
@@ -20,13 +22,15 @@ type Props = Partial<Pick<Types, 'children'>> & Pick<Types, 'layoutType'>;
 export const LayoutHeader = ({ children, layoutType }: Props) => {
   const layoutHome = layoutType === 'home';
   const layoutApp = layoutType === 'app';
+  const isSidebarMobileOpen = useRecoilValue(atomNavigationOpenMobile(layoutType));
 
   return (
     <LayoutHeaderFragment>
       <div
         className={classNames(
           'sticky top-0 flex max-h-[4rem] min-h-[4rem] flex-row items-center justify-between ml:mb-2',
-          layoutHome && 'z-50 mx-auto max-w-7xl bg-slate-50 bg-opacity-60 backdrop-blur-lg',
+          layoutHome && 'z-50 mx-auto max-w-7xl bg-slate-50',
+          layoutHome && isSidebarMobileOpen ? '' : 'bg-opacity-60 backdrop-blur-lg',
           layoutApp && 'bg-transparent',
         )}>
         <LeftSideFragment>


### PR DESCRIPTION
Resolve issues with the homeNavigation menu rendering on small screen sizes and when opening the mobile menu. Ensure proper background opacity and backdrop blur are applied on small screens, enhancing the user experience for mobile devices.