### PR TITLE
feat: Move Header and Hero components to server-side

### DIFF
--- a/components/sections/header.tsx
+++ b/components/sections/header.tsx
@@ -1,5 +1,5 @@
 import { STYLE_BLUR_GRADIENT_B_MD } from '@data/stylePreset';
-import { useVerticalScrollPosition, useWindowWidth } from '@hooks/misc';
+import { useVerticalScrollPosition, useWindowWidth } from '@hooks/ui';
 import { classNames } from '@stateLogics/utils';
 
 export const Header = () => {
@@ -7,6 +7,7 @@ export const Header = () => {
   const clientWidth = useWindowWidth();
   const dynamicStartPoint = clientWidth > 900 ? 900 : clientWidth;
   const scrollPositionRate = (startPosition: number, multiplier: number) => {
+    if (!startPosition) return 0;
     return scrollPosition < startPosition ? 0 : (scrollPosition / startPosition - 1) * multiplier;
   };
   const headerHeightRate = (scrollPositionRate(dynamicStartPoint, 2) * 100) / 9;

--- a/components/sections/hero.tsx
+++ b/components/sections/hero.tsx
@@ -1,6 +1,6 @@
 import { PATH_HOME, PATH_IMAGE_HOME } from '@constAssertions/data';
 import { STYLE_BLUR_GRADIENT_R_LG, STYLE_BUTTON_NORMAL_BLUE } from '@data/stylePreset';
-import { useVerticalScrollPosition } from '@hooks/misc';
+import { useVerticalScrollPosition } from '@hooks/ui';
 import { SignInButton } from '@layouts/layoutHeader/signInButton';
 import { TypesOptionsButton } from '@lib/types/options';
 import { classNames, nextImageLoader } from '@stateLogics/utils';

--- a/components/ui/gradients/labelsHorizontalGradients.tsx
+++ b/components/ui/gradients/labelsHorizontalGradients.tsx
@@ -1,5 +1,5 @@
 import { GRADIENT_POSITION } from '@constAssertions/ui';
-import { useHorizontalScrollPosition } from '@hooks/misc';
+import { useHorizontalScrollPosition } from '@hooks/ui';
 import { Types } from '@lib/types';
 import { classNames } from '@stateLogics/utils';
 import {

--- a/lib/stateLogics/hooks/misc.tsx
+++ b/lib/stateLogics/hooks/misc.tsx
@@ -1,13 +1,13 @@
 import { PATH_APP } from '@constAssertions/data';
 import { Labels, Todos } from '@lib/types';
 import { selectorSessionLabels } from '@states/atomEffects/labels';
-import { selectorSessionTodoItem, atomSelectorTodoItem } from '@states/atomEffects/todos';
+import { atomSelectorTodoItem, selectorSessionTodoItem } from '@states/atomEffects/todos';
 import { atomLabelNew, atomSelectorLabelItem } from '@states/labels';
 import { atomTodoModalMini, atomTodoModalOpen } from '@states/modals';
 import { atomTodoNew, selectorFilterTodoIdsByPathname } from '@states/todos';
 import equal from 'fast-deep-equal/react';
 import { useRouter } from 'next/router';
-import { RefObject, useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { RecoilState, RecoilValue, useRecoilCallback, useRecoilValue } from 'recoil';
 
 export const useFilterTodoIdsWithPathname = () => {
@@ -111,77 +111,6 @@ export const useNextQuery = ({ path, key }: { path?: string; key?: string }) => 
   return value;
 };
 
-export const useHorizontalScrollPosition = (ref: RefObject<HTMLDivElement>) => {
-  const [leftPosition, setLeftPosition] = useState(-1);
-  const [rightPosition, setRightPosition] = useState(-1);
-  const [isOverflow, setIsOverflow] = useState(false);
-
-  const initialOverflown = ref.current && ref.current.scrollWidth > 300;
-
-  useEffect(() => {
-    const currentRef = ref.current;
-
-    if (currentRef) {
-      const overScrollWidth = currentRef.clientWidth < currentRef.scrollWidth;
-      const overflown = overScrollWidth || (initialOverflown as boolean);
-      setIsOverflow(overflown);
-    }
-
-    const handleScroll = () => {
-      if (currentRef) {
-        const scrollWidth = currentRef.scrollWidth - currentRef.clientWidth;
-        const rightPosition = scrollWidth && scrollWidth - currentRef.scrollLeft;
-        setLeftPosition(ref.current.scrollLeft);
-        setRightPosition(rightPosition as number);
-      }
-    };
-
-    ref.current && ref.current.addEventListener('scroll', handleScroll);
-    return () => {
-      currentRef && currentRef.removeEventListener('scroll', handleScroll);
-    };
-  }, [initialOverflown, ref]);
-
-  return { leftPosition, rightPosition, isOverflow };
-};
-
-export const useWindowWidth = () => {
-  const getWindowWidth = () => {
-    return window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
-  };
-  const [windowWidth, setWindowWidth] = useState(getWindowWidth());
-
-  const handleResize = useCallback(() => {
-    setWindowWidth(getWindowWidth());
-  }, []);
-
-  useEffect(() => {
-    window.addEventListener('resize', handleResize);
-    return () => {
-      window.removeEventListener('resize', handleResize);
-    };
-  }, [handleResize]);
-
-  return windowWidth;
-};
-
-export const useVerticalScrollPosition = () => {
-  const [scrollPosition, setScrollPosition] = useState(0);
-
-  const handleScroll = () => {
-    const position = window.pageYOffset;
-    setScrollPosition(position);
-  };
-
-  useEffect(() => {
-    window.addEventListener('scroll', handleScroll);
-    return () => {
-      window.removeEventListener('scroll', handleScroll);
-    };
-  }, []);
-
-  return scrollPosition;
-};
 
 export const useCompareToQueryLabels = () => {
   return useRecoilCallback(({ snapshot }) => (compare: Labels[]) => {

--- a/lib/stateLogics/hooks/ui.tsx
+++ b/lib/stateLogics/hooks/ui.tsx
@@ -1,0 +1,74 @@
+import { RefObject, useCallback, useEffect, useState } from 'react';
+
+export const useHorizontalScrollPosition = (ref: RefObject<HTMLDivElement>) => {
+  const [leftPosition, setLeftPosition] = useState(-1);
+  const [rightPosition, setRightPosition] = useState(-1);
+  const [isOverflow, setIsOverflow] = useState(false);
+
+  const initialOverflown = ref.current && ref.current.scrollWidth > 300;
+
+  useEffect(() => {
+    const currentRef = ref.current;
+
+    if (currentRef) {
+      const overScrollWidth = currentRef.clientWidth < currentRef.scrollWidth;
+      const overflown = overScrollWidth || (initialOverflown as boolean);
+      setIsOverflow(overflown);
+    }
+
+    const handleScroll = () => {
+      if (currentRef) {
+        const scrollWidth = currentRef.scrollWidth - currentRef.clientWidth;
+        const rightPosition = scrollWidth && scrollWidth - currentRef.scrollLeft;
+        setLeftPosition(ref.current.scrollLeft);
+        setRightPosition(rightPosition as number);
+      }
+    };
+
+    ref.current && ref.current.addEventListener('scroll', handleScroll);
+    return () => {
+      currentRef && currentRef.removeEventListener('scroll', handleScroll);
+    };
+  }, [initialOverflown, ref]);
+
+  return { leftPosition, rightPosition, isOverflow };
+};
+
+export const useVerticalScrollPosition = () => {
+  const [scrollPosition, setScrollPosition] = useState(0);
+
+  const handleScroll = () => {
+    const position = window.pageYOffset;
+    setScrollPosition(position);
+  };
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  return scrollPosition;
+};
+
+export const useWindowWidth = () => {
+  if (typeof window === 'undefined') return 0;
+  const getWindowWidth = useCallback(() => {
+    return window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
+  }, []);
+  const [windowWidth, setWindowWidth] = useState(getWindowWidth());
+
+  const handleResize = useCallback(() => {
+    setWindowWidth(getWindowWidth());
+  }, [getWindowWidth]);
+
+  useEffect(() => {
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [handleResize]);
+
+  return windowWidth;
+};

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,12 +2,8 @@ import { LayoutHome } from '@layouts/home';
 import dynamic from 'next/dynamic';
 import { Fragment, ReactElement } from 'react';
 
-const Hero = dynamic(() => import('@components/sections/hero').then((mod) => mod.Hero), {
-  ssr: false,
-});
-const Header = dynamic(() => import('@components/sections/header').then((mod) => mod.Header), {
-  ssr: false,
-});
+const Hero = dynamic(() => import('@components/sections/hero').then((mod) => mod.Hero));
+const Header = dynamic(() => import('@components/sections/header').then((mod) => mod.Header));
 
 const Home = () => {
   return (


### PR DESCRIPTION
This commit transitions the Header and Hero section components from client-side to server-side rendering. This change helps to avoid Flash of Unstyled Content (FOUC) or unnecessary loading spinners, resulting in a more seamless user experience.

Furthermore, custom hooks utilized within the Header and Hero section components have been reorganized into a new directory, /hooks/ui, for better code structure and maintainability. Previously, these hooks were located in the /hooks/misc directory.