### PR TITLE
feat: enhance layout header rendering and fix FOUC

### DIFF
--- a/components/layouts/layoutFooter/index.tsx
+++ b/components/layouts/layoutFooter/index.tsx
@@ -49,7 +49,7 @@ export const LayoutFooter = ({ children, layoutType }: Props) => {
             )}>
             <FooterNavigation layoutType={layoutType}>
               {layoutApp && <AppNavigation />}
-              <div className='ml:hidden'>
+              <div className={isSidebarOpen ? '' : 'hidden'}>
                 {layoutHome && <HomeNavigation layoutType={layoutType} />}
               </div>
             </FooterNavigation>

--- a/components/layouts/layoutHeader/index.tsx
+++ b/components/layouts/layoutHeader/index.tsx
@@ -3,11 +3,11 @@ import { classNames } from '@stateLogics/utils';
 import { atomNavigationOpenMobile } from '@states/layouts';
 import dynamic from 'next/dynamic';
 import {
-    Fragment as LayoutHeaderFragment,
-    Fragment as LeftSideFragment,
-    Fragment as LogoFragment,
-    Fragment as NavigationButtonFragment,
-    Fragment as RightNavigationFragment,
+  Fragment as LayoutHeaderFragment,
+  Fragment as LeftSideFragment,
+  Fragment as LogoFragment,
+  Fragment as NavigationButtonFragment,
+  Fragment as RightNavigationFragment,
 } from 'react';
 import { useRecoilValue } from 'recoil';
 import { Logo } from './logo';
@@ -28,49 +28,57 @@ export const LayoutHeader = ({ children, layoutType }: Props) => {
     <LayoutHeaderFragment>
       <div
         className={classNames(
-          'sticky top-0 flex max-h-[4rem] min-h-[4rem] flex-row items-center justify-between ml:mb-2',
-          layoutHome && 'z-50 mx-auto max-w-7xl bg-slate-50',
-          layoutHome && isSidebarMobileOpen ? '' : 'bg-opacity-60 backdrop-blur-lg',
+          'sticky top-0 w-full',
+          layoutHome && 'z-50 bg-slate-50',
+          layoutHome && !isSidebarMobileOpen ? 'bg-opacity-60 backdrop-blur-lg' : '',
           layoutApp && 'bg-transparent',
         )}>
-        <LeftSideFragment>
-          <div
-            className={classNames(
-              'flex flex-row items-center justify-between pl-3 md:w-full',
-              layoutApp && 'md:max-w-[16rem]',
-              layoutHome && 'md:max-w-[12rem]',
-            )}>
-            <NavigationButtonFragment>{layoutApp && <NavigationButton />}</NavigationButtonFragment>
-            <LogoFragment>
-              <div
-                className={classNames(
-                  'flex w-full flex-row justify-start',
-                  layoutApp && 'max-md:hidden',
-                )}>
-                <Logo />
-              </div>
-            </LogoFragment>
-          </div>
-        </LeftSideFragment>
-        <RightNavigationFragment>
-          <div
-            className={classNames(
-              layoutApp && 'flex flex-1 flex-row items-center justify-end pl-2 ml:mr-3',
-              layoutHome && 'hidden ml:mr-8 ml:flex',
-            )}>
-            {children}
-          </div>
-          <NavigationButtonFragment>
+        <div
+          className={classNames(
+            'flex max-h-[4rem] min-h-[4rem] flex-row items-center justify-between ml:mb-2',
+            layoutHome && 'mx-auto max-w-7xl',
+          )}>
+          <LeftSideFragment>
             <div
               className={classNames(
-                'ml:hidden ml:pr-0',
-                layoutHome && 'pr-6',
-                layoutApp && 'pr-3',
+                'flex flex-row items-center justify-between pl-3 md:w-full',
+                layoutApp && 'md:max-w-[16rem]',
+                layoutHome && 'md:max-w-[12rem]',
               )}>
-              {layoutHome && <NavigationButton />}
+              <NavigationButtonFragment>
+                {layoutApp && <NavigationButton />}
+              </NavigationButtonFragment>
+              <LogoFragment>
+                <div
+                  className={classNames(
+                    'flex w-full flex-row justify-start',
+                    layoutApp && 'max-md:hidden',
+                  )}>
+                  <Logo />
+                </div>
+              </LogoFragment>
             </div>
-          </NavigationButtonFragment>
-        </RightNavigationFragment>
+          </LeftSideFragment>
+          <RightNavigationFragment>
+            <div
+              className={classNames(
+                layoutApp && 'flex flex-1 flex-row items-center justify-end pl-2 ml:mr-3',
+                layoutHome && 'hidden ml:mr-8 ml:flex',
+              )}>
+              {children}
+            </div>
+            <NavigationButtonFragment>
+              <div
+                className={classNames(
+                  'ml:hidden ml:pr-0',
+                  layoutHome && 'pr-6',
+                  layoutApp && 'pr-3',
+                )}>
+                {layoutHome && <NavigationButton />}
+              </div>
+            </NavigationButtonFragment>
+          </RightNavigationFragment>
+        </div>
       </div>
       <UserSessionGroupEffects />
     </LayoutHeaderFragment>


### PR DESCRIPTION
Add a layer on top of the layout header for better alignment of the header menu and background colors.

Address the Flash of Unstyled Content (FOUC) issue in the mobile homeNavigation menu, which occurs when routing from the demo directory to the Home page, by conditionally assigning the 'hidden' class.