### PR TITLE
feat: add HomeContent section component and rename Header/Hero

### DIFF
--- a/components/sections/homeContent.tsx
+++ b/components/sections/homeContent.tsx
@@ -1,0 +1,65 @@
+import { PATH_IMAGE_HOME } from '@constAssertions/data';
+import { classNames, nextImageLoader } from '@stateLogics/utils';
+import Image from 'next/image';
+
+export const HomeContent = () => {
+  const styleImageWrapper =
+    'w-80 rounded-xl shadow-2xl shadow-slate-500/30 ring-2 ring-slate-300/10';
+  const styleImage = 'h-auto w-auto rounded-xl drop-shadow-2xl';
+
+  return (
+    <div className='my-32 px-28 py-10'>
+      <div className='grid grid-cols-2 items-center justify-items-center gap-10'>
+        <div>
+          <div className='flex max-w-md flex-col items-start justify-center space-y-3 font-bold leading-relaxed tracking-wide'>
+            <p className='text-3xl text-slate-800'>Spotlight your to-dos</p>
+            <p className='text-xl text-slate-800/80'>
+              View your to-dos that are intelligently and automatically selected in Today&apos;s
+              Focus.
+            </p>
+            <p className='text-base font-medium text-slate-800/60'>
+              Add your to-dos as you please, with or without due dates and priorities. Today&apos;s
+              Focus will display your most important to-dos for you.
+            </p>
+          </div>
+        </div>
+        <div className={classNames(styleImageWrapper)}>
+          <Image
+            loader={nextImageLoader}
+            width={0}
+            height={0}
+            className={styleImage}
+            src={PATH_IMAGE_HOME['contentFocus']}
+            alt='content focus image'
+            priority
+          />
+        </div>
+        <div className={classNames(styleImageWrapper)}>
+          <Image
+            loader={nextImageLoader}
+            width={0}
+            height={0}
+            className={styleImage}
+            src={PATH_IMAGE_HOME['contentOrganize']}
+            alt='content organize image'
+            priority
+          />
+        </div>
+        <div className='flex max-w-md flex-col items-start justify-center space-y-3 font-bold leading-relaxed tracking-wide'>
+          <p className='text-3xl text-slate-800'>Free your overload</p>
+          <p className='text-xl text-slate-800/80'>
+            Work on a to-do list that is auto-allocated according to your capacity.
+          </p>
+          <p className='text-base font-medium text-slate-800/60'>
+            Today&apos;s Focus efficiently determines the ideal number of to-dos for you. As you
+            consistently complete to-dos, the process adjusts and assigns more or fewer to-dos base
+            on your completion rate.
+          </p>
+          <p className='text-sm font-medium italic tracking-tight text-slate-800/40'>
+            (Note. the current minimum number allocation is set to 7)
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/components/sections/homeHeader.tsx
+++ b/components/sections/homeHeader.tsx
@@ -2,7 +2,7 @@ import { STYLE_BLUR_GRADIENT_B_MD } from '@data/stylePreset';
 import { useVerticalScrollPosition, useWindowWidth } from '@hooks/ui';
 import { classNames } from '@stateLogics/utils';
 
-export const Header = () => {
+export const HomeHeader = () => {
   const scrollPosition = useVerticalScrollPosition();
   const clientWidth = useWindowWidth();
   const dynamicStartPoint = clientWidth > 900 ? 900 : clientWidth;

--- a/components/sections/homeHero.tsx
+++ b/components/sections/homeHero.tsx
@@ -12,7 +12,7 @@ const signInButtonOptions: TypesOptionsButton = {
   className: STYLE_BUTTON_NORMAL_BLUE,
 };
 
-export const Hero = () => {
+export const HomeHero = () => {
   const scrollPosition = useVerticalScrollPosition();
   const demoOpacityScrollRate = scrollPosition < 500 ? scrollPosition / 500 : 500 / scrollPosition;
 

--- a/lib/data/constAssertions/data.tsx
+++ b/lib/data/constAssertions/data.tsx
@@ -55,6 +55,8 @@ export const PATH_IMAGE_APP = {
 export type PATH_IMAGE_HOME = (typeof PATH_IMAGE_HOME)[keyof typeof PATH_IMAGE_HOME];
 export const PATH_IMAGE_HOME = {
   demo: 'home-demo-image-desk.webp',
+  contentFocus: 'home-content-focus.webp',
+  contentOrganize: 'home-content-organize.webp',
 } as const;
 
 export type RETENTION = (typeof RETENTION)[keyof typeof RETENTION];

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,14 +2,20 @@ import { LayoutHome } from '@layouts/home';
 import dynamic from 'next/dynamic';
 import { Fragment, ReactElement } from 'react';
 
-const Hero = dynamic(() => import('@components/sections/hero').then((mod) => mod.Hero));
-const Header = dynamic(() => import('@components/sections/header').then((mod) => mod.Header));
+const HomeHero = dynamic(() => import('@components/sections/homeHero').then((mod) => mod.HomeHero));
+const HomeContent = dynamic(() =>
+  import('@components/sections/homeContent').then((mod) => mod.HomeContent),
+);
+const HomeHeader = dynamic(() =>
+  import('@components/sections/homeHeader').then((mod) => mod.HomeHeader),
+);
 
 const Home = () => {
   return (
     <Fragment>
-      <Hero />
-      <Header />
+      <HomeHero />
+      <HomeHeader />
+      <HomeContent />
     </Fragment>
   );
 };


### PR DESCRIPTION
Add the HomeContent section component, which contains a brief explanation of the application along with two images.

In addition, this commit renames the Header and Hero section components to HomeHeader and HomeHero, respectively, to better distinguish these specialized components.