### PR TITLE
feat: add UnderConstruction component to non-index pages

### DIFF
--- a/components/layouts/home/index.tsx
+++ b/components/layouts/home/index.tsx
@@ -26,12 +26,16 @@ export const LayoutHome = ({ children }: Props) => {
       <Head>
         <title>{slug ? 'Todos - ' + slug : ''}</title>
       </Head>
-      <LayoutHeader layoutType='home'>
-        <HomeNavigation layoutType='home' />
-      </LayoutHeader>
-      <LayoutFooter layoutType='home' />
-      {children}
-      <Footer />
+      <main className='flex min-h-screen flex-col justify-between'>
+        <section>
+          <LayoutHeader layoutType='home'>
+            <HomeNavigation layoutType='home' />
+          </LayoutHeader>
+          <LayoutFooter layoutType='home' />
+          {children}
+        </section>
+        <Footer />
+      </main>
       <LayoutHomeGroupEffects />
     </LayoutFragment>
   );

--- a/components/sections/underConstruction/index.tsx
+++ b/components/sections/underConstruction/index.tsx
@@ -1,0 +1,50 @@
+import { PATH_IMAGE_HOME } from '@constAssertions/data';
+import { STYLE_BUTTON_FULL_BLUE } from '@data/stylePreset';
+import { classNames, nextImageLoader } from '@stateLogics/utils';
+import Image from 'next/image';
+import Link from 'next/link';
+
+export const UnderConstruction = () => {
+  return (
+    <>
+      <div className='grid-row-2 grid items-center justify-items-center gap-2 px-2 py-5 sm:px-10 md:grid-cols-2'>
+        <div className='flex max-w-md flex-col items-center justify-center space-y-6 p-2 text-center'>
+          <div className='flex flex-col items-center justify-center space-y-2 text-slate-800/90'>
+            <p className={classNames('text-3xl font-bold uppercase tracking-wide sm:text-4xl')}>
+              Under
+            </p>
+            <p className={classNames('text-3xl font-bold uppercase tracking-wide sm:text-4xl')}>
+              Construction
+            </p>
+          </div>
+          <div>
+            <p className='text-slate-800/80'>
+              The page is currently under construction for improvements to better serve you. We
+              appreciate your patience. Please check back soon for an upgraded and user-friendly
+              experience. Thank you!
+            </p>
+          </div>
+          <Link
+            href='/'
+            className={classNames(
+              STYLE_BUTTON_FULL_BLUE,
+              'flex w-full max-w-xs flex-row justify-center whitespace-nowrap',
+            )}>
+            Back to homepage
+          </Link>
+        </div>
+        <div className='relative flex h-[30rem] w-full max-w-lg flex-row items-center justify-center rounded-xl'>
+          <Image
+            loader={nextImageLoader}
+            width={0}
+            height={0}
+            className='h-auto w-auto rounded-xl bg-transparent drop-shadow-2xl'
+            src={PATH_IMAGE_HOME['underConstruction']}
+            alt='content under construction'
+            priority
+          />
+        </div>
+      </div>
+    </>
+  );
+};

--- a/lib/data/constAssertions/data.tsx
+++ b/lib/data/constAssertions/data.tsx
@@ -57,6 +57,7 @@ export const PATH_IMAGE_HOME = {
   demo: 'home-demo-image-desk.webp',
   contentFocus: 'home-content-focus.webp',
   contentOrganize: 'home-content-organize.webp',
+  underConstruction: 'home-under-construction.webp',
 } as const;
 
 export type RETENTION = (typeof RETENTION)[keyof typeof RETENTION];

--- a/pages/contact/index.tsx
+++ b/pages/contact/index.tsx
@@ -1,8 +1,17 @@
 import { LayoutHome } from '@layouts/home';
+import dynamic from 'next/dynamic';
 import { ReactElement } from 'react';
 
+const UnderConstruction = dynamic(() =>
+  import('@components/sections/underConstruction').then((mod) => mod.UnderConstruction),
+);
+
 const Contact = () => {
-  return <>Contact</>;
+  return (
+    <>
+      <UnderConstruction />
+    </>
+  );
 };
 
 Contact.getLayout = function getLayout(page: ReactElement) {

--- a/pages/features/index.tsx
+++ b/pages/features/index.tsx
@@ -1,10 +1,15 @@
 import { LayoutHome } from '@layouts/home';
+import dynamic from 'next/dynamic';
 import { ReactElement } from 'react';
+
+const UnderConstruction = dynamic(() =>
+  import('@components/sections/underConstruction').then((mod) => mod.UnderConstruction),
+);
 
 const Features = () => {
   return (
     <>
-      <div>Features</div>
+      <UnderConstruction />
     </>
   );
 };

--- a/pages/implementations/index.tsx
+++ b/pages/implementations/index.tsx
@@ -1,10 +1,15 @@
-import { LayoutHome } from "@layouts/home";
-import { ReactElement } from "react";
+import { LayoutHome } from '@layouts/home';
+import dynamic from 'next/dynamic';
+import { ReactElement } from 'react';
+
+const UnderConstruction = dynamic(() =>
+  import('@components/sections/underConstruction').then((mod) => mod.UnderConstruction),
+);
 
 const Implementations = () => {
   return (
     <>
-      <div>Implementations</div>
+      <UnderConstruction />
     </>
   );
 };
@@ -12,6 +17,5 @@ const Implementations = () => {
 Implementations.getLayout = function getLayout(page: ReactElement) {
   return <LayoutHome>{page}</LayoutHome>;
 };
-
 
 export default Implementations;

--- a/pages/pricing/index.tsx
+++ b/pages/pricing/index.tsx
@@ -1,10 +1,15 @@
-import { LayoutHome } from "@layouts/home";
-import { ReactElement } from "react";
+import { LayoutHome } from '@layouts/home';
+import dynamic from 'next/dynamic';
+import { ReactElement } from 'react';
+
+const UnderConstruction = dynamic(() =>
+  import('@components/sections/underConstruction').then((mod) => mod.UnderConstruction),
+);
 
 const Pricing = () => {
   return (
     <>
-      <div>Pricing</div>
+      <UnderConstruction />
     </>
   );
 };
@@ -12,6 +17,5 @@ const Pricing = () => {
 Pricing.getLayout = function getLayout(page: ReactElement) {
   return <LayoutHome>{page}</LayoutHome>;
 };
-
 
 export default Pricing;


### PR DESCRIPTION
Implement UnderConstruction component to display on all pages except the index (home) page. Add 'home-under-construction' image path to PATH_IMAGE_HOME as 'underConstruction'. Enhance user experience by providing a clear message and visual indication for pages under construction.