### PR TITLE
feat: improve the sidebarmenu on layouthomey

### DIFF
--- a/components/layouts/home/homeNavigation.tsx
+++ b/components/layouts/home/homeNavigation.tsx
@@ -2,6 +2,7 @@ import { PrefetchRouterButton } from '@buttons/button/prefetchRouterButton';
 import { DATA_HOME } from '@collections/home';
 import { PATH_HOME } from '@constAssertions/data';
 import { STYLE_BUTTON_NORMAL_BLACK, STYLE_LINK_NORMAL } from '@data/stylePreset';
+import { useNavigationOpen } from '@hooks/layouts';
 import { SignInButton } from '@layouts/layoutHeader/signInButton';
 import { Types } from '@lib/types';
 import { classNames } from '@stateLogics/utils';
@@ -14,6 +15,12 @@ type Props = Pick<Types, 'layoutType'>;
 export const HomeNavigation = ({ layoutType }: Props) => {
   const layoutApp = layoutType === 'app';
   const layoutHome = layoutType === 'home';
+  const setSidebarOpen = useNavigationOpen();
+  const optionsRouter = {
+    path: PATH_HOME['demo'],
+    className: classNames(STYLE_BUTTON_NORMAL_BLACK, 'ml:ml-2 max-ml:w-full'),
+    tooltip: 'Demo session',
+  };
 
   return (
     <ul
@@ -44,11 +51,8 @@ export const HomeNavigation = ({ layoutType }: Props) => {
       <div className={classNames('pl-0 max-ml:pt-2 ml:pl-2 lg:pl-4')}>
         <SignInButton />
         <PrefetchRouterButton
-          options={{
-            path: PATH_HOME['demo'],
-            className: classNames(STYLE_BUTTON_NORMAL_BLACK, 'ml:ml-2 max-ml:w-full'),
-            tooltip: 'Demo session',
-          }}>
+          options={optionsRouter}
+          onClick={() => setSidebarOpen()}>
           Try Demo
         </PrefetchRouterButton>
       </div>

--- a/components/layouts/home/index.tsx
+++ b/components/layouts/home/index.tsx
@@ -20,6 +20,7 @@ type Props = {
 
 export const LayoutHome = ({ children }: Props) => {
   const slug = useRecoilValue(atomHtmlTitleTag);
+  const layoutType = 'home';
 
   return (
     <LayoutFragment>
@@ -28,10 +29,10 @@ export const LayoutHome = ({ children }: Props) => {
       </Head>
       <main className='flex min-h-screen flex-col justify-between'>
         <section>
-          <LayoutHeader layoutType='home'>
-            <HomeNavigation layoutType='home' />
+          <LayoutHeader layoutType={layoutType}>
+            <HomeNavigation layoutType={layoutType} />
           </LayoutHeader>
-          <LayoutFooter layoutType='home' />
+          <LayoutFooter layoutType={layoutType} />
           {children}
         </section>
         <Footer />

--- a/components/layouts/layoutFooter/footerNavigation.tsx
+++ b/components/layouts/layoutFooter/footerNavigation.tsx
@@ -4,34 +4,30 @@ import { classNames } from '@stateLogics/utils';
 import { atomNavigationOpenMobile } from '@states/layouts';
 import { Backdrop } from '@ui/backdrops/backdrop';
 import { Fragment as FooterSidebarFragment, forwardRef } from 'react';
-import { useRecoilCallback } from 'recoil';
+import { useRecoilValue } from 'recoil';
 
 type Props = Pick<Types, 'children' | 'layoutType'>;
 
 export const FooterNavigation = forwardRef<HTMLDivElement, Props>(
   ({ layoutType, children }: Props, ref) => {
     const setNavigationOpen = useNavigationOpen();
-    const isSidebarMobileOpen = useRecoilCallback(({ snapshot }) => () => {
-      return snapshot.getLoadable(atomNavigationOpenMobile(layoutType)).getValue();
-    });
+    const isSidebarMobileOpen = useRecoilValue(atomNavigationOpenMobile(layoutType));
     const layoutHome = layoutType === 'home';
     const layoutApp = layoutType === 'app';
-    const initiallyHiddenAppMenu = layoutApp && !isSidebarMobileOpen();
 
     return (
       <FooterSidebarFragment>
         <Backdrop
           options={{ isPortal: false }}
-          show={isSidebarMobileOpen()}
+          show={isSidebarMobileOpen}
           onClick={() => setNavigationOpen()}
         />
         <div
           ref={ref}
           className={classNames(
             'fixed z-30 ml:z-auto',
-            initiallyHiddenAppMenu && 'hidden',
             layoutApp &&
-              'left-0 top-0 w-72 bg-slate-50 pl-2 pr-0 pt-3 md:top-[4.6rem] md:flex md:w-full md:max-w-[16.5rem] md:flex-col md:bg-transparent md:pt-0 md:pl-2 md:pr-0',
+              'left-0 top-0 w-72 bg-slate-50 pl-2 pr-0 pt-3 md:top-[4.6rem] md:flex md:w-full md:max-w-[16.5rem] md:flex-col md:bg-transparent md:pl-2 md:pr-0 md:pt-0',
             layoutHome && 'top-[0rem] w-full',
           )}>
           {children}

--- a/components/layouts/layoutFooter/index.tsx
+++ b/components/layouts/layoutFooter/index.tsx
@@ -28,7 +28,7 @@ export const LayoutFooter = ({ children, layoutType }: Props) => {
             enter='transition transform ease-in-out duration-200'
             enterFrom={classNames(
               'transform opacity-0',
-              layoutApp && 'translate-x-0',
+              layoutApp && 'md:-translate-x-0 -translate-x-5',
               layoutHome && '-translate-y-5',
             )}
             enterTo={classNames(
@@ -49,9 +49,7 @@ export const LayoutFooter = ({ children, layoutType }: Props) => {
             )}>
             <FooterNavigation layoutType={layoutType}>
               {layoutApp && <AppNavigation />}
-              <div className={isSidebarOpen ? '' : 'hidden'}>
-                {layoutHome && <HomeNavigation layoutType={layoutType} />}
-              </div>
+              {layoutHome && <HomeNavigation layoutType={layoutType} />}
             </FooterNavigation>
           </Transition.Child>
           <LayoutNavigationGroupEffect />

--- a/components/layouts/layoutHeader/index.tsx
+++ b/components/layouts/layoutHeader/index.tsx
@@ -30,7 +30,7 @@ export const LayoutHeader = ({ children, layoutType }: Props) => {
         className={classNames(
           'sticky top-0 w-full',
           layoutHome && 'z-50 bg-slate-50',
-          layoutHome && !isSidebarMobileOpen ? 'bg-opacity-60 backdrop-blur-lg' : '',
+          layoutHome && !isSidebarMobileOpen && 'bg-opacity-60 backdrop-blur-lg',
           layoutApp && 'bg-transparent',
         )}>
         <div

--- a/components/layouts/layoutHeader/logo.tsx
+++ b/components/layouts/layoutHeader/logo.tsx
@@ -1,17 +1,19 @@
 import { PrefetchRouterButton } from '@buttons/button/prefetchRouterButton';
 import { SvgLogo } from '@components/icons/svgLogo';
 import { NetworkStatus } from '@components/notifications/networkStatus';
+import { useNavigationOpen } from '@hooks/layouts';
 import { Fragment as LogoContainerFragment, Fragment as LogoFragment } from 'react';
 
 export const Logo = () => {
+  const setSidebarOpen = useNavigationOpen();
+  const optionsRouter = { path: '/', className: 'cursor-pointer' };
+
   return (
     <nav className='flex h-0 flex-row items-center'>
       <LogoContainerFragment>
         <PrefetchRouterButton
-          options={{
-            path: '/',
-            className: 'cursor-pointer',
-          }}>
+          options={optionsRouter}
+          onClick={() => setSidebarOpen()}>
           <LogoFragment>
             <span className='flex w-full flex-row items-center justify-center'>
               <SvgLogo type='MainWhite' />

--- a/components/ui/backdrops/backdrop/index.tsx
+++ b/components/ui/backdrops/backdrop/index.tsx
@@ -5,7 +5,9 @@ import { TypesOptionsBackdrop } from '@lib/types/options';
 import { classNames } from '@stateLogics/utils';
 import { Fragment as BackdropFragment, Fragment, useEffect, useRef, useState } from 'react';
 
-type Props = { options: TypesOptionsBackdrop } & Partial<Pick<Types, 'onClick' | 'show' | 'onBlur' | 'onFocus'>>;
+type Props = { options: TypesOptionsBackdrop } & Partial<
+  Pick<Types, 'onClick' | 'show' | 'onBlur' | 'onFocus'>
+>;
 
 export const Backdrop = ({ options, onClick, onBlur, onFocus, show }: Props) => {
   const [isShow, setIsShow] = useState(false);
@@ -27,10 +29,16 @@ export const Backdrop = ({ options, onClick, onBlur, onFocus, show }: Props) => 
           show={show ?? isShow}
           as={Fragment}
           appear={true}
-          enter={classNames('transition-opacity ease-in-out', options.enterDuration ?? 'duration-500')}
+          enter={classNames(
+            'transition-opacity ease-in-out',
+            options.enterDuration ?? 'duration-500',
+          )}
           enterFrom='opacity-0'
           enterTo='opacity-100'
-          leave={classNames('transition-opacity ease-in-out', options.leaveDuration ?? 'duration-100')}
+          leave={classNames(
+            'transition-opacity ease-in-out',
+            options.leaveDuration ?? 'duration-100',
+          )}
           leaveFrom='opacity-100'
           leaveTo='opacity-0'>
           <div

--- a/lib/data/stylePreset.tsx
+++ b/lib/data/stylePreset.tsx
@@ -5,7 +5,7 @@ import { classNames } from '@stateLogics/utils';
  */
 // Base
 export const STYLE_BUTTON_BASE =
-  'transition-all inline-flex items-center justify-center tracking-wide rounded-lg py-[0.66rem] border leading-4 shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2';
+  'transition-all inline-flex items-center justify-center tracking-wide rounded-lg h-10 p-2 border leading-4 shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2';
 export const STYLE_BUTTON_SIZE_NORMAL = 'px-4 text-base';
 export const STYLE_BUTTON_SIZE_LARGE = 'px-14 text-base';
 export const STYLE_BUTTON_SIZE_FULL = 'px-14 text-base';

--- a/lib/stateLogics/effects/layout.tsx
+++ b/lib/stateLogics/effects/layout.tsx
@@ -3,27 +3,32 @@ import {
   useFilterPathApp,
   useFilterPathHome,
   useInitialNavigation,
-  useLayoutNavigationMobileReset,
   useLayoutBodyTagClass,
+  useLayoutNavigationMobileReset,
   useLayoutType,
 } from '@hooks/layouts';
 import { LabelModal } from '@modals/labelModals/labelModal';
-import { atomCatch } from '@states/misc';
-import { useRecoilValue } from 'recoil';
-import { TodoModal } from '@modals/todoModals/todoModal';
 import { MinimizedModal } from '@modals/minimizedModal';
+import { TodoModal } from '@modals/todoModals/todoModal';
+import { atomNavigationOpenMobile } from '@states/layouts';
+import { atomCatch } from '@states/misc';
 import { Notification } from 'components/notifications/notification';
+import { useRecoilValue, useResetRecoilState } from 'recoil';
 import { GroupEffects } from './groupEffects';
 
 export const LayoutHomeGroupEffects = () => {
+  const layoutType = 'home';
   const filterPath = useFilterPathHome();
-  const setNavigation = useInitialNavigation({ layoutType: 'home' });
-  const setLayoutType = useLayoutType({ layoutType: 'home' });
-  const setBodyTagClass = useLayoutBodyTagClass({ layoutType: 'home' });
+  const setNavigation = useInitialNavigation({ layoutType: layoutType });
+  const setLayoutType = useLayoutType({ layoutType: layoutType });
+  const setBodyTagClass = useLayoutBodyTagClass({ layoutType: layoutType });
+  const restSidebarOpen = useResetRecoilState(atomNavigationOpenMobile(layoutType));
 
   return (
     <>
-      <GroupEffects effects={[filterPath, setLayoutType, setNavigation, setBodyTagClass]} />
+      <GroupEffects
+        effects={[filterPath, setLayoutType, setNavigation, setBodyTagClass, restSidebarOpen]}
+      />
     </>
   );
 };

--- a/lib/stateLogics/hooks/layouts.tsx
+++ b/lib/stateLogics/hooks/layouts.tsx
@@ -18,9 +18,9 @@ import { atomEffectMediaQuery } from '@states/atomEffects/misc';
 import { CATCH } from '@constAssertions/misc';
 
 export const useNavigationOpen = () => {
+  const layoutType = useRecoilValue(atomLayoutType);
   return useRecoilCallback(({ snapshot, set }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
-    const layoutType = get(atomLayoutType);
     const breakpoint =
       layoutType === 'app'
         ? get(atomEffectMediaQuery(BREAKPOINT['md']))


### PR DESCRIPTION
improve the sidebarmenu on the layouthome by resetting its state whenever users route to the different page. initially this feature has not been added to reset the state of the layouthome's sidebarmenu.

additionally improve the backdrop of homelayout's sidebarmenu for better user experiences.