### PR TITLE
fix: fix flashing of sidebar menu during route transitions

### DIFF
--- a/components/layouts/home/homeNavigation.tsx
+++ b/components/layouts/home/homeNavigation.tsx
@@ -1,28 +1,19 @@
 import { PrefetchRouterButton } from '@buttons/button/prefetchRouterButton';
 import { DATA_HOME } from '@collections/home';
 import { PATH_HOME } from '@constAssertions/data';
-import { BREAKPOINT } from '@constAssertions/ui';
 import { STYLE_BUTTON_NORMAL_BLACK, STYLE_LINK_NORMAL } from '@data/stylePreset';
-import { useNavigationOpen } from '@hooks/layouts';
 import { SignInButton } from '@layouts/layoutHeader/signInButton';
 import { Types } from '@lib/types';
 import { classNames } from '@stateLogics/utils';
-import { atomEffectMediaQuery } from '@states/atomEffects/misc';
 import { DividerX } from '@ui/dividers/dividerX';
 import { DividerY } from '@ui/dividers/dividerY';
 import Link from 'next/link';
-import { useRecoilValueLoadable } from 'recoil';
 
 type Props = Pick<Types, 'layoutType'>;
 
 export const HomeNavigation = ({ layoutType }: Props) => {
   const layoutApp = layoutType === 'app';
   const layoutHome = layoutType === 'home';
-  const breakpointMD = useRecoilValueLoadable(atomEffectMediaQuery(BREAKPOINT['md'])).valueMaybe();
-  const setSidebarOpen = useNavigationOpen();
-  const onClickRouterHandler = () => {
-    !breakpointMD && setSidebarOpen();
-  };
   const optionsRouter = {
     path: PATH_HOME['demo'],
     className: classNames(STYLE_BUTTON_NORMAL_BLACK, 'ml:ml-2 max-ml:w-full'),
@@ -57,11 +48,7 @@ export const HomeNavigation = ({ layoutType }: Props) => {
       {layoutHome && <DividerX options={{ hidden: 'ml:hidden' }} />}
       <div className={classNames('pl-0 max-ml:pt-2 ml:pl-2 lg:pl-4')}>
         <SignInButton />
-        <PrefetchRouterButton
-          options={optionsRouter}
-          onClick={() => onClickRouterHandler()}>
-          Try Demo
-        </PrefetchRouterButton>
+        <PrefetchRouterButton options={optionsRouter}>Try Demo</PrefetchRouterButton>
       </div>
     </ul>
   );

--- a/components/layouts/layoutFooter/footerNavigation.tsx
+++ b/components/layouts/layoutFooter/footerNavigation.tsx
@@ -1,7 +1,7 @@
 import { useNavigationOpen } from '@hooks/layouts';
 import { Types } from '@lib/types';
 import { classNames } from '@stateLogics/utils';
-import { atomNavigationOpenMobile } from '@states/layouts';
+import { selectorNavigationOpenOnMobile } from '@states/layouts';
 import { Backdrop } from '@ui/backdrops/backdrop';
 import { Fragment as FooterSidebarFragment, forwardRef } from 'react';
 import { useRecoilValue } from 'recoil';
@@ -11,7 +11,7 @@ type Props = Pick<Types, 'children' | 'layoutType'>;
 export const FooterNavigation = forwardRef<HTMLDivElement, Props>(
   ({ layoutType, children }: Props, ref) => {
     const setNavigationOpen = useNavigationOpen();
-    const isSidebarMobileOpen = useRecoilValue(atomNavigationOpenMobile(layoutType));
+    const isSidebarMobileOpen = useRecoilValue(selectorNavigationOpenOnMobile);
     const layoutHome = layoutType === 'home';
     const layoutApp = layoutType === 'app';
 

--- a/components/layouts/layoutFooter/index.tsx
+++ b/components/layouts/layoutFooter/index.tsx
@@ -7,7 +7,6 @@ import { selectorNavigationOpen } from '@states/layouts';
 import { Fragment as FooterBodyFragment, Fragment, Fragment as LayoutFooterFragment } from 'react';
 import { useRecoilValue } from 'recoil';
 import { FooterNavigation } from './footerNavigation';
-import { LayoutNavigationGroupEffect } from '@effects/layout';
 
 type Props = Pick<Types, 'layoutType'> & Partial<Pick<Types, 'children'>>;
 
@@ -23,8 +22,7 @@ export const LayoutFooter = ({ children, layoutType }: Props) => {
           show={isSidebarOpen}
           as='div'>
           <Transition.Child
-            appear={true}
-            as={Fragment}
+            as={isSidebarOpen ? Fragment : 'div'}
             enter='transition transform ease-in-out duration-200'
             enterFrom={classNames(
               'transform opacity-0',
@@ -47,12 +45,13 @@ export const LayoutFooter = ({ children, layoutType }: Props) => {
               layoutApp && '-translate-x-5',
               layoutHome && '-translate-y-5',
             )}>
-            <FooterNavigation layoutType={layoutType}>
-              {layoutApp && <AppNavigation />}
-              {layoutHome && <HomeNavigation layoutType={layoutType} />}
-            </FooterNavigation>
+            {isSidebarOpen && (
+              <FooterNavigation layoutType={layoutType}>
+                {layoutApp && <AppNavigation />}
+                {layoutHome && <HomeNavigation layoutType={layoutType} />}
+              </FooterNavigation>
+            )}
           </Transition.Child>
-          <LayoutNavigationGroupEffect />
         </Transition.Root>
         <FooterBodyFragment>{children}</FooterBodyFragment>
       </div>

--- a/components/layouts/layoutHeader/index.tsx
+++ b/components/layouts/layoutHeader/index.tsx
@@ -1,6 +1,6 @@
+import { useVerticalScrollPosition } from '@hooks/ui';
 import { Types } from '@lib/types';
 import { classNames } from '@stateLogics/utils';
-import { atomNavigationOpenMobile } from '@states/layouts';
 import dynamic from 'next/dynamic';
 import {
   Fragment as LayoutHeaderFragment,
@@ -12,6 +12,7 @@ import {
 import { useRecoilValue } from 'recoil';
 import { Logo } from './logo';
 import { NavigationButton } from './navigationButton';
+import { atomNavigationOpen } from '@states/layouts';
 
 const UserSessionGroupEffects = dynamic(() =>
   import('@effects/users').then((mod) => mod.UserSessionGroupEffects),
@@ -22,7 +23,9 @@ type Props = Partial<Pick<Types, 'children'>> & Pick<Types, 'layoutType'>;
 export const LayoutHeader = ({ children, layoutType }: Props) => {
   const layoutHome = layoutType === 'home';
   const layoutApp = layoutType === 'app';
-  const isSidebarMobileOpen = useRecoilValue(atomNavigationOpenMobile(layoutType));
+  const isSidebarOpen = useRecoilValue(atomNavigationOpen(layoutType));
+  const scrollPosition = useVerticalScrollPosition();
+  const homeSidebarClose = layoutHome && !isSidebarOpen && scrollPosition;
 
   return (
     <LayoutHeaderFragment>
@@ -30,7 +33,7 @@ export const LayoutHeader = ({ children, layoutType }: Props) => {
         className={classNames(
           'sticky top-0 w-full',
           layoutHome && 'z-50 bg-slate-50',
-          layoutHome && !isSidebarMobileOpen && 'bg-opacity-60 backdrop-blur-lg',
+          homeSidebarClose && 'bg-opacity-60 backdrop-blur-lg',
           layoutApp && 'bg-transparent',
         )}>
         <div

--- a/components/layouts/layoutHeader/logo.tsx
+++ b/components/layouts/layoutHeader/logo.tsx
@@ -1,26 +1,15 @@
 import { PrefetchRouterButton } from '@buttons/button/prefetchRouterButton';
 import { SvgLogo } from '@components/icons/svgLogo';
 import { NetworkStatus } from '@components/notifications/networkStatus';
-import { BREAKPOINT } from '@constAssertions/ui';
-import { useNavigationOpen } from '@hooks/layouts';
-import { atomEffectMediaQuery } from '@states/atomEffects/misc';
 import { Fragment as LogoContainerFragment, Fragment as LogoFragment } from 'react';
-import { useRecoilValueLoadable } from 'recoil';
 
 export const Logo = () => {
-  const breakpointMD = useRecoilValueLoadable(atomEffectMediaQuery(BREAKPOINT['md'])).valueMaybe();
-  const setSidebarOpen = useNavigationOpen();
-  const onClickRouterHandler = () => {
-    !breakpointMD && setSidebarOpen();
-  };
   const optionsRouter = { path: '/', className: 'cursor-pointer' };
 
   return (
     <nav className='flex h-0 flex-row items-center'>
       <LogoContainerFragment>
-        <PrefetchRouterButton
-          options={optionsRouter}
-          onClick={() => onClickRouterHandler()}>
+        <PrefetchRouterButton options={optionsRouter}>
           <LogoFragment>
             <span className='flex w-full flex-row items-center justify-center'>
               <SvgLogo type='MainWhite' />

--- a/lib/stateLogics/effects/layout.tsx
+++ b/lib/stateLogics/effects/layout.tsx
@@ -4,16 +4,14 @@ import {
   useFilterPathHome,
   useInitialNavigation,
   useLayoutBodyTagClass,
-  useLayoutNavigationMobileReset,
   useLayoutType,
 } from '@hooks/layouts';
 import { LabelModal } from '@modals/labelModals/labelModal';
 import { MinimizedModal } from '@modals/minimizedModal';
 import { TodoModal } from '@modals/todoModals/todoModal';
-import { atomNavigationOpenMobile } from '@states/layouts';
 import { atomCatch } from '@states/misc';
 import { Notification } from 'components/notifications/notification';
-import { useRecoilValue, useResetRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import { GroupEffects } from './groupEffects';
 
 export const LayoutHomeGroupEffects = () => {
@@ -22,13 +20,10 @@ export const LayoutHomeGroupEffects = () => {
   const setNavigation = useInitialNavigation({ layoutType: layoutType });
   const setLayoutType = useLayoutType({ layoutType: layoutType });
   const setBodyTagClass = useLayoutBodyTagClass({ layoutType: layoutType });
-  const restSidebarOpen = useResetRecoilState(atomNavigationOpenMobile(layoutType));
 
   return (
     <>
-      <GroupEffects
-        effects={[filterPath, setLayoutType, setNavigation, setBodyTagClass, restSidebarOpen]}
-      />
+      <GroupEffects effects={[filterPath, setLayoutType, setNavigation, setBodyTagClass]} />
     </>
   );
 };
@@ -47,15 +42,6 @@ export const LayoutAppGroupEffects = () => {
       <TodoModal />
       <MinimizedModal />
       {!catchTodoModal && <LabelModal />}
-    </>
-  );
-};
-
-export const LayoutNavigationGroupEffect = () => {
-  const mobileReset = useLayoutNavigationMobileReset();
-  return (
-    <>
-      <GroupEffects effects={[mobileReset]} />
     </>
   );
 };

--- a/lib/stateLogics/states/layouts.tsx
+++ b/lib/stateLogics/states/layouts.tsx
@@ -1,23 +1,13 @@
-import { BREAKPOINT } from '@constAssertions/ui';
 import { Types } from '@lib/types';
 import { atom, atomFamily, selector } from 'recoil';
 import { atomEffectMediaQuery } from './atomEffects/misc';
+import { BREAKPOINT } from '@constAssertions/ui';
 
 /**
  * Atoms
  **/
-export const atomNavigationInitialOpen = atomFamily<boolean, Types['layoutType']>({
-  key: 'atomNavigationInitialOpen',
-  default: false,
-});
-
-export const atomNavigationOpenMobile = atomFamily<boolean, Types['layoutType']>({
-  key: 'atomNavigationOpenMobile',
-  default: false,
-});
-
-export const atomNavigationOpenSetting = atomFamily<boolean, Types['layoutType']>({
-  key: 'atomNavigationOpenSetting',
+export const atomNavigationOpen = atomFamily<boolean, Types['layoutType']>({
+  key: 'atomNavigationOpen',
   default: false,
 });
 
@@ -38,15 +28,23 @@ export const selectorNavigationOpen = selector({
   key: 'selectorNavigationOpen',
   get: ({ get }) => {
     const layoutType = get(atomLayoutType);
+    return get(atomNavigationOpen(layoutType));
+  },
+  cachePolicy_UNSTABLE: {
+    eviction: 'most-recent',
+  },
+});
+
+export const selectorNavigationOpenOnMobile = selector({
+  key: 'selectorNavigationOpenOnMobile',
+  get: ({ get }) => {
+    const layoutType = get(atomLayoutType);
     const breakpointMedium =
       layoutType === 'app'
         ? get(atomEffectMediaQuery(BREAKPOINT['md']))
         : get(atomEffectMediaQuery(BREAKPOINT['ml']));
-    if (get(atomNavigationOpenSetting(layoutType)) && breakpointMedium)
-      return get(atomNavigationOpenSetting(layoutType)) ? false : true;
-    return breakpointMedium
-      ? get(atomNavigationInitialOpen(layoutType))
-      : get(atomNavigationOpenMobile(layoutType));
+
+    return !breakpointMedium && get(atomNavigationOpen(layoutType));
   },
   cachePolicy_UNSTABLE: {
     eviction: 'most-recent',


### PR DESCRIPTION
Resolve the issue of the footer sidebar menu flashing briefly when navigating between 'app' and 'home' routes. The issue was caused by conditional rendering based on the layoutType without taking into account the sidebarOpen state. By incorporating an additional condition 'isSidebarOpen', the flashing behavior has been eliminated.

Additionally, this commit removes any unnecessary and unused code for better maintainability and readability.