### PR TITLE
fix: correctly load external user avatar on initial page load

### DIFF
--- a/components/layouts/layoutHeader/user.tsx
+++ b/components/layouts/layoutHeader/user.tsx
@@ -9,14 +9,12 @@ export const User = () => {
   const offSession = getSessionStorage(STORAGE_KEY['offSession']);
   const { data: session } = useSession();
 
-  const userSession = !offSession && !!session;
   const userOffSession = !!offSession && !session;
 
   return (
     <Fragment>
       <div className='ml-4 flex min-w-[2rem] items-center md:ml-6'>
-        {userOffSession && <SignInButton />}
-        {userSession && <UserDropdown />}
+        {userOffSession ? <SignInButton /> : <UserDropdown />}
       </div>
     </Fragment>
   );


### PR DESCRIPTION
Resolve an issue where user avatars from external sources, such as Google or GitHub, were not being rendered correctly on the initial page load. This was caused by a conditional check. Updating the logic to use a ternary operator now ensures that external avatars are properly loaded upon initial page load.