### PR TITLE
fix: fix the casing

### DIFF
--- a/lib/data/collections/footer.tsx
+++ b/lib/data/collections/footer.tsx
@@ -27,7 +27,7 @@ export const DATA_FOOTER_NAVIGATION: TypesFooterNavigation[] = [
   { name: 'Implementation', path: PATH_HOME['implementations'] },
   { name: 'Pricing', path: PATH_HOME['pricing'] },
   { name: 'Demo', path: PATH_HOME['demo'] },
-  { name: 'contact', path: PATH_HOME['contact'] },
+  { name: 'Contact', path: PATH_HOME['contact'] },
 ];
 
 export const DATA_FOOTER_SOCIAL: TypesFooterSocial[] = [


### PR DESCRIPTION
Update footer navigation menu to meet capitalization requirements. The previous version used some lowercase letters, but the new version capitalizes the first letter of each word for consistency and better readability.