### PR TITLE
refactor: optimize Next-Auth SignIn call performance

### DIFF
--- a/components/layouts/layoutHeader/signInButton.tsx
+++ b/components/layouts/layoutHeader/signInButton.tsx
@@ -1,10 +1,13 @@
 import { Button } from '@buttons/button';
+import { PATH_HOME } from '@constAssertions/data';
 import { STYLE_BUTTON_NORMAL_BLUE } from '@data/stylePreset';
 import { Types } from '@lib/types';
 import { TypesOptionsButton } from '@lib/types/options';
 import { classNames } from '@stateLogics/utils';
 import { atomLayoutType } from '@states/layouts';
 import { signIn } from 'next-auth/react';
+import router from 'next/router';
+import { useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
 
 type Props = { options?: Partial<TypesOptionsButton> };
@@ -22,11 +25,16 @@ export const SignInButton = ({ options }: Props) => {
   const layoutType = useRecoilValue(atomLayoutType);
   const buttonOptions = buttonOptionsHandler(layoutType);
 
+  useEffect(() => {
+    router.prefetch(PATH_HOME['auth']);
+  }, []);
+
   return (
     <>
       <Button
         options={options ?? buttonOptions}
-        onClick={() => signIn()}>
+        onClick={() => signIn()}
+      >
         {signInButtonName}
       </Button>
     </>

--- a/components/ui/modals/modal/modalHeaders/headerDescription.tsx
+++ b/components/ui/modals/modal/modalHeaders/headerDescription.tsx
@@ -8,7 +8,8 @@ export const HeaderDescription = ({
   return (
     <Dialog.Description
       as='div'
-      className={className || 'text-base text-gray-600'}>
+      className={className || 'p-1 text-base text-gray-600'}
+    >
       <p>{children}</p>
     </Dialog.Description>
   );


### PR DESCRIPTION
Improve the performance of Next-Auth's SignIn call by prefetching the signIn page URL. This optimization may not be crucial in a development environment, but it is beneficial when serving cached landing pages.

Prefetching helps mitigate slow responses and redirection to the signIn page when users first interact with the application, as they might initially encounter a cached version without initiating a server start.

By prefetching the URL, the server is warmed up from a cold start, resulting in faster redirection and improved response handling.