### PR TITLE
test: add unit tests for Users module with updated structure

### DIFF
--- a/components/users/userSessionGroupEffect/__test__/userSessionGroupEffect.test.tsx
+++ b/components/users/userSessionGroupEffect/__test__/userSessionGroupEffect.test.tsx
@@ -1,0 +1,46 @@
+import { getSessionStorage, renderWithRecoilRoot } from '@stateLogics/utils';
+import { Session } from 'next-auth';
+import { SessionProvider } from 'next-auth/react';
+import { UserSessionGroupEffect } from '..';
+import 'fake-indexeddb/auto';
+import { DATA_IDB } from '@collections/idb';
+import { peekIDB } from '@lib/dataConnections/indexedDB';
+
+describe('UserSessionGroupEffect', () => {
+  const renderUserSessionEffect = (session: Session | null) => {
+    return renderWithRecoilRoot(
+      <SessionProvider session={session}>
+        <UserSessionGroupEffect />
+      </SessionProvider>,
+    );
+  };
+
+  const renderWithQueryElement = (session: Session | null) => {
+    const { container } = renderUserSessionEffect(session);
+    const offSession = getSessionStorage('offSession');
+    return { container, offSession };
+  };
+
+  it('should render the offSession true when UserSessionEffect component is mounted', () => {
+    const { container, offSession } = renderWithQueryElement(null);
+
+    expect(container).not.toBeNull();
+    expect(offSession).not.toBeNull();
+    expect(offSession).toBe(true);
+  });
+
+  it('should render no localStorage and indexedDB when UserSessionResetEffect component is mounted', async () => {
+    const { container } = renderWithQueryElement(null);
+
+    const allIdb = await Promise.all(
+      DATA_IDB.map((idb) => {
+        return peekIDB(idb.store);
+      }),
+    );
+    const allIdbUndefined = allIdb.every((item) => item === undefined);
+
+    expect(container).not.toBeNull();
+    expect(localStorage).toHaveLength(0);
+    expect(allIdbUndefined).toBe(true);
+  });
+});

--- a/components/users/userSessionGroupEffect/userSessionEffect/__test__/userSessionEffect.test.tsx
+++ b/components/users/userSessionGroupEffect/userSessionEffect/__test__/userSessionEffect.test.tsx
@@ -1,0 +1,86 @@
+import mockRouter from 'next-router-mock';
+import {
+  RecoilObserverValue,
+  getSessionStorage,
+  mockSession,
+  renderWithRecoilRoot,
+} from '@stateLogics/utils';
+import { screen } from '@testing-library/react';
+import { atomUserSession } from '@users/user/user.states';
+import { Session } from 'next-auth';
+import { SessionProvider } from 'next-auth/react';
+import { UserSessionEffect } from '..';
+
+jest.mock('next/router', () => require('next-router-mock'));
+
+describe('UserSessionEffect', () => {
+  const renderUserSessionEffect = (session: Session | null) => {
+    return renderWithRecoilRoot(
+      <SessionProvider session={session}>
+        <UserSessionEffect />
+        <RecoilObserverValue node={atomUserSession} />
+      </SessionProvider>,
+    );
+  };
+
+  const renderWithQueryElement = (session: Session | null) => {
+    const { container } = renderUserSessionEffect(session);
+    const active = screen.queryByText('active');
+    const inactive = screen.queryByText('inactive');
+    const offSession = getSessionStorage('offSession');
+
+    return { container, offSession, active, inactive };
+  };
+
+  beforeEach(() => {
+    mockRouter.push({
+      pathname: '/',
+    });
+  });
+
+  it('should offSession return true when pathname is not equal to /auth', async () => {
+    const { container, offSession } = renderWithQueryElement(null);
+
+    expect(container).not.toBeNull();
+    expect(mockRouter).toMatchObject({ pathname: '/' });
+    expect(offSession).toBe(true);
+  });
+
+  it('should offSession return null when pathname is equal to /auth', async () => {
+    mockRouter.push('/auth');
+    const { container, offSession } = renderWithQueryElement(null);
+
+    expect(container).not.toBeNull();
+    expect(mockRouter).toMatchObject({ pathname: '/auth' });
+    expect(offSession).toBeNull();
+  });
+
+  it('should offSession return null when user has a session', async () => {
+    const { container, offSession } = renderWithQueryElement(mockSession);
+
+    expect(container).not.toBeNull();
+    expect(offSession).toBeNull();
+  });
+
+  it('should document have an active string when user has a session', async () => {
+    const { container, active, inactive } = renderWithQueryElement(mockSession);
+    expect(active).toBeInTheDocument();
+    expect(inactive).not.toBeInTheDocument();
+    expect(container).not.toBeNull();
+  });
+
+  it('should offSession return true when user does not have a session', async () => {
+    const { container, offSession } = renderWithQueryElement(null);
+
+    expect(container).not.toBeNull();
+    expect(offSession).toBe(true);
+  });
+
+  it('should document have an inactive string when user does not have a session', async () => {
+    const { container, active, inactive } = renderWithQueryElement(null);
+
+    expect(active).not.toBeInTheDocument();
+    expect(inactive).toBeInTheDocument();
+    expect(container).not.toBeNull();
+  });
+});

--- a/components/users/userSessionGroupEffect/userSessionResetEffect/__test__/userSesionResetEffect.test.tsx
+++ b/components/users/userSessionGroupEffect/userSessionResetEffect/__test__/userSesionResetEffect.test.tsx
@@ -1,0 +1,73 @@
+import { DATA_IDB } from '@collections/idb';
+import { peekIDB } from '@lib/dataConnections/indexedDB';
+import { RecoilObserverValue, getSessionStorage, renderWithRecoilRoot } from '@stateLogics/utils';
+import { selectorSessionLabels } from '@states/atomEffects/labels';
+import { selectorSessionTodoIds } from '@states/atomEffects/todos';
+import { screen } from '@testing-library/react';
+import 'fake-indexeddb/auto';
+import { Session } from 'next-auth';
+import { SessionProvider } from 'next-auth/react';
+import { RecoilState } from 'recoil';
+import { UserSessionResetEffect } from '..';
+
+describe('userSessionResetEffect', () => {
+  const renderUserSessionEffect = <T,>(session: Session | null, node: RecoilState<T> | null) =>
+    renderWithRecoilRoot(
+      <SessionProvider session={session}>
+        <UserSessionResetEffect />
+        <RecoilObserverValue node={node} />
+      </SessionProvider>,
+    );
+
+  const renderWithQueryElement = <T,>(session: Session | null, node: RecoilState<T> | null) => {
+    const { container } = renderUserSessionEffect(session, node);
+    const offSession = getSessionStorage('offSession');
+    const active = screen.queryByText('active');
+    const inactive = screen.queryByText('inactive');
+    return { container, offSession, active, inactive };
+  };
+
+  it('should initial offSession is null', () => {
+    const { container, offSession } = renderWithQueryElement(null, null);
+
+    expect(container).not.toBeNull();
+    expect(offSession).toBeNull();
+  });
+
+  it('should return no localStorage when the user does not have a session', () => {
+    const { container } = renderWithQueryElement(null, null);
+
+    expect(container).not.toBeNull();
+    expect(localStorage).toHaveLength(0);
+  });
+
+  it('should return inactive of selectorSessionTodoIds when the user does not have a session', () => {
+    const { container, active, inactive } = renderWithQueryElement(null, selectorSessionTodoIds);
+
+    expect(container).not.toBeNull();
+    expect(active).not.toBeInTheDocument();
+    expect(inactive).toBeInTheDocument();
+  });
+
+  it('should return inactive of selectorSessionLabels when the user does not have a session', () => {
+    const { container, active, inactive } = renderWithQueryElement(null, selectorSessionLabels);
+
+    expect(container).not.toBeNull();
+    expect(active).not.toBeInTheDocument();
+    expect(inactive).toBeInTheDocument();
+  });
+
+  it('should return undefined on indexedDB when the user does not have a session', async () => {
+    const { container } = renderWithQueryElement(null, null);
+
+    const allIdb = await Promise.all(
+      DATA_IDB.map((idb) => {
+        return peekIDB(idb.store);
+      }),
+    );
+    const allIdbUndefined = allIdb.every((item) => item === undefined);
+
+    expect(container).not.toBeNull();
+    expect(allIdbUndefined).toBe(true);
+  });
+});

--- a/lib/stateLogics/hooks/misc.tsx
+++ b/lib/stateLogics/hooks/misc.tsx
@@ -7,8 +7,13 @@ import { atomTodoModalMini, atomTodoModalOpen } from '@states/modals';
 import { atomTodoNew, selectorFilterTodoIdsByPathname } from '@states/todos';
 import equal from 'fast-deep-equal/react';
 import { useRouter } from 'next/router';
-import { useEffect, useMemo } from 'react';
-import { RecoilState, RecoilValue, useRecoilCallback, useRecoilValue, useRecoilValueLoadable } from 'recoil';
+import { useMemo } from 'react';
+import {
+    RecoilValue,
+    useRecoilCallback,
+    useRecoilValue,
+    useRecoilValueLoadable
+} from 'recoil';
 
 export const useFilterTodoIdsWithPathname = () => {
   const router = useRouter();
@@ -76,19 +81,6 @@ export const useConditionCompareLabelItemsEqual = (_id: Labels['_id']) => {
   const labelItemCompare = useRecoilValue(atomSelectorLabelItem(_id));
   if (typeof _id == 'undefined') return;
   return equal(labelItem, labelItemCompare);
-};
-
-// recoil test observer: required to observe state change on unit test
-export const RecoilObserver = <T,>({
-  node,
-  onChange,
-}: {
-  node: RecoilState<T>;
-  onChange: (value: T) => void;
-}) => {
-  const value = useRecoilValue(node);
-  useEffect(() => onChange(value), [onChange, value]);
-  return null;
 };
 
 export const useNextQuery = ({ path, key }: { path?: string; key?: string }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-testing-library": "^5.10.3",
+        "fake-indexeddb": "^4.0.1",
         "husky": "^8.0.3",
         "jest-environment-jsdom": "^29.5.0",
         "lint-staged": "^13.2.1",
@@ -3735,6 +3736,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base64-arraybuffer-es6": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.7.0.tgz",
+      "integrity": "sha512-ESyU/U1CFZDJUdr+neHRhNozeCv72Y7Vm0m1DCbjX3KBjT6eYocvAJlSk6+8+HkVwXlT1FNxhGW6q3UKAlCvvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -5324,6 +5334,15 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-4.0.1.tgz",
+      "integrity": "sha512-hFRyPmvEZILYgdcLBxVdHLik4Tj3gDTu/g7s9ZDOiU3sTNiGx+vEu1ri/AMsFJUZ/1sdRbAVrEcKndh3sViBcA==",
+      "dev": true,
+      "dependencies": {
+        "realistic-structured-clone": "^3.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -9105,6 +9124,32 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/realistic-structured-clone": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/realistic-structured-clone/-/realistic-structured-clone-3.0.0.tgz",
+      "integrity": "sha512-rOjh4nuWkAqf9PWu6JVpOWD4ndI+JHfgiZeMmujYcPi+fvILUu7g6l26TC1K5aBIp34nV+jE1cDO75EKOfHC5Q==",
+      "dev": true,
+      "dependencies": {
+        "domexception": "^1.0.1",
+        "typeson": "^6.1.0",
+        "typeson-registry": "^1.0.0-alpha.20"
+      }
+    },
+    "node_modules/realistic-structured-clone/node_modules/domexception": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "dev": true,
+      "dependencies": {
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/realistic-structured-clone/node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
     "node_modules/recoil": {
       "version": "0.7.7",
       "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.7.tgz",
@@ -10358,6 +10403,64 @@
         "node": ">=12.20"
       }
     },
+    "node_modules/typeson": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/typeson/-/typeson-6.1.0.tgz",
+      "integrity": "sha512-6FTtyGr8ldU0pfbvW/eOZrEtEkczHRUtduBnA90Jh9kMPCiFNnXIon3vF41N0S4tV1HHQt4Hk1j4srpESziCaA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
+    "node_modules/typeson-registry": {
+      "version": "1.0.0-alpha.39",
+      "resolved": "https://registry.npmjs.org/typeson-registry/-/typeson-registry-1.0.0-alpha.39.tgz",
+      "integrity": "sha512-NeGDEquhw+yfwNhguLPcZ9Oj0fzbADiX4R0WxvoY8nGhy98IbzQy1sezjoEFWOywOboj/DWehI+/aUlRVrJnnw==",
+      "dev": true,
+      "dependencies": {
+        "base64-arraybuffer-es6": "^0.7.0",
+        "typeson": "^6.0.0",
+        "whatwg-url": "^8.4.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/typeson-registry/node_modules/tr46": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typeson-registry/node_modules/webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.4"
+      }
+    },
+    "node_modules/typeson-registry/node_modules/whatwg-url": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.7.0",
+        "tr46": "^2.1.0",
+        "webidl-conversions": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ua-parser-js": {
       "version": "1.0.33",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.33.tgz",
@@ -10770,9 +10873,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
-      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
       "dev": true,
       "engines": {
         "node": ">= 14"
@@ -13643,6 +13746,12 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "base64-arraybuffer-es6": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.7.0.tgz",
+      "integrity": "sha512-ESyU/U1CFZDJUdr+neHRhNozeCv72Y7Vm0m1DCbjX3KBjT6eYocvAJlSk6+8+HkVwXlT1FNxhGW6q3UKAlCvvw==",
+      "dev": true
+    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -14794,6 +14903,15 @@
         "jest-matcher-utils": "^29.5.0",
         "jest-message-util": "^29.5.0",
         "jest-util": "^29.5.0"
+      }
+    },
+    "fake-indexeddb": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-4.0.1.tgz",
+      "integrity": "sha512-hFRyPmvEZILYgdcLBxVdHLik4Tj3gDTu/g7s9ZDOiU3sTNiGx+vEu1ri/AMsFJUZ/1sdRbAVrEcKndh3sViBcA==",
+      "dev": true,
+      "requires": {
+        "realistic-structured-clone": "^3.0.0"
       }
     },
     "fast-deep-equal": {
@@ -17389,6 +17507,34 @@
         "picomatch": "^2.2.1"
       }
     },
+    "realistic-structured-clone": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/realistic-structured-clone/-/realistic-structured-clone-3.0.0.tgz",
+      "integrity": "sha512-rOjh4nuWkAqf9PWu6JVpOWD4ndI+JHfgiZeMmujYcPi+fvILUu7g6l26TC1K5aBIp34nV+jE1cDO75EKOfHC5Q==",
+      "dev": true,
+      "requires": {
+        "domexception": "^1.0.1",
+        "typeson": "^6.1.0",
+        "typeson-registry": "^1.0.0-alpha.20"
+      },
+      "dependencies": {
+        "domexception": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+          "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+          "dev": true,
+          "requires": {
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "dev": true
+        }
+      }
+    },
     "recoil": {
       "version": "0.7.7",
       "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.7.tgz",
@@ -18278,6 +18424,51 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
       "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw=="
     },
+    "typeson": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/typeson/-/typeson-6.1.0.tgz",
+      "integrity": "sha512-6FTtyGr8ldU0pfbvW/eOZrEtEkczHRUtduBnA90Jh9kMPCiFNnXIon3vF41N0S4tV1HHQt4Hk1j4srpESziCaA==",
+      "dev": true
+    },
+    "typeson-registry": {
+      "version": "1.0.0-alpha.39",
+      "resolved": "https://registry.npmjs.org/typeson-registry/-/typeson-registry-1.0.0-alpha.39.tgz",
+      "integrity": "sha512-NeGDEquhw+yfwNhguLPcZ9Oj0fzbADiX4R0WxvoY8nGhy98IbzQy1sezjoEFWOywOboj/DWehI+/aUlRVrJnnw==",
+      "dev": true,
+      "requires": {
+        "base64-arraybuffer-es6": "^0.7.0",
+        "typeson": "^6.0.0",
+        "whatwg-url": "^8.4.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+          "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+          "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+          "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.7.0",
+            "tr46": "^2.1.0",
+            "webidl-conversions": "^6.1.0"
+          }
+        }
+      }
+    },
     "ua-parser-js": {
       "version": "1.0.33",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.33.tgz",
@@ -18569,9 +18760,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
-      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-testing-library": "^5.10.3",
+    "fake-indexeddb": "^4.0.1",
     "husky": "^8.0.3",
     "jest-environment-jsdom": "^29.5.0",
     "lint-staged": "^13.2.1",


### PR DESCRIPTION
This commit introduces unit tests for the Users module, following the transition to a colocation-based project structure. Key changes include:

- Add fake-indexeddb package for testing indexedDB functionality.
- Update RecoilObserverValue to return 'active' or 'inactive' based on the Recoil value, with null or undefined returning 'inactive'.
- Introduce testingOnlyAtom to return undefined if node is null in RecoilObserverValue, useful for various testing scenarios where a node might not be required.
- Rename RecoilObserver to RecoilObserverOnChange for clarity.
- Implement minor code improvements discovered during testing.