### PR TITLE
feat: improve test utilities organization

### DIFF
--- a/components/notifications/__tests__/networkStatus.test.tsx
+++ b/components/notifications/__tests__/networkStatus.test.tsx
@@ -1,8 +1,8 @@
 import { screen } from '@testing-library/react';
 import { snapshot_UNSTABLE } from 'recoil';
 import { NetworkStatus } from '../networkStatus';
-import { renderWithRecoilRoot } from '@stateLogics/utils';
 import { atomEffectNetworkStatus } from '@states/atomEffects/misc';
+import { renderWithRecoilRoot } from '@stateLogics/utils/testUtils';
 
 describe('NetworkStatus', () => {
   beforeEach(() => renderWithRecoilRoot(<NetworkStatus />));

--- a/components/users/user/__test__/user.test.tsx
+++ b/components/users/user/__test__/user.test.tsx
@@ -1,9 +1,10 @@
-import { getSessionStorage, renderWithRecoilRoot, setSessionStorage } from '@stateLogics/utils';
+import { getSessionStorage, setSessionStorage } from '@stateLogics/utils';
 import { screen, waitFor } from '@testing-library/dom';
 import { mockedUserSession } from '__mock__/next-auth';
 import { Session } from 'next-auth';
 import { SessionProvider } from 'next-auth/react';
 import { User } from '..';
+import { renderWithRecoilRoot } from '@stateLogics/utils/testUtils';
 
 describe('User', () => {
   const renderWithSession = (session: Session | null) => {

--- a/components/users/user/userDropdown/__test__/userDropdown.test.tsx
+++ b/components/users/user/userDropdown/__test__/userDropdown.test.tsx
@@ -1,5 +1,5 @@
 import { PATH_IMAGE_APP } from '@constAssertions/data';
-import { nextImageLoader, renderWithRecoilRoot } from '@stateLogics/utils';
+import { nextImageLoader } from '@stateLogics/utils';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { mockedImageUrl } from '__mock__/next';
 import { mockedUserSession } from '__mock__/next-auth';
@@ -7,6 +7,7 @@ import { Session } from 'next-auth';
 import { SessionProvider } from 'next-auth/react';
 import 'whatwg-fetch';
 import { UserDropdown } from '..';
+import { renderWithRecoilRoot } from '@stateLogics/utils/testUtils';
 
 describe('UserDropdown', () => {
   const renderWithSession = (session: Session | null) => {

--- a/components/users/userSessionGroupEffect/__test__/userSessionGroupEffect.test.tsx
+++ b/components/users/userSessionGroupEffect/__test__/userSessionGroupEffect.test.tsx
@@ -1,10 +1,11 @@
-import { getSessionStorage, renderWithRecoilRoot } from '@stateLogics/utils';
+import { getSessionStorage } from '@stateLogics/utils';
 import { Session } from 'next-auth';
 import { SessionProvider } from 'next-auth/react';
 import { UserSessionGroupEffect } from '..';
 import 'fake-indexeddb/auto';
 import { DATA_IDB } from '@collections/idb';
 import { peekIDB } from '@lib/dataConnections/indexedDB';
+import { renderWithRecoilRoot } from '@stateLogics/utils/testUtils';
 
 describe('UserSessionGroupEffect', () => {
   const renderUserSessionEffect = (session: Session | null) => {

--- a/components/users/userSessionGroupEffect/userSessionEffect/__test__/userSessionEffect.test.tsx
+++ b/components/users/userSessionGroupEffect/userSessionEffect/__test__/userSessionEffect.test.tsx
@@ -1,11 +1,12 @@
-import mockRouter from 'next-router-mock';
-import { RecoilObserverValue, getSessionStorage, renderWithRecoilRoot } from '@stateLogics/utils';
+import { getSessionStorage } from '@stateLogics/utils';
 import { screen } from '@testing-library/react';
 import { atomUserSession } from '@users/user/user.states';
+import { mockedUserSession } from '__mock__/next-auth';
 import { Session } from 'next-auth';
 import { SessionProvider } from 'next-auth/react';
+import mockRouter from 'next-router-mock';
 import { UserSessionEffect } from '..';
-import { mockedUserSession } from '__mock__/next-auth';
+import { RecoilObserverValue, renderWithRecoilRoot } from '@stateLogics/utils/testUtils';
 
 jest.mock('next/router', () => require('next-router-mock'));
 

--- a/components/users/userSessionGroupEffect/userSessionResetEffect/__test__/userSesionResetEffect.test.tsx
+++ b/components/users/userSessionGroupEffect/userSessionResetEffect/__test__/userSesionResetEffect.test.tsx
@@ -1,6 +1,6 @@
 import { DATA_IDB } from '@collections/idb';
 import { peekIDB } from '@lib/dataConnections/indexedDB';
-import { RecoilObserverValue, getSessionStorage, renderWithRecoilRoot } from '@stateLogics/utils';
+import { getSessionStorage } from '@stateLogics/utils';
 import { selectorSessionLabels } from '@states/atomEffects/labels';
 import { selectorSessionTodoIds } from '@states/atomEffects/todos';
 import { screen } from '@testing-library/react';
@@ -9,6 +9,7 @@ import { Session } from 'next-auth';
 import { SessionProvider } from 'next-auth/react';
 import { RecoilState } from 'recoil';
 import { UserSessionResetEffect } from '..';
+import { RecoilObserverValue, renderWithRecoilRoot } from '@stateLogics/utils/testUtils';
 
 describe('userSessionResetEffect', () => {
   const renderUserSessionEffect = <T,>(session: Session | null, node: RecoilState<T> | null) =>

--- a/lib/stateLogics/utils/index.tsx
+++ b/lib/stateLogics/utils/index.tsx
@@ -1,7 +1,4 @@
 import { STORAGE_KEY } from '@constAssertions/storage';
-import { RenderOptions, render } from '@testing-library/react';
-import React, { FC, ReactElement, useEffect } from 'react';
-import { RecoilRoot, RecoilState, atom, useRecoilSnapshot, useRecoilValue } from 'recoil';
 import validator from 'validator';
 
 // Days
@@ -17,12 +14,6 @@ export const queries = (...queries: unknown[]) => queries.filter(Boolean).join('
 export const paths = (...paths: unknown[]) => paths.filter(Boolean).join('') || '';
 
 // test-utils for custom render
-const RecoilRootProvider: FC<{ children: React.ReactNode }> = ({ children }) => {
-  return <RecoilRoot>{children}</RecoilRoot>;
-};
-
-export const renderWithRecoilRoot = (ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) =>
-  render(ui, { wrapper: RecoilRootProvider, ...options });
 
 export const fetchWithRetry = async (url: string, options?: {}, retryCount = 3) => {
   const offSession = getSessionStorage(STORAGE_KEY['offSession']);
@@ -93,25 +84,4 @@ export const sanitizeObject = (obj: object) => {
     return [key, typeof value === 'string' ? sanitize(value as string) : value];
   });
   return Object.fromEntries(sanitizedEntries) as typeof obj;
-};
-
-export const RecoilObserverValue = <T,>({ node }: { node: RecoilState<T> | null }) => {
-  const testingOnlyAtom = atom({ key: 'atomForTestingPurposeOnly' });
-  const state = node ? node : testingOnlyAtom;
-  const value = useRecoilSnapshot().getLoadable(state).valueMaybe();
-
-  return <div>{!!value ? 'active' : 'inactive'}</div>;
-};
-
-// recoil test observer: required to observe state change on unit test
-export const RecoilObserverOnChange = <T,>({
-  node,
-  onChange,
-}: {
-  node: RecoilState<T>;
-  onChange: (value: T) => void;
-}) => {
-  const value = useRecoilValue(node);
-  useEffect(() => onChange(value), [onChange, value]);
-  return null;
 };

--- a/lib/stateLogics/utils/testUtils.tsx
+++ b/lib/stateLogics/utils/testUtils.tsx
@@ -1,0 +1,31 @@
+import { FC, ReactElement, useEffect } from 'react';
+import { RenderOptions, render } from '@testing-library/react';
+import { RecoilRoot, RecoilState, atom, useRecoilSnapshot, useRecoilValue } from 'recoil';
+
+const RecoilRootProvider: FC<{ children: React.ReactNode }> = ({ children }) => {
+  return <RecoilRoot>{children}</RecoilRoot>;
+};
+
+export const renderWithRecoilRoot = (ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) =>
+  render(ui, { wrapper: RecoilRootProvider, ...options });
+
+export const RecoilObserverValue = <T,>({ node }: { node: RecoilState<T> | null }) => {
+  const testingOnlyAtom = atom({ key: 'atomForTestingPurposeOnly' });
+  const state = node ? node : testingOnlyAtom;
+  const value = useRecoilSnapshot().getLoadable(state).valueMaybe();
+
+  return <div>{!!value ? 'active' : 'inactive'}</div>;
+};
+
+// recoil test observer: required to observe state change on unit test
+export const RecoilObserverOnChange = <T,>({
+  node,
+  onChange,
+}: {
+  node: RecoilState<T>;
+  onChange: (value: T) => void;
+}) => {
+  const value = useRecoilValue(node);
+  useEffect(() => onChange(value), [onChange, value]);
+  return null;
+};


### PR DESCRIPTION
Create a new `testUtils` folder to enhance the management of test-related utilities. Move `RecoilObserverValues`, `RecoilObserverOnChange`, and `renderWithRecoilRoot` into the `testUtils` folder for better organization and efficiency.