### PR TITLE
refactor: enhance custom render function with SessionProvider

### DIFF
--- a/components/notifications/__tests__/networkStatus.test.tsx
+++ b/components/notifications/__tests__/networkStatus.test.tsx
@@ -2,10 +2,10 @@ import { screen } from '@testing-library/react';
 import { snapshot_UNSTABLE } from 'recoil';
 import { NetworkStatus } from '../networkStatus';
 import { atomEffectNetworkStatus } from '@states/atomEffects/misc';
-import { renderWithRecoilRoot } from '@stateLogics/utils/testUtils';
+import { renderRecoilRootAndSession } from '@stateLogics/utils/testUtils';
 
 describe('NetworkStatus', () => {
-  beforeEach(() => renderWithRecoilRoot(<NetworkStatus />));
+  beforeEach(() => renderRecoilRootAndSession(<NetworkStatus />));
 
   it('should not render offline component when online', () => {
     const online = snapshot_UNSTABLE().getLoadable(atomEffectNetworkStatus).valueOrThrow();

--- a/components/users/user/__test__/user.test.tsx
+++ b/components/users/user/__test__/user.test.tsx
@@ -1,18 +1,13 @@
 import { getSessionStorage, setSessionStorage } from '@stateLogics/utils';
+import { renderRecoilRootAndSession } from '@stateLogics/utils/testUtils';
 import { screen, waitFor } from '@testing-library/dom';
 import { mockedUserSession } from '__mock__/next-auth';
 import { Session } from 'next-auth';
-import { SessionProvider } from 'next-auth/react';
 import { User } from '..';
-import { renderWithRecoilRoot } from '@stateLogics/utils/testUtils';
 
 describe('User', () => {
   const renderWithSession = (session: Session | null) => {
-    return renderWithRecoilRoot(
-      <SessionProvider session={session}>
-        <User />
-      </SessionProvider>,
-    );
+    return renderRecoilRootAndSession(<User />, { session: session });
   };
 
   const mockedSession = mockedUserSession({ userImage: null });

--- a/components/users/user/userDropdown/__test__/userDropdown.test.tsx
+++ b/components/users/user/userDropdown/__test__/userDropdown.test.tsx
@@ -4,18 +4,13 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { mockedImageUrl } from '__mock__/next';
 import { mockedUserSession } from '__mock__/next-auth';
 import { Session } from 'next-auth';
-import { SessionProvider } from 'next-auth/react';
 import 'whatwg-fetch';
 import { UserDropdown } from '..';
-import { renderWithRecoilRoot } from '@stateLogics/utils/testUtils';
+import { renderRecoilRootAndSession } from '@stateLogics/utils/testUtils';
 
 describe('UserDropdown', () => {
   const renderWithSession = (session: Session | null) => {
-    return renderWithRecoilRoot(
-      <SessionProvider session={session}>
-        <UserDropdown />
-      </SessionProvider>,
-    );
+    return renderRecoilRootAndSession(<UserDropdown />, { session: session });
   };
 
   const mockedSession = mockedUserSession({ userImage: true }) as Session;

--- a/components/users/userSessionGroupEffect/__test__/userSessionGroupEffect.test.tsx
+++ b/components/users/userSessionGroupEffect/__test__/userSessionGroupEffect.test.tsx
@@ -1,19 +1,14 @@
-import { getSessionStorage } from '@stateLogics/utils';
-import { Session } from 'next-auth';
-import { SessionProvider } from 'next-auth/react';
-import { UserSessionGroupEffect } from '..';
-import 'fake-indexeddb/auto';
 import { DATA_IDB } from '@collections/idb';
 import { peekIDB } from '@lib/dataConnections/indexedDB';
-import { renderWithRecoilRoot } from '@stateLogics/utils/testUtils';
+import { getSessionStorage } from '@stateLogics/utils';
+import { renderRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import 'fake-indexeddb/auto';
+import { Session } from 'next-auth';
+import { UserSessionGroupEffect } from '..';
 
 describe('UserSessionGroupEffect', () => {
   const renderUserSessionEffect = (session: Session | null) => {
-    return renderWithRecoilRoot(
-      <SessionProvider session={session}>
-        <UserSessionGroupEffect />
-      </SessionProvider>,
-    );
+    return renderRecoilRootAndSession(<UserSessionGroupEffect />, { session: session });
   };
 
   const renderWithQueryElement = (session: Session | null) => {

--- a/components/users/userSessionGroupEffect/userSessionEffect/__test__/userSessionEffect.test.tsx
+++ b/components/users/userSessionGroupEffect/userSessionEffect/__test__/userSessionEffect.test.tsx
@@ -1,22 +1,22 @@
 import { getSessionStorage } from '@stateLogics/utils';
+import { RecoilObserverValue, renderRecoilRootAndSession } from '@stateLogics/utils/testUtils';
 import { screen } from '@testing-library/react';
 import { atomUserSession } from '@users/user/user.states';
 import { mockedUserSession } from '__mock__/next-auth';
 import { Session } from 'next-auth';
-import { SessionProvider } from 'next-auth/react';
 import mockRouter from 'next-router-mock';
 import { UserSessionEffect } from '..';
-import { RecoilObserverValue, renderWithRecoilRoot } from '@stateLogics/utils/testUtils';
 
 jest.mock('next/router', () => require('next-router-mock'));
 
 describe('UserSessionEffect', () => {
   const renderUserSessionEffect = (session: Session | null) => {
-    return renderWithRecoilRoot(
-      <SessionProvider session={session}>
+    return renderRecoilRootAndSession(
+      <>
         <UserSessionEffect />
         <RecoilObserverValue node={atomUserSession} />
-      </SessionProvider>,
+      </>,
+      { session: session },
     );
   };
 

--- a/components/users/userSessionGroupEffect/userSessionResetEffect/__test__/userSesionResetEffect.test.tsx
+++ b/components/users/userSessionGroupEffect/userSessionResetEffect/__test__/userSesionResetEffect.test.tsx
@@ -1,23 +1,23 @@
 import { DATA_IDB } from '@collections/idb';
 import { peekIDB } from '@lib/dataConnections/indexedDB';
 import { getSessionStorage } from '@stateLogics/utils';
+import { RecoilObserverValue, renderRecoilRootAndSession } from '@stateLogics/utils/testUtils';
 import { selectorSessionLabels } from '@states/atomEffects/labels';
 import { selectorSessionTodoIds } from '@states/atomEffects/todos';
 import { screen } from '@testing-library/react';
 import 'fake-indexeddb/auto';
 import { Session } from 'next-auth';
-import { SessionProvider } from 'next-auth/react';
 import { RecoilState } from 'recoil';
 import { UserSessionResetEffect } from '..';
-import { RecoilObserverValue, renderWithRecoilRoot } from '@stateLogics/utils/testUtils';
 
 describe('userSessionResetEffect', () => {
   const renderUserSessionEffect = <T,>(session: Session | null, node: RecoilState<T> | null) =>
-    renderWithRecoilRoot(
-      <SessionProvider session={session}>
+    renderRecoilRootAndSession(
+      <>
         <UserSessionResetEffect />
         <RecoilObserverValue node={node} />
-      </SessionProvider>,
+      </>,
+      { session: session },
     );
 
   const renderWithQueryElement = <T,>(session: Session | null, node: RecoilState<T> | null) => {

--- a/lib/stateLogics/utils/testUtils.tsx
+++ b/lib/stateLogics/utils/testUtils.tsx
@@ -1,13 +1,30 @@
-import { FC, ReactElement, useEffect } from 'react';
 import { RenderOptions, render } from '@testing-library/react';
+import { Session } from 'next-auth';
+import { SessionProvider } from 'next-auth/react';
+import { ReactElement, ReactNode, useEffect } from 'react';
 import { RecoilRoot, RecoilState, atom, useRecoilSnapshot, useRecoilValue } from 'recoil';
 
-const RecoilRootProvider: FC<{ children: React.ReactNode }> = ({ children }) => {
-  return <RecoilRoot>{children}</RecoilRoot>;
+const RecoilRootProvider = ({ children, session }: { children: ReactNode; session: Session | null }) => {
+  return (
+    <RecoilRoot>
+      <SessionProvider session={session}>{children}</SessionProvider>
+    </RecoilRoot>
+  );
 };
 
-export const renderWithRecoilRoot = (ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) =>
-  render(ui, { wrapper: RecoilRootProvider, ...options });
+export const renderRecoilRootAndSession = (
+  ui: ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'> & { session: Session | null },
+) =>
+  render(ui, {
+    wrapper: (props) => (
+      <RecoilRootProvider
+        {...props}
+        session={options?.session ?? null}
+      />
+    ),
+    ...options,
+  });
 
 export const RecoilObserverValue = <T,>({ node }: { node: RecoilState<T> | null }) => {
   const testingOnlyAtom = atom({ key: 'atomForTestingPurposeOnly' });


### PR DESCRIPTION
Rename the `renderWithRecoilRoot` function to `renderRecoilRootAndSession`. The updated custom render function now includes both a `RecoilRoot` from Recoil and a `SessionProvider` from Next-auth, allowing it to accept an optional `session` parameter. This parameter can take either a `mockedSession` value or `null`, providing flexibility for testing in different environments.