### PR TITLE
refactor: rename renderRecoilAndSession function

### DIFF
--- a/components/notifications/__tests__/networkStatus.test.tsx
+++ b/components/notifications/__tests__/networkStatus.test.tsx
@@ -2,10 +2,10 @@ import { screen } from '@testing-library/react';
 import { snapshot_UNSTABLE } from 'recoil';
 import { NetworkStatus } from '../networkStatus';
 import { atomEffectNetworkStatus } from '@states/atomEffects/misc';
-import { renderRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
 
 describe('NetworkStatus', () => {
-  beforeEach(() => renderRecoilRootAndSession(<NetworkStatus />));
+  beforeEach(() => renderWithRecoilRootAndSession(<NetworkStatus />));
 
   it('should not render offline component when online', () => {
     const online = snapshot_UNSTABLE().getLoadable(atomEffectNetworkStatus).valueOrThrow();

--- a/components/user/__test__/user.test.tsx
+++ b/components/user/__test__/user.test.tsx
@@ -1,13 +1,13 @@
 import { getSessionStorage, setSessionStorage } from '@stateLogics/utils';
-import { renderRecoilRootAndSession } from '@stateLogics/utils/testUtils';
 import { screen, waitFor } from '@testing-library/dom';
 import { mockedUserSession } from '__mock__/next-auth';
 import { Session } from 'next-auth';
 import { User } from '..';
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
 
 describe('User', () => {
   const renderWithSession = (session: Session | null) => {
-    return renderRecoilRootAndSession(<User />, { session: session });
+    return renderWithRecoilRootAndSession(<User />, { session: session });
   };
 
   const mockedSession = mockedUserSession({ userImage: null });

--- a/components/user/userDropdown/__test__/userDropdown.test.tsx
+++ b/components/user/userDropdown/__test__/userDropdown.test.tsx
@@ -6,11 +6,11 @@ import { mockedUserSession } from '__mock__/next-auth';
 import { Session } from 'next-auth';
 import 'whatwg-fetch';
 import { UserDropdown } from '..';
-import { renderRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
 
 describe('UserDropdown', () => {
   const renderWithSession = (session: Session | null) => {
-    return renderRecoilRootAndSession(<UserDropdown />, { session: session });
+    return renderWithRecoilRootAndSession(<UserDropdown />, { session: session });
   };
 
   const mockedSession = mockedUserSession({ userImage: true }) as Session;

--- a/components/user/userSessionGroupEffect/__test__/userSessionGroupEffect.test.tsx
+++ b/components/user/userSessionGroupEffect/__test__/userSessionGroupEffect.test.tsx
@@ -1,14 +1,14 @@
 import { DATA_IDB } from '@collections/idb';
 import { peekIDB } from '@lib/dataConnections/indexedDB';
 import { getSessionStorage } from '@stateLogics/utils';
-import { renderRecoilRootAndSession } from '@stateLogics/utils/testUtils';
 import 'fake-indexeddb/auto';
 import { Session } from 'next-auth';
 import { UserSessionGroupEffect } from '..';
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
 
 describe('UserSessionGroupEffect', () => {
   const renderUserSessionEffect = (session: Session | null) => {
-    return renderRecoilRootAndSession(<UserSessionGroupEffect />, { session: session });
+    return renderWithRecoilRootAndSession(<UserSessionGroupEffect />, { session: session });
   };
 
   const renderWithQueryElement = (session: Session | null) => {

--- a/components/user/userSessionGroupEffect/userSessionEffect/__test__/userSessionEffect.test.tsx
+++ b/components/user/userSessionGroupEffect/userSessionEffect/__test__/userSessionEffect.test.tsx
@@ -1,5 +1,5 @@
 import { getSessionStorage } from '@stateLogics/utils';
-import { RecoilObserverValue, renderRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { RecoilObserverValue, renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
 import { screen } from '@testing-library/react';
 import { mockedUserSession } from '__mock__/next-auth';
 import { Session } from 'next-auth';
@@ -11,7 +11,7 @@ jest.mock('next/router', () => require('next-router-mock'));
 
 describe('UserSessionEffect', () => {
   const renderUserSessionEffect = (session: Session | null) => {
-    return renderRecoilRootAndSession(
+    return renderWithRecoilRootAndSession(
       <>
         <UserSessionEffect />
         <RecoilObserverValue node={atomUserSession} />

--- a/components/user/userSessionGroupEffect/userSessionResetEffect/__test__/userSesionResetEffect.test.tsx
+++ b/components/user/userSessionGroupEffect/userSessionResetEffect/__test__/userSesionResetEffect.test.tsx
@@ -1,7 +1,7 @@
 import { DATA_IDB } from '@collections/idb';
 import { peekIDB } from '@lib/dataConnections/indexedDB';
 import { getSessionStorage } from '@stateLogics/utils';
-import { RecoilObserverValue, renderRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { RecoilObserverValue, renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
 import { selectorSessionLabels } from '@states/atomEffects/labels';
 import { selectorSessionTodoIds } from '@states/atomEffects/todos';
 import { screen } from '@testing-library/react';
@@ -12,7 +12,7 @@ import { UserSessionResetEffect } from '..';
 
 describe('userSessionResetEffect', () => {
   const renderUserSessionEffect = <T,>(session: Session | null, node: RecoilState<T> | null) =>
-    renderRecoilRootAndSession(
+    renderWithRecoilRootAndSession(
       <>
         <UserSessionResetEffect />
         <RecoilObserverValue node={node} />

--- a/lib/stateLogics/utils/testUtils.tsx
+++ b/lib/stateLogics/utils/testUtils.tsx
@@ -12,7 +12,7 @@ const RecoilRootProvider = ({ children, session }: { children: ReactNode; sessio
   );
 };
 
-export const renderRecoilRootAndSession = (
+export const renderWithRecoilRootAndSession = (
   ui: ReactElement,
   options?: Omit<RenderOptions, 'wrapper'> & { session: Session | null },
 ) =>


### PR DESCRIPTION
Update the function name from renderRecoilAndSession to renderWithRecoilAndSession to achieve better naming consistency and clarity in its purpose.