### PR TITLE
test: implement unit tests for AuthConfirmation component

### DIFF
--- a/components/auth/auth.states.ts
+++ b/components/auth/auth.states.ts
@@ -3,7 +3,7 @@ import { atom } from 'recoil';
 
 export const atomAuthUser = atom<Users>({
   key: 'atomAuthUser',
-  default: { email: '', password: '' } as Users,
+  default: { email: '' } as Users,
 });
 
 export const atomAuthErrorMessage = atom<string>({

--- a/components/auth/authConfirmation/__test__/authConfirmation.test.tsx
+++ b/components/auth/authConfirmation/__test__/authConfirmation.test.tsx
@@ -1,0 +1,88 @@
+import { atomAuthUser } from '@auth/auth.states';
+import {
+  RecoilObserverSetValue,
+  RecoilObserverValue,
+  renderWithRecoilRootAndSession,
+} from '@stateLogics/utils/testUtils';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { Session } from 'next-auth';
+import { RecoilState } from 'recoil';
+import { AuthConfirmation } from '..';
+import { SPINNER } from '@constAssertions/ui';
+import { atomLoadingSpinner } from '@states/misc';
+
+type Props<T> = { session: Session | null; node?: RecoilState<T>; state?: T };
+
+describe('AuthConfirmation', () => {
+  const renderAuthConfirmation = <T,>({ session, node, state }: Props<T>) =>
+    renderWithRecoilRootAndSession(
+      <>
+        <AuthConfirmation />
+        {state && (
+          <RecoilObserverSetValue
+            node={node}
+            state={state}
+          />
+        )}
+        <RecoilObserverValue node={node} />
+      </>,
+      { session: session },
+    );
+
+  it('should render component correctly', () => {
+    const { container } = renderAuthConfirmation({ session: null });
+    const header = screen.getByText('Please check your email');
+    const subHeader = screen.getByText(/Your sign-in link has been sent/i);
+    const confirmationMessage = screen.getByText(/Please check your email to complete the sign-in process./i);
+    const moreMessage = screen.getByText(/If you can't find the email, be sure to check your spam folder./i);
+    const buttonName = screen.getByText(/Back to homepage/i);
+
+    expect(container).toBeInTheDocument();
+    expect(header).toBeInTheDocument();
+    expect(subHeader).toBeInTheDocument();
+    expect(confirmationMessage).toBeInTheDocument();
+    expect(moreMessage).toBeInTheDocument();
+    expect(buttonName).toBeInTheDocument();
+  });
+
+  it('should render active when user email is displayed', () => {
+    const userEmail = 'user@example.com';
+    const { container } = renderAuthConfirmation({
+      session: null,
+      node: atomAuthUser,
+      state: { email: userEmail },
+    });
+
+    const email = screen.queryByText(/user@example.com/);
+
+    expect(container).toBeInTheDocument();
+    expect(email).toBeInTheDocument();
+  });
+
+  it('should render spinner onClick the Back to homepage button', async () => {
+    const { container } = renderAuthConfirmation({
+      session: null,
+      node: atomLoadingSpinner(SPINNER['verificationConfirm']),
+    });
+
+    const backToHomepageButton = screen.getByRole('button', { name: /Back to homepage/i });
+    const spinnerOn = screen.queryByText('active');
+    const spinnerOff = screen.queryByText('inactive');
+
+    expect(container).toBeInTheDocument();
+    expect(backToHomepageButton).toBeInTheDocument();
+    expect(spinnerOn).toBeNull();
+    expect(spinnerOff).toBeInTheDocument();
+
+    fireEvent.click(backToHomepageButton);
+
+    await waitFor(() => {
+      const spinnerOn = screen.queryByText('active');
+      expect(spinnerOn).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      const spinnerOff = screen.queryByText('inactive');
+      expect(spinnerOff).toBeNull();
+    });
+  });
+});

--- a/components/user/userSessionGroupEffect/userSessionResetEffect/__test__/userSesionResetEffect.test.tsx
+++ b/components/user/userSessionGroupEffect/userSessionResetEffect/__test__/userSesionResetEffect.test.tsx
@@ -11,7 +11,7 @@ import { RecoilState } from 'recoil';
 import { UserSessionResetEffect } from '..';
 
 describe('userSessionResetEffect', () => {
-  const renderUserSessionEffect = <T,>(session: Session | null, node: RecoilState<T> | null) =>
+  const renderUserSessionEffect = <T,>(session: Session | null, node?: RecoilState<T>) =>
     renderWithRecoilRootAndSession(
       <>
         <UserSessionResetEffect />
@@ -20,7 +20,7 @@ describe('userSessionResetEffect', () => {
       { session: session },
     );
 
-  const renderWithQueryElement = <T,>(session: Session | null, node: RecoilState<T> | null) => {
+  const renderWithQueryElement = <T,>(session: Session | null, node?: RecoilState<T>) => {
     const { container } = renderUserSessionEffect(session, node);
     const offSession = getSessionStorage('offSession');
     const active = screen.queryByText('active');
@@ -29,14 +29,14 @@ describe('userSessionResetEffect', () => {
   };
 
   it('should initial offSession is null', () => {
-    const { container, offSession } = renderWithQueryElement(null, null);
+    const { container, offSession } = renderWithQueryElement(null);
 
     expect(container).not.toBeNull();
     expect(offSession).toBeNull();
   });
 
   it('should return no localStorage when the user does not have a session', () => {
-    const { container } = renderWithQueryElement(null, null);
+    const { container } = renderWithQueryElement(null);
 
     expect(container).not.toBeNull();
     expect(localStorage).toHaveLength(0);
@@ -59,7 +59,7 @@ describe('userSessionResetEffect', () => {
   });
 
   it('should return undefined on indexedDB when the user does not have a session', async () => {
-    const { container } = renderWithQueryElement(null, null);
+    const { container } = renderWithQueryElement(null);
 
     const allIdb = await Promise.all(
       DATA_IDB.map((idb) => {

--- a/lib/stateLogics/utils/testUtils.tsx
+++ b/lib/stateLogics/utils/testUtils.tsx
@@ -2,7 +2,7 @@ import { RenderOptions, render } from '@testing-library/react';
 import { Session } from 'next-auth';
 import { SessionProvider } from 'next-auth/react';
 import { ReactElement, ReactNode, useEffect } from 'react';
-import { RecoilRoot, RecoilState, atom, useRecoilSnapshot, useRecoilValue } from 'recoil';
+import { RecoilRoot, RecoilState, atom, useRecoilSnapshot, useRecoilValue, useSetRecoilState } from 'recoil';
 
 const RecoilRootProvider = ({ children, session }: { children: ReactNode; session: Session | null }) => {
   return (
@@ -26,12 +26,24 @@ export const renderWithRecoilRootAndSession = (
     ...options,
   });
 
-export const RecoilObserverValue = <T,>({ node }: { node: RecoilState<T> | null }) => {
-  const testingOnlyAtom = atom({ key: 'atomForTestingPurposeOnly' });
-  const state = node ? node : testingOnlyAtom;
+export const RecoilObserverValue = <T,>({ node }: { node?: RecoilState<T> }) => {
+  const testAtom = atom<T>({ key: 'atomRecoilObserverValue' });
+  const state = node ? node : testAtom;
   const value = useRecoilSnapshot().getLoadable(state).valueMaybe();
 
   return <div>{!!value ? 'active' : 'inactive'}</div>;
+};
+
+export const RecoilObserverSetValue = <T,>({ node, state }: { node?: RecoilState<T>; state?: T }) => {
+  const testAtom = atom<T>({ key: 'atomRecoilObserverSetValue' });
+  const dynamicNode = node ? node : testAtom;
+  const setValue = useSetRecoilState(dynamicNode);
+
+  useEffect(() => {
+    state && setValue(state);
+  }, [setValue, state]);
+
+  return null;
 };
 
 // recoil test observer: required to observe state change on unit test


### PR DESCRIPTION
Add unit tests to verify the functionality and reliability of the AuthConfirmation component. Enhance testingUtils by incorporating RecoilObserverSetValue, which allows for mocking specific conditions and manual state manipulation to create a tailored testing environment.