### PR TITLE
refactor: enhance renderWithRecoilAndSession function

### DIFF
--- a/components/auth/authConfirmation/__test__/authConfirmation.test.tsx
+++ b/components/auth/authConfirmation/__test__/authConfirmation.test.tsx
@@ -1,33 +1,19 @@
 import { atomAuthUser } from '@auth/auth.states';
-import {
-  RecoilObserverSetValue,
-  RecoilObserverValue,
-  renderWithRecoilRootAndSession,
-} from '@stateLogics/utils/testUtils';
+import { SPINNER } from '@constAssertions/ui';
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { atomLoadingSpinner } from '@states/misc';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { Session } from 'next-auth';
 import { RecoilState } from 'recoil';
 import { AuthConfirmation } from '..';
-import { SPINNER } from '@constAssertions/ui';
-import { atomLoadingSpinner } from '@states/misc';
 
 type Props<T> = { session: Session | null; node?: RecoilState<T>; state?: T };
 
 describe('AuthConfirmation', () => {
-  const renderAuthConfirmation = <T,>({ session, node, state }: Props<T>) =>
-    renderWithRecoilRootAndSession(
-      <>
-        <AuthConfirmation />
-        {state && (
-          <RecoilObserverSetValue
-            node={node}
-            state={state}
-          />
-        )}
-        <RecoilObserverValue node={node} />
-      </>,
-      { session: session },
-    );
+  const renderAuthConfirmation = <T,>({ session, node, state }: Props<T>) => {
+    const options = { session: session, node: node, state: state };
+    return renderWithRecoilRootAndSession(<AuthConfirmation />, options);
+  };
 
   it('should render component correctly', () => {
     const { container } = renderAuthConfirmation({ session: null });

--- a/components/auth/authEffect/authErrorMessageEffect.tsx
+++ b/components/auth/authEffect/authErrorMessageEffect.tsx
@@ -3,7 +3,7 @@ import { validateEmailFormat } from '@stateLogics/utils';
 import { useEffect } from 'react';
 import { useRecoilValue, useRecoilCallback } from 'recoil';
 
-export const UserAuthGroupEffect = () => {
+export const AuthErrorMessageEffect = () => {
   const user = useRecoilValue(atomAuthUser);
   const isEmailInValidated = !validateEmailFormat(user.email);
 

--- a/components/auth/authForm/index.tsx
+++ b/components/auth/authForm/index.tsx
@@ -17,8 +17,8 @@ import { AuthErrorMessage } from '@auth/authErrorMessage';
 import { atomAuthErrorMessage, atomAuthUser } from '@auth/auth.states';
 import { useAuthFormSubmit, useAuthUserValueUpdate } from '@auth/auth.hooks';
 
-const UserAuthGroupEffect = dynamic(() =>
-  import('@auth/authEffect/authErrorMessageEffect').then((mod) => mod.UserAuthGroupEffect),
+const AuthErrorMessageEffect = dynamic(() =>
+  import('@auth/authEffect/authErrorMessageEffect').then((mod) => mod.AuthErrorMessageEffect),
 );
 
 export const AuthForm = () => {
@@ -73,7 +73,7 @@ export const AuthForm = () => {
           </form>
         </section>
       </div>
-      <UserAuthGroupEffect />
+      <AuthErrorMessageEffect />
     </Fragment>
   );
 };

--- a/components/user/userSessionGroupEffect/userSessionEffect/__test__/userSessionEffect.test.tsx
+++ b/components/user/userSessionGroupEffect/userSessionEffect/__test__/userSessionEffect.test.tsx
@@ -1,5 +1,5 @@
 import { getSessionStorage } from '@stateLogics/utils';
-import { RecoilObserverValue, renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
 import { screen } from '@testing-library/react';
 import { mockedUserSession } from '__mock__/next-auth';
 import { Session } from 'next-auth';
@@ -11,13 +11,8 @@ jest.mock('next/router', () => require('next-router-mock'));
 
 describe('UserSessionEffect', () => {
   const renderUserSessionEffect = (session: Session | null) => {
-    return renderWithRecoilRootAndSession(
-      <>
-        <UserSessionEffect />
-        <RecoilObserverValue node={atomUserSession} />
-      </>,
-      { session: session },
-    );
+    const options = { session: session, node: atomUserSession };
+    return renderWithRecoilRootAndSession(<UserSessionEffect />, options);
   };
 
   const mockedSession = mockedUserSession({ userImage: true });

--- a/components/user/userSessionGroupEffect/userSessionResetEffect/__test__/userSesionResetEffect.test.tsx
+++ b/components/user/userSessionGroupEffect/userSessionResetEffect/__test__/userSesionResetEffect.test.tsx
@@ -1,7 +1,7 @@
 import { DATA_IDB } from '@collections/idb';
 import { peekIDB } from '@lib/dataConnections/indexedDB';
 import { getSessionStorage } from '@stateLogics/utils';
-import { RecoilObserverValue, renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
 import { selectorSessionLabels } from '@states/atomEffects/labels';
 import { selectorSessionTodoIds } from '@states/atomEffects/todos';
 import { screen } from '@testing-library/react';
@@ -11,14 +11,10 @@ import { RecoilState } from 'recoil';
 import { UserSessionResetEffect } from '..';
 
 describe('userSessionResetEffect', () => {
-  const renderUserSessionEffect = <T,>(session: Session | null, node?: RecoilState<T>) =>
-    renderWithRecoilRootAndSession(
-      <>
-        <UserSessionResetEffect />
-        <RecoilObserverValue node={node} />
-      </>,
-      { session: session },
-    );
+  const renderUserSessionEffect = <T,>(session: Session | null, node?: RecoilState<T>) => {
+    const options = { session: session, node: node };
+    return renderWithRecoilRootAndSession(<UserSessionResetEffect />, options);
+  };
 
   const renderWithQueryElement = <T,>(session: Session | null, node?: RecoilState<T>) => {
     const { container } = renderUserSessionEffect(session, node);


### PR DESCRIPTION
- Remove RecoilObserverOnChange component for simplicity
- Merge RecoilObserverValue and RecoilObserverSetValue into a single RecoilObserver component for better usability
- Integrate RecoilObserver directly into renderWithRecoilRootAndSession to allow seamless usage through options parameter when needed