### PR TITLE
test: enhance AuthErrorMessage component test coverage

### DIFF
--- a/components/auth/auth.types.ts
+++ b/components/auth/auth.types.ts
@@ -2,3 +2,14 @@ export interface TypesNextAuthError {
   _id: string;
   message: string;
 }
+
+export interface TypesAuthErrorMessage {
+  isError: boolean;
+  isSignIn: boolean;
+  defaultMessage: string;
+  errorMessage: string;
+}
+
+export type TypesPropsErrorMessage = {
+  options?: Partial<TypesAuthErrorMessage>;
+};

--- a/components/auth/authEffect/__test__/authErrorMessageEffect.test.tsx
+++ b/components/auth/authEffect/__test__/authErrorMessageEffect.test.tsx
@@ -31,7 +31,7 @@ describe('AuthErrorMessageEffect', () => {
 
   const renderWithQueryElement = <T,>({ node, state }: Props<T>) => {
     const { container } = renderAuthConfirmation({ node: node, state: state });
-    const defaultErrorMessage = screen.queryByText(/Something went wrong/!);
+    const defaultErrorMessage = screen.queryByText(/Something went wrong/i);
 
     return { container, defaultErrorMessage };
   };

--- a/components/auth/authErrorMessage/__test__/authErrorMessage.test.tsx
+++ b/components/auth/authErrorMessage/__test__/authErrorMessage.test.tsx
@@ -1,0 +1,74 @@
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { screen, waitFor } from '@testing-library/react';
+import { RecoilState } from 'recoil';
+import { AuthErrorMessage } from '..';
+import { TypesAuthErrorMessage } from '@auth/auth.types';
+import { atomAuthErrorMessage } from '@auth/auth.states';
+import mockRouter from 'next-router-mock';
+
+type Props<T> = {
+  node?: RecoilState<T>;
+  state?: T;
+  defaultMessage?: TypesAuthErrorMessage['defaultMessage'];
+};
+
+describe('AuthErrorMessage', () => {
+  const renderAuthErrorMessage = <T,>({ node, state, defaultMessage }: Props<T>) => {
+    const options = { session: null, node: node, state: state };
+    return renderWithRecoilRootAndSession(
+      <AuthErrorMessage options={{ defaultMessage: defaultMessage }} />,
+      options,
+    );
+  };
+
+  const renderWithQueryElement = <T,>({ node, state, defaultMessage }: Props<T>) => {
+    const { container } = renderAuthErrorMessage({
+      node: node,
+      state: state,
+      defaultMessage: defaultMessage,
+    });
+    const message = defaultMessage && defaultMessage;
+    const defaultMessageOutput = screen.queryByText(`${message}`);
+
+    return { container, defaultMessageOutput };
+  };
+
+  it('should render defaultMessage if exists', () => {
+    const { container, defaultMessageOutput } = renderWithQueryElement({
+      defaultMessage: 'This is the default message',
+    });
+
+    expect(container).toBeInTheDocument();
+    expect(defaultMessageOutput).toBeInTheDocument();
+  });
+
+  it('should render clientErrorMessage if exists', () => {
+    const customClientErrorMessage = 'something went wrong';
+    const { container } = renderWithQueryElement({
+      node: atomAuthErrorMessage,
+      state: customClientErrorMessage,
+    });
+    const clientErrorMessage = screen.queryByText(/Something went wrong/i);
+
+    expect(container).toBeInTheDocument();
+    expect(clientErrorMessage).toBeInTheDocument();
+  });
+
+  it('should render serverErrorMessage if exists', async () => {
+    const { container } = renderWithQueryElement({
+      node: atomAuthErrorMessage,
+    });
+
+    expect(container).toBeInTheDocument();
+
+    await waitFor(() => {
+      const urlString = '/test-url?error=default';
+      mockRouter.push(urlString);
+      expect(mockRouter).toMatchObject({ asPath: urlString });
+    });
+    await waitFor(() => {
+      const serverErrorMessage = screen.queryByText(/Unable to sign in./i);
+      expect(serverErrorMessage).toBeInTheDocument();
+    });
+  });
+});

--- a/components/auth/authErrorMessage/index.tsx
+++ b/components/auth/authErrorMessage/index.tsx
@@ -1,19 +1,21 @@
 import { DATA_NEXTAUTH_ERROR } from '@auth/auth.data';
 import { atomAuthErrorMessage } from '@auth/auth.states';
+import { TypesPropsErrorMessage } from '@auth/auth.types';
 import { SvgIcon } from '@components/icons/svgIcon';
 import { ICON_ERROR_FILL } from '@data/materialSymbols';
 import { useNextQuery } from '@hooks/misc';
-import { TypesOptionsAuthErrorMessage } from '@lib/types/options';
 import { classNames } from '@stateLogics/utils';
 import { useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 
-type Props = { options?: TypesOptionsAuthErrorMessage };
-
-export const AuthErrorMessage = ({ options }: Props) => {
+export const AuthErrorMessage = ({ options }: TypesPropsErrorMessage) => {
   const errorId = useNextQuery({ key: 'error' })?.toLowerCase();
   const serverError = DATA_NEXTAUTH_ERROR.find((error) => error._id === errorId);
   const [clientErrorMessage, setClientErrorMessage] = useRecoilState(atomAuthErrorMessage);
+  const svgOptions = {
+    path: clientErrorMessage ? ICON_ERROR_FILL : '',
+    className: classNames('w-[1.2rem] h-[1.2rem] mr-1', clientErrorMessage && 'fill-red-600'),
+  };
 
   useEffect(() => {
     const errorMessage = serverError ? serverError.message : '';
@@ -28,12 +30,7 @@ export const AuthErrorMessage = ({ options }: Props) => {
       )}
     >
       <span className='h-full pr-1'>
-        <SvgIcon
-          options={{
-            path: clientErrorMessage ? ICON_ERROR_FILL : '',
-            className: classNames('w-[1.2rem] h-[1.2rem] mr-1', clientErrorMessage && 'fill-red-600'),
-          }}
-        />
+        <SvgIcon options={svgOptions} />
       </span>
       <span className={classNames('text-sm', clientErrorMessage && 'text-red-600')}>
         {clientErrorMessage ? clientErrorMessage : options?.defaultMessage}

--- a/lib/types/bases/ui.ts
+++ b/lib/types/bases/ui.ts
@@ -139,9 +139,6 @@ export interface TypesInputAttributes {
   isPasswordShown: boolean;
   inputValue: string | number | readonly string[];
   isError: boolean;
-  isSignIn: boolean;
-  defaultMessage: string;
-  errorMessage: string;
 }
 
 export interface TypesModals {

--- a/lib/types/options/index.ts
+++ b/lib/types/options/index.ts
@@ -23,15 +23,7 @@ export type TypesOptionsButton = Partial<
     type: Extract<TypesElement['type'], 'button' | 'submit' | 'reset'>;
   } & Pick<
       TypesStyleAttributes,
-      | 'padding'
-      | 'margin'
-      | 'display'
-      | 'width'
-      | 'size'
-      | 'color'
-      | 'container'
-      | 'hoverBg'
-      | 'borderRadius'
+      'padding' | 'margin' | 'display' | 'width' | 'size' | 'color' | 'container' | 'hoverBg' | 'borderRadius'
     >
 >;
 
@@ -47,22 +39,13 @@ export type TypesOptionsPriority = Partial<
   Pick<Types, 'isInitiallyVisible' | 'priorityImportant' | 'priorityNormal' | 'priorityUrgent'> &
     Pick<
       TypesStyleAttributes,
-      | 'margin'
-      | 'display'
-      | 'width'
-      | 'container'
-      | 'padding'
-      | 'size'
-      | 'color'
-      | 'borderRadius'
-      | 'hoverBg'
+      'margin' | 'display' | 'width' | 'container' | 'padding' | 'size' | 'color' | 'borderRadius' | 'hoverBg'
     >
 > &
   Pick<Types, 'priorityLevel'>;
 
 export type TypesOptionsBackdrop = Partial<
-  Pick<Types, 'isPortal' | 'enterDuration' | 'leaveDuration'> &
-    Pick<TypesStyleAttributes, 'color' | 'zIndex'>
+  Pick<Types, 'isPortal' | 'enterDuration' | 'leaveDuration'> & Pick<TypesStyleAttributes, 'color' | 'zIndex'>
 >;
 
 export type TypesOptionsDropdown = Partial<
@@ -119,10 +102,6 @@ export type TypesOptionsFloatingLabelInput = Partial<
     | 'isPasswordShown'
     | 'name'
   >
->;
-
-export type TypesOptionsAuthErrorMessage = Partial<
-  Pick<Types, 'isError' | 'isSignIn' | 'defaultMessage' | 'errorMessage'>
 >;
 
 export type TypesOptionsPrefetchRouterButton = Pick<Types, 'path'> &


### PR DESCRIPTION
Expand testing coverage for the AuthErrorMessage component, which is responsible for displaying both server-side and client-side error messages. The added tests primarily focus on verifying the accurate rendering of error messages based on different query parameters and error conditions.