### PR TITLE
test: enhance testing for EditorComposer and TodoEditor

### DIFF
--- a/components/editor/editorComposer/__test__/editorComposer.test.tsx
+++ b/components/editor/editorComposer/__test__/editorComposer.test.tsx
@@ -1,10 +1,17 @@
 import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { EditorComposer } from '.';
+import { RecoilState } from 'recoil';
+import { EditorComposer } from '..';
+import { CATCH } from '@constAssertions/misc';
+import { atomCatch } from '@states/misc';
+import mockRouter from 'next-router-mock';
+import { PATH_APP } from '@constAssertions/data';
+
+type Props<T> = { node?: RecoilState<T>; state?: T; isAutoFocus?: boolean };
 
 describe('EditorComposer', () => {
-  const renderWithEditorComposer = (isAutoFocus?: boolean) => {
-    const options = { session: null };
+  const renderWithEditorComposer = <T,>({ node, state, isAutoFocus }: Props<T>) => {
+    const options = { session: null, node: node, state: state };
     return renderWithRecoilRootAndSession(
       <EditorComposer
         titleName='title'
@@ -16,8 +23,8 @@ describe('EditorComposer', () => {
     );
   };
 
-  const renderWithQueryElement = async (isAutoFocus?: boolean) => {
-    const { container } = renderWithEditorComposer(isAutoFocus);
+  const renderWithQueryElement = async <T,>({ node, state, isAutoFocus }: Props<T>) => {
+    const { container } = renderWithEditorComposer({ node: node, state: state, isAutoFocus: isAutoFocus });
     const updatedTodo = 'Updated Todo item';
     const editable = await screen.findByText(/Todo name/i);
     const editableInput = await screen.findByRole('textbox');
@@ -26,7 +33,7 @@ describe('EditorComposer', () => {
   };
 
   it('should render placeholder', async () => {
-    const { container, editable } = await renderWithQueryElement();
+    const { container, editable } = await renderWithQueryElement({});
 
     expect(container).toBeInTheDocument();
 
@@ -34,7 +41,7 @@ describe('EditorComposer', () => {
   });
 
   it('should render updated input', async () => {
-    const { container, editable, updatedTodo } = await renderWithQueryElement();
+    const { container, editable, updatedTodo } = await renderWithQueryElement({});
 
     expect(container).toBeInTheDocument();
     expect(editable).toBeInTheDocument();
@@ -46,7 +53,7 @@ describe('EditorComposer', () => {
   });
 
   it('should update the input with keybinding', async () => {
-    const { container, editable, updatedTodo } = await renderWithQueryElement();
+    const { container, editable, updatedTodo } = await renderWithQueryElement({});
 
     expect(container).toBeInTheDocument();
     expect(editable).toBeInTheDocument();
@@ -68,16 +75,37 @@ describe('EditorComposer', () => {
   });
 
   it('should autoFocus when isAutoFocus prop is true', async () => {
-    const { container, editableInput } = await renderWithQueryElement(true);
+    const { container, editableInput } = await renderWithQueryElement({ isAutoFocus: true });
 
     expect(container).toBeInTheDocument();
     await waitFor(() => expect(editableInput).toHaveFocus());
   });
 
   it('should not autoFocus when isAutoFocus prop is false', async () => {
-    const { container, editableInput } = await renderWithQueryElement(false);
+    const { container, editableInput } = await renderWithQueryElement({ isAutoFocus: false });
 
     expect(container).toBeInTheDocument();
+    await waitFor(() => expect(editableInput).not.toHaveFocus());
+  });
+
+  it('should not autoFocus when confirmation modal is open while isAutoFocus is set to true', async () => {
+    const { container, editableInput } = await renderWithQueryElement({
+      node: atomCatch(CATCH.confirmModal),
+      state: true,
+      isAutoFocus: true,
+    });
+
+    expect(container).toBeInTheDocument();
+    await waitFor(() => expect(editableInput).not.toHaveFocus());
+  });
+
+  it('should not autoFocus when routed to Complete while isAutoFocus is set to true', async () => {
+    mockRouter.push(PATH_APP['completed']);
+
+    const { container, editableInput } = await renderWithQueryElement({ isAutoFocus: true });
+
+    expect(container).toBeInTheDocument();
+    expect(mockRouter).toMatchObject({ pathname: PATH_APP['completed'] });
     await waitFor(() => expect(editableInput).not.toHaveFocus());
   });
 });

--- a/components/editor/editorEffect/editorAutoFocusEffect.tsx
+++ b/components/editor/editorEffect/editorAutoFocusEffect.tsx
@@ -8,6 +8,7 @@ import { useRecoilValue } from 'recoil';
 import { Editor, Transforms } from 'slate';
 import { ReactEditor } from 'slate-react';
 
+// test is done on editorComposer.test.tsx
 export const EditorAutoFocusEffect = ({ isAutoFocus, editor }: TypesPropsAuthFocusEffect) => {
   const router = useRouter();
   const completedPath = router.asPath === PATH_APP['completed'];

--- a/components/editor/todoEditor/__test__/todoEditor.test.tsx
+++ b/components/editor/todoEditor/__test__/todoEditor.test.tsx
@@ -1,0 +1,28 @@
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { screen } from '@testing-library/dom';
+import { TodoEditors } from '..';
+
+const titlePlaceholder = 'Todo Name';
+const descriptionPlaceholder = 'Write your Note';
+
+describe('TodoEditor', () => {
+  const renderWithTodoEditor = () => {
+    const options = { session: null };
+    return renderWithRecoilRootAndSession(<TodoEditors />, options);
+  };
+
+  it('should contain the placeholders', async () => {
+    const { container } = renderWithTodoEditor();
+
+    const placeholderTitle = await screen.findByText(titlePlaceholder);
+    const placeholderDescription = await screen.findByText(descriptionPlaceholder);
+
+    expect(container).toBeInTheDocument();
+    expect(placeholderTitle).toBeInTheDocument();
+    expect(placeholderDescription).toBeInTheDocument();
+  });
+  // Slate does not render Recoil state updates when manually updating
+  // Recoil values within a testing environment.
+  // As a result, other tests, such as rendering conditional placeholders,
+  // will be conducted in the integration tests of other components.
+});


### PR DESCRIPTION
This commit extends the testing suite by adding more integration tests for EditorComposer, incorporating the EditorAutoFocusEffect component. The tests were conducted using EditorComposer rather than EditorAutoFocusEffect due to its higher testing efficiency. i

Additionally, new tests have been added for TodoEditor, with missing tests such as conditional rendering checks of placeholder being handled within other component's integration tests to maintain efficiency.