### PR TITLE
fix: Downgrade to slate-react@0.92.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "slate": "^0.94.0",
         "slate-history": "^0.93.0",
         "slate-hyperscript": "^0.77.0",
-        "slate-react": "^0.94.0",
+        "slate-react": "^0.92.0",
         "validator": "^13.9.0"
       },
       "devDependencies": {
@@ -9632,9 +9632,9 @@
       }
     },
     "node_modules/slate-react": {
-      "version": "0.94.0",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.94.0.tgz",
-      "integrity": "sha512-8LW3HdC3Rya+3E1Gm5voyXdEfQrJGvm0QYl0bgtW2C06Dh82imxhGIPqRv2sj8j2Zf869oJGNp2bGUoCuNBJ6g==",
+      "version": "0.92.0",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.92.0.tgz",
+      "integrity": "sha512-xEDKu5RKw5f0N95l1UeNQnrB0Pxh4JPjpIZR/BVsMo0ININnLAknR99gLo46bl/Ffql4mr7LeaxQRoXxbFtJOQ==",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",
         "@types/is-hotkey": "^0.1.1",
@@ -17849,9 +17849,9 @@
       }
     },
     "slate-react": {
-      "version": "0.94.0",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.94.0.tgz",
-      "integrity": "sha512-8LW3HdC3Rya+3E1Gm5voyXdEfQrJGvm0QYl0bgtW2C06Dh82imxhGIPqRv2sj8j2Zf869oJGNp2bGUoCuNBJ6g==",
+      "version": "0.92.0",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.92.0.tgz",
+      "integrity": "sha512-xEDKu5RKw5f0N95l1UeNQnrB0Pxh4JPjpIZR/BVsMo0ININnLAknR99gLo46bl/Ffql4mr7LeaxQRoXxbFtJOQ==",
       "requires": {
         "@juggle/resize-observer": "^3.4.0",
         "@types/is-hotkey": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "slate": "^0.94.0",
     "slate-history": "^0.93.0",
     "slate-hyperscript": "^0.77.0",
-    "slate-react": "^0.94.0",
+    "slate-react": "^0.92.0",
     "validator": "^13.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Downgrade slate-react to v0.92.0 to resolve the placeholder delaying issue. Plans to replace slate with an alternative WYSIWYG library in the future.