### PR TITLE
feat: Add run-test workflow

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -1,0 +1,37 @@
+name: Run Tests on Pull Request
+
+on:
+  pull_request:
+    branches:
+      - '**'
+      - '!master'
+      - '!*dependabot*'
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+
+      - name: Cache node modules
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,6 @@ yarn-error.log*
 # env files
 .env.*
 
-# github
-.github/
-
 # vercel
 .vercel
 


### PR DESCRIPTION
Introduce a new workflow, `run-test`, which is triggered on pull requests targeting branches other than 'master' and without 'dependabot' in their names.

This approach avoids running tests for dependabot-related updates and reserves more thorough testing for the 'master' branch, such as building a Docker image and running tests within the Docker environment.

Additionally '.github' is removed from .gitignore.