### PR TITLE
feat(CI): Implement Cloud Run Revision Cleanup Workflow

### DIFF
--- a/.github/workflows/build-deploy-cloudrun.yml
+++ b/.github/workflows/build-deploy-cloudrun.yml
@@ -5,9 +5,6 @@ on:
     workflows: ['Run Test with Cache']
     types:
       - completed
-  pull_request:
-    branches:
-      - 'master'
 
 jobs:
   build-push-deploy:

--- a/.github/workflows/cleanup-gcr-resources.yml
+++ b/.github/workflows/cleanup-gcr-resources.yml
@@ -1,0 +1,37 @@
+name: Cleanup Google Cloud Run Resources
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - 'master'
+
+env:
+  NUMBER_OF_REVISION_TO_KEEP: 5
+
+jobs:
+  build-push-deploy:
+    name: Remove Old Resources of Google Cloud Run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCR_SERVICE_ACCOUNT }}'
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Remove old revisions of Google Cloud Run
+        run: |-
+          gcloud run revisions list \
+            --region=${{ secrets.GCR_DEPLOY_REGION }} \
+            --sort-by=~metadata.creationTimestamp \
+            --format='value(metadata.name)' | 
+              tail -n +$((${{ env.NUMBER_OF_REVISION_TO_KEEP }} + 1 )) | 
+              xargs -r -L1 gcloud run revisions delete \
+            --quiet --region=${{ secrets.GCR_DEPLOY_REGION }}


### PR DESCRIPTION
Introduces a new workflow for managing Google Cloud Run revisions. It offers the capability to specify the number of revisions to retain, configurable via an environment variable within the workflow itself. This flexibility allows developers to dictate the count of preserved environment variables as per their requirements.

Additionally, an unnecessary line in build-deploy-cloudrun has been removed.