### PR TITLE
feat(CI): Introduce Container Registry Image Cleanup Step

### DIFF
--- a/.github/workflows/cleanup-gcr-resources.yml
+++ b/.github/workflows/cleanup-gcr-resources.yml
@@ -8,7 +8,7 @@ on:
       - 'master'
 
 env:
-  NUMBER_OF_REVISION_TO_KEEP: 5
+  NUMBER_OF_RESOURCES_TO_KEEP: 5
 
 jobs:
   build-push-deploy:
@@ -32,6 +32,17 @@ jobs:
             --region=${{ secrets.GCR_DEPLOY_REGION }} \
             --sort-by=~metadata.creationTimestamp \
             --format='value(metadata.name)' | 
-              tail -n +$((${{ env.NUMBER_OF_REVISION_TO_KEEP }} + 1 )) | 
+              tail -n +$((${{ env.NUMBER_OF_RESOURCES_TO_KEEP }} + 1 )) | 
               xargs -r -L1 gcloud run revisions delete \
             --quiet --region=${{ secrets.GCR_DEPLOY_REGION }}
+
+      - name: Remove old images from Google Container Registry
+        run: |-
+          REPO="${{ secrets.GCP_PROJECT_ID }}"
+          IMAGE="${{ github.event.repository.name }}"
+          IMAGES_TO_DELETE=$(gcloud container images list-tags gcr.io/$REPO/$IMAGE \
+            --limit=999999 --sort-by=~timestamp --format='get(digest)' |
+              tail -n +$((${{ env.NUMBER_OF_RESOURCES_TO_KEEP }} + 1 )))
+          for digest in ${IMAGES_TO_DELETE}; do
+            gcloud container images delete -q --force-delete-tags "gcr.io/$REPO/$IMAGE@$digest"
+          done


### PR DESCRIPTION
Incorporates a fresh step into the workflow to handle removal of outdated images from the Container Registry, retaining only the last 5 images. This enhancement aids in maintaining a clean latest images within the Google Container Registry.

Also, for consistency, the environment variable names responsible for dictating the count of preserved resources have been updated. These environment variables now uniformly control the quantity of both revisions and images preserved in the Container Registry.