### PR TITLE
feat: Separate the workflows of building and deploying docker

### DIFF
--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -1,0 +1,48 @@
+name: Build and Push to Google Container Registry
+
+on:
+  workflow_run:
+    workflows: ['Run Test with Cache']
+    types:
+      - completed
+
+jobs:
+  build-and-push-docker-image:
+    name: Build and Push to Google Cloud Run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCR_SERVICE_ACCOUNT }}'
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Authorize Docker push
+        run: gcloud auth configure-docker
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build and tag the Docker image
+        run: |-
+          docker build . -t gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ github.event.repository.name }}:${{ github.sha }} \
+            --build-arg BUILD_IMAGE_DOMAIN=${{ vars.GCR_IMAGE_DOMAIN }} \
+            --build-arg BUILD_HOSTNAME=${{ vars.GCR_HOSTNAME }} \
+            --build-arg BUILD_EMAIL_SERVER_HOST=${{ vars.GCR_EMAIL_SERVER_HOST }} \
+            --build-arg BUILD_EMAIL_SERVER_PORT=${{ vars.GCR_EMAIL_SERVER_PORT }} \
+            --build-arg BUILD_EMAIL_FROM=${{ vars.GCR_EMAIL_FROM }} \
+            --build-arg BUILD_SOCIAL_GITHUB=${{ vars.GCR_SOCIAL_GITHUB }} \
+
+      - name: Push the image to the Google Container Registry
+        run: |-
+          docker push gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ github.event.repository.name }}:${{ github.sha }}

--- a/.github/workflows/docker-image-deploy.yml
+++ b/.github/workflows/docker-image-deploy.yml
@@ -1,14 +1,14 @@
-name: Build, Push, Deploy to Google Cloud Run
+name: Deploy to Google Cloud Run
 
 on:
   workflow_run:
-    workflows: ['Run Test with Cache']
+    workflows: ['Build and Push to Google Container Registry']
     types:
       - completed
 
 jobs:
-  build-push-deploy:
-    name: Build, Push, Deploy Cloud Run
+  deploy-docker-image:
+    name: Deploy to Cloud Run
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -21,31 +21,6 @@ jobs:
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
-
-      - name: Authorize Docker push
-        run: gcloud auth configure-docker
-
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
-      - name: Build and tag the Docker image
-        run: |-
-          docker build . -t gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ github.event.repository.name }}:${{ github.sha }} \
-            --build-arg BUILD_IMAGE_DOMAIN=${{ vars.GCR_IMAGE_DOMAIN }} \
-            --build-arg BUILD_HOSTNAME=${{ vars.GCR_HOSTNAME }} \
-            --build-arg BUILD_EMAIL_SERVER_HOST=${{ vars.GCR_EMAIL_SERVER_HOST }} \
-            --build-arg BUILD_EMAIL_SERVER_PORT=${{ vars.GCR_EMAIL_SERVER_PORT }} \
-            --build-arg BUILD_EMAIL_FROM=${{ vars.GCR_EMAIL_FROM }} \
-            --build-arg BUILD_SOCIAL_GITHUB=${{ vars.GCR_SOCIAL_GITHUB }} \
-
-      - name: Push the image to the Google Container Registry
-        run: |-
-          docker push gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ github.event.repository.name }}:${{ github.sha }}
 
       - name: Deploy to Google Cloud Run
         run: |-


### PR DESCRIPTION
This commit separates the build-deploy-docker workflow into two separate workflows: build-push and deploy. This improves the maintainability of the project by making it easier to understand and update the workflows. The deploy workflow will wait for the build-push workflow to be completed before initiating.

Additionally, this commit removes the build-deploy-cloudrun workflow as it is no longer in use.