### PR TITLE
feat: Add icon.types and icon.const

### DIFF
--- a/components/icon/icon.const.ts
+++ b/components/icon/icon.const.ts
@@ -1,0 +1,5 @@
+export type VIEWBOX = (typeof VIEWBOX)[keyof typeof VIEWBOX];
+export const VIEWBOX = {
+  24: '0 0 24 24',
+  96: '0 96 960 960',
+} as const;

--- a/components/icon/icon.types.ts
+++ b/components/icon/icon.types.ts
@@ -1,0 +1,30 @@
+import { VIEWBOX } from '@constAssertions/ui';
+import { ReactElement } from 'react';
+
+export interface TypesSvgLogos {
+  name: 'Google' | 'GitHub' | 'MainWhite' | 'MainLogoOnlyWhite';
+  className?: string;
+  isAriaHidden?: boolean;
+  height: string;
+  width: string;
+  viewBox: string;
+  path: ReactElement;
+}
+
+export interface TypesSvgIconAttributes {
+  path: string;
+  height: string | number;
+  width: string | number;
+  viewBox: VIEWBOX;
+  isAriaHidden: boolean;
+}
+
+export type TypesOptionsSvg = Partial<TypesSvgIconAttributes & Pick<TypesSvgLogos, 'className'>>;
+
+/*
+ * Props Types
+ * */
+
+export type TypesPropsOptionsSvg = { options?: TypesOptionsSvg };
+
+export type TypesPropsSvgLogoNames = { type: TypesSvgLogos['name'] };

--- a/components/icon/svgIcon/index.tsx
+++ b/components/icon/svgIcon/index.tsx
@@ -1,10 +1,8 @@
 import { VIEWBOX } from '@constAssertions/ui';
-import { TypesOptionsSvg } from '@lib/types/options';
+import { TypesPropsOptionsSvg } from '@icon/icon.types';
 import { memo } from 'react';
 
-type Props = { options: TypesOptionsSvg };
-
-export const SvgIcon = memo(({ options }: Props) => {
+export const SvgIcon = memo(({ options = {} }: TypesPropsOptionsSvg) => {
   return (
     <svg
       xmlns='http://www.w3.org/2000/svg'
@@ -12,7 +10,8 @@ export const SvgIcon = memo(({ options }: Props) => {
       height={options.height ?? '24'}
       width={options.width ?? '24'}
       viewBox={options.viewBox ?? VIEWBOX['24']}
-      className={options.className ?? 'h-5 w-5 fill-gray-500 hover:fill-gray-700'}>
+      className={options.className ?? 'h-5 w-5 fill-gray-500 hover:fill-gray-700'}
+    >
       <path d={options.path} />
     </svg>
   );

--- a/components/icon/svgLogo/index.tsx
+++ b/components/icon/svgLogo/index.tsx
@@ -1,11 +1,9 @@
 import { DATA_SVG_LOGOS } from '@collections/svgLogo';
 import { VIEWBOX } from '@constAssertions/ui';
-import { TypesSvgLogos } from '@lib/types';
+import { TypesPropsSvgLogoNames, TypesSvgLogos } from '@icon/icon.types';
 import { memo } from 'react';
 
-type Props = { type: TypesSvgLogos['name'] };
-
-export const SvgLogo = memo(({ type }: Props) => {
+export const SvgLogo = memo(({ type }: TypesPropsSvgLogoNames) => {
   const svgData = DATA_SVG_LOGOS.find((svg) => svg.name === type) ?? ({} as TypesSvgLogos);
 
   return (
@@ -14,7 +12,8 @@ export const SvgLogo = memo(({ type }: Props) => {
       aria-hidden={svgData.isAriaHidden}
       height={svgData.height ?? '24'}
       width={svgData.width ?? '24'}
-      viewBox={svgData.viewBox ?? VIEWBOX['24']}>
+      viewBox={svgData.viewBox ?? VIEWBOX['24']}
+    >
       {svgData.path}
     </svg>
   );

--- a/components/layouts/layoutHeader/logo.tsx
+++ b/components/layouts/layoutHeader/logo.tsx
@@ -1,8 +1,8 @@
 import { PrefetchRouterButton } from '@buttons/button/prefetchRouterButton';
 import { NetworkStatus } from '@components/notifications/networkStatus';
 import { PATH_HOME } from '@constAssertions/data';
+import { TypesSvgLogos } from '@icon/icon.types';
 import { SvgLogo } from '@icon/svgLogo';
-import { TypesSvgLogos } from '@lib/types';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/router';
 import { Fragment as LogoContainerFragment, Fragment as LogoFragment } from 'react';

--- a/components/ui/buttons/button/svgLogoButton.tsx
+++ b/components/ui/buttons/button/svgLogoButton.tsx
@@ -1,13 +1,10 @@
-import { TypesSvgLogos } from '@lib/types';
-import { TypesOptionsSvg } from '@lib/types/options';
+import { DATA_SVG_PROVIDERS } from '@collections/svgLogo';
+import { TypesPropsOptionsSvg, TypesSvgLogos } from '@icon/icon.types';
 import { signIn } from 'next-auth/react';
 import { useRouter } from 'next-router-mock';
 import { Button } from '.';
-import { DATA_SVG_PROVIDERS } from '@collections/svgLogo';
 
-type Props = { options?: TypesOptionsSvg };
-
-export const SvgLogoButton = ({ options = {} }: Props) => {
+export const SvgLogoButton = ({ options = {} }: TypesPropsOptionsSvg) => {
   const router = useRouter();
 
   const oAuthSignIn = async (logo: TypesSvgLogos) => {
@@ -23,20 +20,23 @@ export const SvgLogoButton = ({ options = {} }: Props) => {
       {DATA_SVG_PROVIDERS.map((logo) => (
         <div
           key={logo.name}
-          className='mb-3'>
+          className='mb-3'
+        >
           <Button
             options={{
               type: 'button',
               className: logo.className,
             }}
-            onClick={() => oAuthSignIn(logo)}>
+            onClick={() => oAuthSignIn(logo)}
+          >
             <span className='pr-2'>
               <svg
                 xmlns='http://www.w3.org/2000/svg'
                 aria-hidden={true}
                 height={options.height ?? '24'}
                 width={options.width ?? '24'}
-                viewBox={logo.viewBox}>
+                viewBox={logo.viewBox}
+              >
                 {logo.path}
               </svg>
             </span>

--- a/lib/data/collections/svgLogo.tsx
+++ b/lib/data/collections/svgLogo.tsx
@@ -1,4 +1,4 @@
-import { TypesSvgLogos } from '@lib/types';
+import { TypesSvgLogos } from '@icon/icon.types';
 
 export const DATA_SVG_LOGOS: TypesSvgLogos[] = [
   {

--- a/lib/data/options/svg.tsx
+++ b/lib/data/options/svg.tsx
@@ -6,7 +6,7 @@ import {
   ICON_REPORT,
   ICON_DELETE,
 } from '@data/materialSymbols';
-import { TypesOptionsSvg } from '@lib/types/options';
+import { TypesOptionsSvg } from '@icon/icon.types';
 
 // network status
 export const optionsSvgNetworkStatus: TypesOptionsSvg = {

--- a/lib/types/bases/data.ts
+++ b/lib/types/bases/data.ts
@@ -1,7 +1,6 @@
 import { PATH_APP, PATH_IMAGE_APP, PATH_IMAGE_HOME } from '@constAssertions/data';
 import { IDB, IDB_STORE, IDB_VERSION } from '@constAssertions/storage';
 import { NOTIFICATION } from '@constAssertions/ui';
-import { ReactElement } from 'react';
 import { Types } from '..';
 
 export type CollectTypesData = TypesIndexedDB;
@@ -38,14 +37,4 @@ export interface TypesPathnameImage {
   alt: string;
   title: string;
   description?: string;
-}
-
-export interface TypesSvgLogos {
-  name: 'Google' | 'GitHub' | 'MainWhite' | 'MainLogoOnlyWhite';
-  className?: Types['className'];
-  isAriaHidden?: boolean;
-  height: string;
-  width: string;
-  viewBox: string;
-  path: ReactElement;
 }

--- a/lib/types/bases/ui.ts
+++ b/lib/types/bases/ui.ts
@@ -1,28 +1,20 @@
+import { DURATION, GRADIENT_POSITION, GRADIENT_TYPE, POSITION_X, POSITION_Y } from '@constAssertions/ui';
+import { Placement } from '@popperjs/core';
 import {
-  DURATION,
-  GRADIENT_TYPE,
-  GRADIENT_POSITION,
-  VIEWBOX,
-  POSITION_X,
-  POSITION_Y,
-} from '@constAssertions/ui';
-import {
-  ReactNode,
-  ReactElement,
   ChangeEventHandler,
-  MouseEventHandler,
   FocusEventHandler,
   KeyboardEventHandler,
+  MouseEventHandler,
+  ReactElement,
+  ReactNode,
 } from 'react';
 import { TriggerType } from 'react-popper-tooltip';
 import { Types } from '..';
-import { Placement } from '@popperjs/core';
 
 export type CollectTypesUi = TypesReactChildren &
   TypesUi &
   TypesLoadings &
   TypesTooltipAttributes &
-  TypesSvgIconAttributes &
   TypesInputAttributes &
   TypesComboboxAttributes &
   TypesDropdownAttributes &
@@ -104,14 +96,6 @@ export interface TypesTooltipAttributes {
   placement: Placement;
   isVisible: boolean;
   isCloseOnTriggerHidden: boolean;
-}
-
-export interface TypesSvgIconAttributes {
-  path: string;
-  height: string | number;
-  width: string | number;
-  viewBox: VIEWBOX;
-  isAriaHidden: boolean;
 }
 
 export interface TypesComboboxAttributes {

--- a/lib/types/options/index.ts
+++ b/lib/types/options/index.ts
@@ -1,10 +1,5 @@
 import { Types } from '..';
-import { TypesSvgIconAttributes, TypesElement, TypesStyleAttributes } from '../bases/ui';
-
-export type TypesOptionsSvg = Partial<
-  Pick<TypesSvgIconAttributes, 'height' | 'width' | 'viewBox' | 'path' | 'isAriaHidden'> &
-    Pick<Types, 'className'>
->;
+import { TypesElement, TypesStyleAttributes } from '../bases/ui';
 
 export type TypesOptionsButton = Partial<
   Pick<


### PR DESCRIPTION
Introduce `icon.types` for managing component icon-related type definitions, and `icon.const` for storing related constant assertions. Subsequent updates have been made to all subscribers for seamless integration with the new types and constant assertions.