### PR TITLE
feat: Extend test script to include watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint": "next lint",
     "prepare": "husky install",
     "pre-commit": "npm run lint --fix",
+    "test:watch": "jest --watch",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
Introduces an option for running tests in watch mode. With the command `npm run test:watch`, tests will automatically re-run when changes are detected. This enhancement provides flexibility for local development without affecting the standard test run behavior during Continuous Integration (CI) processes, where tests should complete without entering a watch state.