### PR TITLE
fix: Resolve deployment workflow interruption

### DIFF
--- a/.github/workflows/docker-image-deploy.yml
+++ b/.github/workflows/docker-image-deploy.yml
@@ -4,7 +4,6 @@ on:
   workflow_run:
     workflows: [Build and Push to Google Artifact Registry]
     types: [completed]
-    branches: [master]
 
 jobs:
   deploy-docker-image:


### PR DESCRIPTION
Adjustment made to the deploy-workflow where the `branches: [master]` directive was removed. This action addresses the issue of the deploy workflow failing to initiate following the completion of the build workflow.