### PR TITLE
feat: Implement Label Alias Path in Configurations

### DIFF
--- a/components/layouts/app/appNavigation/index.tsx
+++ b/components/layouts/app/appNavigation/index.tsx
@@ -16,7 +16,7 @@ import dynamic from 'next/dynamic';
 import { LoadingLabels } from '@components/loadable/loadingStates/loadingLabels';
 import { SvgIcon } from '@icon/svgIcon';
 
-const LabelList = dynamic(() => import('@components/label/labelList').then((mod) => mod.LabelList), {
+const LabelList = dynamic(() => import('@label/labelList').then((mod) => mod.LabelList), {
   ssr: false,
 });
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -32,6 +32,7 @@ const customJestConfig = {
     '^@auth/(.*)$': ['<rootDir>/components/auth/$1'],
     '^@editor/(.*)$': ['<rootDir>/components/editor/$1'],
     '^@icon/(.*)$': ['<rootDir>/components/icon/$1'],
+    '^@label/(.*)$': ['<rootDir>/components/label/$1'],
     '^@user/(.*)$': ['<rootDir>/components/user/$1'],
     '^@layouts/(.*)$': ['<rootDir>/components/layouts/$1'],
     '^@buttons/(.*)$': ['<rootDir>/components/ui/buttons/$1'],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
       "@auth/*": ["components/auth/*"],
       "@editor/*": ["components/editor/*"],
       "@icon/*": ["components/icon/*"],
+      "@label/*": ["components/label/*"],
       "@user/*": ["components/user/*"],
       "@layouts/*": ["components/layouts/*"],
       "@buttons/*": ["components/ui/buttons/*"],


### PR DESCRIPTION
Include the alias path of the label component within tsconfig and jest.config files. Moreover, update the alias path in the subscriber for a more streamlined path resolution, enhancing code maintainability.