### PR TITLE
refactor: Relocate Label-related Hooks to label.hooks

### DIFF
--- a/components/icon/icon.types.ts
+++ b/components/icon/icon.types.ts
@@ -1,5 +1,5 @@
-import { VIEWBOX } from '@constAssertions/ui';
 import { ReactElement } from 'react';
+import { VIEWBOX } from './icon.const';
 
 export interface TypesSvgLogos {
   name: 'Google' | 'GitHub' | 'MainWhite' | 'MainLogoOnlyWhite';

--- a/components/icon/svgIcon/index.tsx
+++ b/components/icon/svgIcon/index.tsx
@@ -1,4 +1,4 @@
-import { VIEWBOX } from '@constAssertions/ui';
+import { VIEWBOX } from '@icon/icon.const';
 import { TypesPropsOptionsSvg } from '@icon/icon.types';
 import { memo } from 'react';
 

--- a/components/icon/svgLogo/index.tsx
+++ b/components/icon/svgLogo/index.tsx
@@ -1,4 +1,4 @@
-import { VIEWBOX } from '@constAssertions/ui';
+import { VIEWBOX } from '@icon/icon.const';
 import { DATA_SVG_LOGOS } from '@icon/icon.data';
 import { TypesPropsSvgLogoNames, TypesSvgLogos } from '@icon/icon.types';
 import { memo } from 'react';

--- a/components/label/label.hooks.tsx
+++ b/components/label/label.hooks.tsx
@@ -2,6 +2,8 @@ import { CATCH } from '@constAssertions/misc';
 import { NOTIFICATION } from '@constAssertions/ui';
 import { ICON_FILTER_LIST, ICON_FILTER_LIST_OFF } from '@data/materialSymbols';
 import { STYLE_COLORS } from '@data/stylePreset';
+import { useGetWithRecoilCallback, useCompareToQueryLabels } from '@hooks/misc';
+import { useNotificationState } from '@hooks/notifications';
 import {
   atomLabelNew,
   atomSelectorLabelItem,
@@ -27,8 +29,6 @@ import ObjectID from 'bson-objectid';
 import { useSession } from 'next-auth/react';
 import { useEffect } from 'react';
 import { RecoilValue, useRecoilCallback, useRecoilValue, useResetRecoilState } from 'recoil';
-import { useCompareToQueryLabels, useGetWithRecoilCallback } from './misc';
-import { useNotificationState } from './notifications';
 
 /**
  * Hooks

--- a/components/ui/comboBoxes/labelComboBox.tsx
+++ b/components/ui/comboBoxes/labelComboBox.tsx
@@ -4,7 +4,6 @@ import { STYLE_HOVER_SLATE_LIGHT } from '@data/stylePreset';
 import { ComboBoxSelectedLabelsEffect } from '@effects/comboBoxSelectedLabelsEffect';
 import { Combobox } from '@headlessui/react';
 import { useSetFilterLabels } from '@hooks/comboBoxes';
-import { useLabelChangeHandler, useDataButtonComboboxFilterLabel } from '@hooks/labels';
 import { useLabelModalStateOpen } from '@hooks/modals';
 import { Types } from '@lib/types';
 import { atomComboBoxQuery } from '@states/comboBoxes';
@@ -16,6 +15,7 @@ import { classNames } from '@stateLogics/utils';
 import { SvgIcon } from '@icon/svgIcon';
 import { selectorSelectedLabels, selectorComboBoxFilteredLabels } from '@label/label.states';
 import { Labels, TypesLabel } from '@label/label.types';
+import { useLabelChangeHandler, useDataButtonComboboxFilterLabel } from '@label/label.hooks';
 
 type Props = Partial<Pick<Types, 'todo'> & Pick<TypesLabel, 'selectedQueryLabels'>>;
 

--- a/components/ui/dropdowns/v1/labelComboBoxDropdown.tsx
+++ b/components/ui/dropdowns/v1/labelComboBoxDropdown.tsx
@@ -11,13 +11,13 @@ import { PRIORITY_LEVEL } from '@constAssertions/misc';
 import { GRADIENT_POSITION } from '@constAssertions/ui';
 import { optionsButtonLabelRemove } from '@options/button';
 import { optionsDropdownComboBox } from '@options/misc';
-import { useLabelRemoveItemTitleId } from '@hooks/labels';
 import { useTodoModalStateClose } from '@hooks/modals';
 import { selectorSessionTodoItem } from '@states/atomEffects/todos';
 import { atomTodoNew } from '@states/todos';
 import { classNames, paths } from '@stateLogics/utils';
 import { selectorSelectedLabels } from '@label/label.states';
 import { TypesLabel } from '@label/label.types';
+import { useLabelRemoveItemTitleId } from '@label/label.hooks';
 
 type Props = Partial<Pick<Types, 'container' | 'todo'> & Pick<TypesLabel, 'selectedQueryLabels'>>;
 

--- a/components/ui/dropdowns/v1/labelItemDropdown.tsx
+++ b/components/ui/dropdowns/v1/labelItemDropdown.tsx
@@ -4,10 +4,10 @@ import { Dropdown } from './dropdown';
 import { DropdownMenuItem } from './dropdown/dropdownMenuItem';
 import { optionsDropdownLabelItem } from '@options/misc';
 import { ActiveDropdownMenuItemEffect } from '@effects/activeDropdownMenuItemEffect';
-import { useLabelRemoveItem } from '@hooks/labels';
 import { useLabelModalStateOpen } from '@hooks/modals';
 import { TypesOptionsDropdown } from '@lib/types/options';
 import { TypesLabel } from '@label/label.types';
+import { useLabelRemoveItem } from '@label/label.hooks';
 
 type Props = { options: TypesOptionsDropdown } & Pick<TypesLabel, 'label'> &
   Partial<Pick<Types, 'menuContentOnClose'>>;

--- a/components/ui/modals/labelModals/labelModal/index.tsx
+++ b/components/ui/modals/labelModals/labelModal/index.tsx
@@ -9,7 +9,6 @@ import {
   optionsButtonTodoModalCancel,
   optionsButtonLabelModalAddLabel,
 } from '@options/button';
-import { useLabelValueUpdate, useLabelAdd } from '@hooks/labels';
 import { useConditionCheckLabelTitleEmpty } from '@hooks/misc';
 import { useLabelModalStateClose } from '@hooks/modals';
 import { ModalTransitionChild } from '@modals/modal/modalTransition/modalTransitionChild';
@@ -20,6 +19,7 @@ import { KeysWithLabelModalEffect } from '@effects/KeysWithLabelModalEffect';
 import { DividerX } from '@ui/dividers/dividerX';
 import { atomLabelNew, atomSelectorLabelItem } from '@label/label.states';
 import { TypesLabel } from '@label/label.types';
+import { useLabelValueUpdate, useLabelAdd } from '@label/label.hooks';
 
 type Props = Partial<
   Pick<Types, 'children' | 'menuButtonContent' | 'footerButtons' | 'headerButtons'> &

--- a/components/ui/modals/labelModals/labelModal/itemLabelModal.tsx
+++ b/components/ui/modals/labelModals/labelModal/itemLabelModal.tsx
@@ -1,11 +1,11 @@
 import { DisableButton } from '@buttons/disableButton';
 import { KeysWithLabelModalEffect } from '@effects/KeysWithLabelModalEffect';
-import { useLabelUpdateItem } from '@hooks/labels';
 import { useConditionCompareLabelItemsEqual } from '@hooks/misc';
 import { TypesLabel } from '@label/label.types';
 import { optionsButtonLabelModalUpdateLabel } from '@options/button';
 import { Fragment } from 'react';
 import { LabelModal } from '.';
+import { useLabelUpdateItem } from '@label/label.hooks';
 
 export const ItemLabelModal = ({ label }: Pick<TypesLabel, 'label'>) => {
   const updateLabel = useLabelUpdateItem(label._id);

--- a/lib/data/constAssertions/ui.tsx
+++ b/lib/data/constAssertions/ui.tsx
@@ -76,12 +76,6 @@ export const BREAKPOINT = {
   xl: 1280,
 } as const;
 
-export type VIEWBOX = (typeof VIEWBOX)[keyof typeof VIEWBOX];
-export const VIEWBOX = {
-  24: '0 0 24 24',
-  96: '0 96 960 960',
-} as const;
-
 export type SPINNER = (typeof SPINNER)[keyof typeof SPINNER];
 export const SPINNER = {
   authForm: 'authForm',

--- a/lib/stateLogics/effects/comboBoxSelectedLabelsEffect.tsx
+++ b/lib/stateLogics/effects/comboBoxSelectedLabelsEffect.tsx
@@ -3,8 +3,8 @@ import { useEffect } from 'react';
 import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
 import { atomFilterSelected } from '@states/comboBoxes';
 import { CATCH } from '@constAssertions/misc';
-import { useLabelUpdateDataItem } from '@hooks/labels';
 import { atomCatch } from '@states/misc';
+import { useLabelUpdateDataItem } from '@label/label.hooks';
 
 type Props = Partial<Pick<Types, 'todo'>>;
 

--- a/lib/stateLogics/hooks/keybindings.tsx
+++ b/lib/stateLogics/hooks/keybindings.tsx
@@ -13,7 +13,6 @@ import {
 } from '@states/modals';
 import { isMacOs, isMobile } from 'react-device-detect';
 import { RecoilValue, useRecoilCallback } from 'recoil';
-import { useLabelAdd, useLabelUpdateDataItem, useLabelUpdateItem } from './labels';
 import { useConditionCheckLabelTitleEmpty, useFilterTodoIdsWithPathname } from './misc';
 import {
   useTodoModalStateExitMinimize,
@@ -24,6 +23,7 @@ import {
 } from './modals';
 import { useTodoCompleteItem, useTodoRemoveItem } from './todos';
 import { Labels } from '@label/label.types';
+import { useLabelAdd, useLabelUpdateItem, useLabelUpdateDataItem } from '@label/label.hooks';
 
 export const useItemModalWithKey = (_id: Todos['_id']) => {
   const completeTodo = useTodoCompleteItem(_id);

--- a/lib/stateLogics/hooks/modals.tsx
+++ b/lib/stateLogics/hooks/modals.tsx
@@ -5,7 +5,6 @@ import { RecoilValue, useRecoilCallback, useResetRecoilState } from 'recoil';
 import { CATCH } from '@constAssertions/misc';
 import { atomSelectorTodoItem } from '@states/atomEffects/todos';
 import { useCalResetDateItemOnly } from './calendar';
-import { useLabelRemoveItem } from './labels';
 import { useConditionCompareTodoItemsEqual, useConditionCheckTodoTitleEmpty } from './misc';
 import { useTodoRemoveItem } from './todos';
 import {
@@ -19,6 +18,7 @@ import {
 import { atomCatch } from '@states/misc';
 import { atomLabelNew, atomSelectorLabelItem, atomSelectorLabels } from '@label/label.states';
 import { Labels } from '@label/label.types';
+import { useLabelRemoveItem } from '@label/label.hooks';
 
 /**
  * Hooks


### PR DESCRIPTION
Transition all label-related hooks to label.hooks, promoting centralized and more efficient hook management. Also, eliminate unused const assertions to maintain a clean and clutter-free codebase.