### PR TITLE
refactor: Relocate Constants to label.const

### DIFF
--- a/components/label/label.const.ts
+++ b/components/label/label.const.ts
@@ -1,0 +1,18 @@
+import { ICON_LABEL, ICON_LABEL_FILL, ICON_NEW_LABEL } from '@data/materialSymbols';
+import { TypesOptionsButton } from '@lib/types/options';
+
+export const optionsLabelButtonAddMore: TypesOptionsButton = {
+  path: ICON_NEW_LABEL,
+  tooltip: 'Add new label',
+  padding: 'p-2',
+  color: 'hover:enabled:bg-fill-700',
+};
+
+export const optionsLabelRouteMatched: TypesOptionsButton = {
+  path: ICON_LABEL_FILL,
+  className: 'h-5 w-5 fill-yellow-500',
+};
+export const optionsLabelRouteUnmatched: TypesOptionsButton = {
+  path: ICON_LABEL,
+  className: 'h-5 w-5 fill-gray-500 group-hover:fill-yellow-500 ',
+};

--- a/components/label/label.hooks.ts
+++ b/components/label/label.hooks.ts
@@ -53,7 +53,7 @@ export const useLabelAdd = () => {
   const setNotification = useNotificationState();
 
   return useRecoilCallback(({ snapshot, set, reset }) => () => {
-    const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
+    const get = <T>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
 
     set(atomSelectorLabels, [...get(atomSelectorLabels), { ...get(atomLabelNew) }]);
     set(selectorSessionLabels, [...get(selectorSessionLabels), { ...get(atomLabelNew) }]);
@@ -71,7 +71,7 @@ export const useLabelUpdateItem = (_id: Labels['_id']) => {
   const setNotification = useNotificationState();
 
   return useRecoilCallback(({ snapshot, set, reset }) => () => {
-    const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
+    const get = <T>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
 
     const updateLabels = get(selectorSessionLabels).map((label) => ({
       ...label,
@@ -92,7 +92,7 @@ export const useLabelRemoveItem = (_id: Labels['_id']) => {
   const setNotification = useNotificationState();
 
   return useRecoilCallback(({ snapshot, set, reset }) => () => {
-    const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
+    const get = <T>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
 
     if (!get(atomConfirmModalDelete(_id))) {
       set(atomConfirmModalDelete(_id), true);
@@ -113,7 +113,7 @@ export const useLabelRemoveItemTitleId = (_id: Todos['_id']) => {
   const get = useGetWithRecoilCallback();
 
   const removeLabelItemTitleId = useRecoilCallback(({ snapshot, set }) => (labelId: Labels['_id']) => {
-    const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
+    const get = <T>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
     const todoId = _id ? _id! : get(atomTodoNew)._id!;
 
     const filteredLabelsRemoved = get(atomSelectorLabels).map((label) => {
@@ -149,7 +149,7 @@ export const useLabelUpdateDataItem = () => {
   const { status } = useSession();
   const compareLabelsToQueryLabel = useCompareToQueryLabels();
   return useRecoilCallback(({ snapshot, set, reset }) => () => {
-    const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
+    const get = <T>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
     const updatedLabels = get(atomSelectorLabels);
     const filteredLabels = compareLabelsToQueryLabel(get(atomSelectorLabels));
 
@@ -163,7 +163,7 @@ export const useLabelUpdateDataItem = () => {
 export const useLabelChangeHandler = (_id: Todos['_id']) => {
   const compareLabelsToQueryLabel = useCompareToQueryLabels();
   return useRecoilCallback(({ set, snapshot }) => (selected: Labels[]) => {
-    const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
+    const get = <T>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
     const todoId = _id ? _id! : get(atomTodoNew)._id!;
     const labels = get(selectorSessionLabels);
     const isTodoModalOpen = get(atomCatch(CATCH['todoModal']));

--- a/components/label/labelList/index.tsx
+++ b/components/label/labelList/index.tsx
@@ -1,10 +1,10 @@
 import { IconButton } from '@buttons/iconButton';
+import { useLabelModalStateOpen } from '@hooks/modals';
+import { optionsLabelButtonAddMore } from '@label/label.const';
+import { selectorSessionLabels } from '@label/label.states';
 import { Fragment } from 'react';
 import { useRecoilValue } from 'recoil';
 import { LabelItem } from './labelItem';
-import { optionsButtonLabelAddMore } from '@options/button';
-import { useLabelModalStateOpen } from '@hooks/modals';
-import { selectorSessionLabels } from '@label/label.states';
 
 export const LabelList = () => {
   const labelList = useRecoilValue(selectorSessionLabels);
@@ -16,7 +16,7 @@ export const LabelList = () => {
         <div className='item-center flex flex-row justify-between fill-gray-500 pb-1 text-base opacity-90'>
           <div className='py-2 pl-2'>Labels</div>
           <IconButton
-            options={optionsButtonLabelAddMore}
+            options={optionsLabelButtonAddMore}
             onClick={() => labelModalOpen()}
           />
         </div>

--- a/components/label/labelList/labelItem/index.tsx
+++ b/components/label/labelList/labelItem/index.tsx
@@ -5,8 +5,8 @@ import { STYLE_HOVER_ENABLED_SLATE_DARK } from '@data/stylePreset';
 import { useNavigationOpen } from '@hooks/layouts';
 import { useNextQuery } from '@hooks/misc';
 import { SvgIcon } from '@icon/svgIcon';
+import { optionsLabelRouteMatched, optionsLabelRouteUnmatched } from '@label/label.const';
 import { TypesLabel } from '@label/label.types';
-import { optionsButtonLabelRouteMatched, optionsButtonLabelRouteUnmatched } from '@options/button';
 import { classNames, paths } from '@stateLogics/utils';
 import { atomEffectMediaQuery } from '@states/atomEffects/misc';
 import dynamic from 'next/dynamic';
@@ -54,9 +54,9 @@ export const LabelItem = ({ label }: Pick<TypesLabel, 'label'>) => {
           >
             <div className='flex w-full flex-row  px-2 py-2'>
               {matchedSlug ? (
-                <SvgIcon options={optionsButtonLabelRouteMatched} />
+                <SvgIcon options={optionsLabelRouteMatched} />
               ) : (
-                <SvgIcon options={optionsButtonLabelRouteUnmatched} />
+                <SvgIcon options={optionsLabelRouteUnmatched} />
               )}
               <div className='max-w-[10.7rem] truncate pl-2 text-gray-600 group-hover:text-gray-900'>
                 {label.name}

--- a/lib/data/options/button.tsx
+++ b/lib/data/options/button.tsx
@@ -1,24 +1,21 @@
 import { MODIFIER_KBD } from '@constAssertions/misc';
 import {
-  ICON_CHEVRON_LEFT,
-  ICON_CHEVRON_RIGHT,
-  ICON_CLOSE,
-  ICON_DELETE,
-  ICON_LABEL,
-  ICON_LABEL_FILL,
-  ICON_MAXIMIZE,
-  ICON_MENU,
-  ICON_MINIMIZE,
-  ICON_NEW_LABEL,
-  ICON_OPEN_IN_FULL,
-  ICON_UNFOLD_MORE,
+    ICON_CHEVRON_LEFT,
+    ICON_CHEVRON_RIGHT,
+    ICON_CLOSE,
+    ICON_DELETE,
+    ICON_MAXIMIZE,
+    ICON_MENU,
+    ICON_MINIMIZE,
+    ICON_OPEN_IN_FULL,
+    ICON_UNFOLD_MORE
 } from '@data/materialSymbols';
 import {
-  STYLE_BUTTON_LARGE_BLUE,
-  STYLE_BUTTON_NORMAL_BLUE,
-  STYLE_BUTTON_NORMAL_RED,
-  STYLE_BUTTON_NORMAL_WHITE,
-  STYLE_HOVER_ENABLED_SLATE_DARK,
+    STYLE_BUTTON_LARGE_BLUE,
+    STYLE_BUTTON_NORMAL_BLUE,
+    STYLE_BUTTON_NORMAL_RED,
+    STYLE_BUTTON_NORMAL_WHITE,
+    STYLE_HOVER_ENABLED_SLATE_DARK,
 } from '@data/stylePreset';
 import { TypesOptionsButton } from '@lib/types/options';
 import { classNames } from '@stateLogics/utils';
@@ -33,11 +30,14 @@ export const optionsButtonGlobalClose: TypesOptionsButton = {
 // network Status
 export const optionsButtonNetworkStatus: TypesOptionsButton = {
   isDisabled: true,
-  className: 'break-word inline-flex w-auto items-center justify-center rounded-lg border py-1 px-2 text-sm  shadow-sm',
+  className:
+    'break-word inline-flex w-auto items-center justify-center rounded-lg border py-1 px-2 text-sm  shadow-sm',
   tooltip: (
     <span>
       <p className='px-1 pb-1 text-sm'>You are offline!</p>
-      <p className='break-word w-36 whitespace-normal px-1'>Check your internet connection and try again later.</p>
+      <p className='break-word w-36 whitespace-normal px-1'>
+        Check your internet connection and try again later.
+      </p>
     </span>
   ),
 };
@@ -159,22 +159,6 @@ export const optionsButtonLabelModalUpdateLabel: TypesOptionsButton = {
   tooltip: 'Update label',
   kbd: 'Enter',
   className: classNames(STYLE_BUTTON_NORMAL_BLUE, 'mx-2'),
-};
-
-export const optionsButtonLabelRouteMatched: TypesOptionsButton = {
-  path: ICON_LABEL_FILL,
-  className: 'h-5 w-5 fill-yellow-500',
-};
-export const optionsButtonLabelRouteUnmatched: TypesOptionsButton = {
-  path: ICON_LABEL,
-  className: 'h-5 w-5 fill-gray-500 group-hover:fill-yellow-500 ',
-};
-
-export const optionsButtonLabelAddMore: TypesOptionsButton = {
-  path: ICON_NEW_LABEL,
-  tooltip: 'Add new label',
-  padding: 'p-2',
-  color: 'hover:enabled:bg-fill-700',
 };
 
 export const optionsButtonLabelRemove: TypesOptionsButton = {


### PR DESCRIPTION
Transition various constants to label.const, ensuring a unified location for constants management. Further, implement appropriate renaming to maintain consistency in naming conventions.