### PR TITLE
feat(CI/CD): Refine Github Actions Workflows

### DIFF
--- a/.github/workflows/cleanup-gcr-resources.yml
+++ b/.github/workflows/cleanup-gcr-resources.yml
@@ -8,7 +8,7 @@ on:
       - 'master'
 
 env:
-  NUMBER_OF_RESOURCES_TO_KEEP: 10
+  NUMBER_OF_RESOURCES_TO_KEEP: 3
 
 jobs:
   build-push-deploy:

--- a/.github/workflows/docker-image-deploy.yml
+++ b/.github/workflows/docker-image-deploy.yml
@@ -29,7 +29,9 @@ jobs:
             --region ${{ secrets.GCR_DEPLOY_REGION }} \
             --platform ${{ secrets.GCR_PLATFORM }} \
             --allow-unauthenticated \
-            --cpu-boost \
+            --min-instances=1 \ #Set to more than 1 to reduce the cold starts 
+            --no-cpu-throttling \ #Set the CPU always on, which reduces the cost of CPU and memory usage by 25%. Only useful when min-instance is more than 1 or continuous CPU usage occurs. To set up 'CPU is only allocated during request processing', --cpu-throttling
+            # --cpu-boost \ # this feature does not provide benefit if there is min instances more than 0 as well as CPU always on (aka --no-cpu-throttling)
             --vpc-connector ${{ secrets.GCR_VPC_CONNECTOR }} \
             --vpc-egress ${{ secrets.GCR_VPC_EGRESS }} \
             --region ${{ secrets.GCR_VPC_REGION }} \


### PR DESCRIPTION
Adjusts 'cleanup-gcr-resources' to retain only the three most recent resources, a reduction from the previous setting of ten.

In 'docker-image-deploy', multiple flags are modified:

- Add `--min-instances=1` to enhance the cold start time for Google Cloud Run.
- Add `--no-cpu-throttling` to establish 'CPU always allocated', leading to a 25% cost decrease in CPU and memory usage. Beneficial when a CPU is i continuously running, such as when min instance is greater than 0.
- Disable `--cpu-boost` by commenting it out, considering it does not offer extra benefits when the min-instances is above 0 and 'CPU always allocated' is in place.