### PR TITLE
ffrefactor: Extract options props within LabelItem component

### DIFF
--- a/components/label/label.const.ts
+++ b/components/label/label.const.ts
@@ -1,6 +1,13 @@
+import { PATH_APP } from '@constAssertions/data';
 import { ICON_LABEL, ICON_LABEL_FILL, ICON_NEW_LABEL } from '@data/materialSymbols';
-import { TypesOptionsButton } from '@lib/types/options';
+import { TypesOptionsButton, TypesOptionsPrefetchRouterButton } from '@lib/types/options';
+import { classNames, paths } from '@stateLogics/utils';
+import { TypesLabel } from './label.types';
+import { STYLE_HOVER_ENABLED_SLATE_DARK } from '@data/stylePreset';
 
+/**
+ * LabelList
+ * */
 export const optionsLabelButtonAddMore: TypesOptionsButton = {
   path: ICON_NEW_LABEL,
   tooltip: 'Add new label',
@@ -8,11 +15,31 @@ export const optionsLabelButtonAddMore: TypesOptionsButton = {
   color: 'hover:enabled:bg-fill-700',
 };
 
-export const optionsLabelRouteMatched: TypesOptionsButton = {
+/**
+ * LabelItem
+ * */
+export const optionsLabelItemRouteMatched: TypesOptionsButton = {
   path: ICON_LABEL_FILL,
   className: 'h-5 w-5 fill-yellow-500',
 };
-export const optionsLabelRouteUnmatched: TypesOptionsButton = {
+export const optionsLabelItemRouteUnmatched: TypesOptionsButton = {
   path: ICON_LABEL,
   className: 'h-5 w-5 fill-gray-500 group-hover:fill-yellow-500 ',
+};
+
+export const optionsLabelItemPrefetchButton = (
+  label: TypesLabel['label'],
+): TypesOptionsPrefetchRouterButton => {
+  return {
+    tooltip: label.name,
+    path: paths(PATH_APP['label'] + '/', label._id),
+    className: classNames('w-full focus:outline-none focus:ring-0 focus:ring-offset-0'),
+  };
+};
+
+export const optionsLabelItemDropdown = (matchedSlug: boolean) => {
+  return {
+    isInitiallyVisible: false,
+    hoverBg: matchedSlug ? 'hover:bg-blue-900 hover:bg-opacity-[0.07]' : STYLE_HOVER_ENABLED_SLATE_DARK,
+  };
 };

--- a/components/label/labelList/labelItem/index.tsx
+++ b/components/label/labelList/labelItem/index.tsx
@@ -1,13 +1,17 @@
 import { PrefetchRouterButton } from '@buttons/button/prefetchRouterButton';
 import { PATH_APP } from '@constAssertions/data';
 import { BREAKPOINT } from '@constAssertions/ui';
-import { STYLE_HOVER_ENABLED_SLATE_DARK } from '@data/stylePreset';
 import { useNavigationOpen } from '@hooks/layouts';
 import { useNextQuery } from '@hooks/misc';
 import { SvgIcon } from '@icon/svgIcon';
-import { optionsLabelRouteMatched, optionsLabelRouteUnmatched } from '@label/label.const';
+import {
+  optionsLabelItemPrefetchButton,
+  optionsLabelItemDropdown,
+  optionsLabelItemRouteMatched,
+  optionsLabelItemRouteUnmatched,
+} from '@label/label.const';
 import { TypesLabel } from '@label/label.types';
-import { classNames, paths } from '@stateLogics/utils';
+import { classNames } from '@stateLogics/utils';
 import { atomEffectMediaQuery } from '@states/atomEffects/misc';
 import dynamic from 'next/dynamic';
 import { Fragment, Fragment as LabelModalFragment, Suspense } from 'react';
@@ -45,19 +49,13 @@ export const LabelItem = ({ label }: Pick<TypesLabel, 'label'>) => {
       >
         <div className='mr-[0.5rem] inline-block w-full'>
           <PrefetchRouterButton
-            options={{
-              tooltip: label.name,
-              path: paths(PATH_APP['label'] + '/', label._id),
-              className: classNames('w-full focus:outline-none focus:ring-0 focus:ring-offset-0'),
-            }}
+            options={optionsLabelItemPrefetchButton(label)}
             onClick={() => !isBreakpointMd && setNavigationOpen()}
           >
             <div className='flex w-full flex-row  px-2 py-2'>
-              {matchedSlug ? (
-                <SvgIcon options={optionsLabelRouteMatched} />
-              ) : (
-                <SvgIcon options={optionsLabelRouteUnmatched} />
-              )}
+              <SvgIcon
+                options={matchedSlug ? optionsLabelItemRouteMatched : optionsLabelItemRouteUnmatched}
+              />
               <div className='max-w-[10.7rem] truncate pl-2 text-gray-600 group-hover:text-gray-900'>
                 {label.name}
               </div>
@@ -66,12 +64,7 @@ export const LabelItem = ({ label }: Pick<TypesLabel, 'label'>) => {
         </div>
         <LabelItemDropdown
           label={label}
-          options={{
-            isInitiallyVisible: false,
-            hoverBg: matchedSlug
-              ? 'hover:bg-blue-900 hover:bg-opacity-[0.07]'
-              : STYLE_HOVER_ENABLED_SLATE_DARK,
-          }}
+          options={optionsLabelItemDropdown(matchedSlug)}
           menuContentOnClose={
             <span className='absolute right-[0.73rem] top-1/2 -translate-y-2/4 select-none text-xs tracking-tighter text-slate-400 group-hover:invisible'>
               <Suspense>


### PR DESCRIPTION
Extract and abstract the option properties for both PrefetchButton and LabelItemDropdown within the LabelItem component. This change enhances modularity and improves readability of the component code.