### PR TITLE
refactor: Decompose LabelItem component

### DIFF
--- a/components/label/labelList/labelItem/index.tsx
+++ b/components/label/labelList/labelItem/index.tsx
@@ -3,25 +3,17 @@ import { PATH_APP } from '@constAssertions/data';
 import { BREAKPOINT } from '@constAssertions/ui';
 import { useNavigationOpen } from '@hooks/layouts';
 import { useNextQuery } from '@hooks/misc';
-import { SvgIcon } from '@icon/svgIcon';
-import {
-  optionsLabelItemPrefetchButton,
-  optionsLabelItemDropdown,
-  optionsLabelItemRouteMatched,
-  optionsLabelItemRouteUnmatched,
-} from '@label/label.const';
+import { optionsLabelItemDropdown, optionsLabelItemPrefetchButton } from '@label/label.const';
 import { TypesLabel } from '@label/label.types';
 import { classNames } from '@stateLogics/utils';
 import { atomEffectMediaQuery } from '@states/atomEffects/misc';
 import dynamic from 'next/dynamic';
-import { Fragment, Fragment as LabelModalFragment, Suspense } from 'react';
+import { Fragment, Suspense } from 'react';
 import { useRecoilValue } from 'recoil';
+import { LabelItemButtonContent } from './labelItemButtonContent';
+import { DropdownContentOnClose } from './labelItemDropdown/dropdownContentOnClose';
 
-const TodosCount = dynamic(() => import('@layouts/app/todosCount').then((mod) => mod.TodosCount));
-
-const LabelItemDropdown = dynamic(() =>
-  import('@dropdowns/v1/labelItemDropdown').then((mod) => mod.LabelItemDropdown),
-);
+const LabelItemDropdown = dynamic(() => import('./labelItemDropdown').then((mod) => mod.LabelItemDropdown));
 const ItemLabelModal = dynamic(() =>
   import('@modals/labelModals/labelModal/itemLabelModal').then((mod) => mod.ItemLabelModal),
 );
@@ -36,48 +28,35 @@ export const LabelItem = ({ label }: Pick<TypesLabel, 'label'>) => {
   const matchedSlug = slug === label._id;
   const isBreakpointMd = useRecoilValue(atomEffectMediaQuery(BREAKPOINT['md']));
   const setNavigationOpen = useNavigationOpen();
+  const labelItemClassName = classNames(
+    'group relative flex w-full cursor-pointer flex-row items-center justify-between rounded-lg pr-[0.20rem]',
+    matchedSlug ? 'bg-blue-100 font-semibold text-opacity-80' : 'hover:bg-slate-200 hover:bg-opacity-80 ',
+  );
 
   return (
     <Fragment>
-      <div
-        className={classNames(
-          'group relative flex w-full cursor-pointer flex-row items-center justify-between rounded-lg pr-[0.20rem]',
-          matchedSlug
-            ? 'bg-blue-100 font-semibold text-opacity-80'
-            : 'hover:bg-slate-200 hover:bg-opacity-80 ',
-        )}
-      >
+      <div className={labelItemClassName}>
         <div className='mr-[0.5rem] inline-block w-full'>
           <PrefetchRouterButton
             options={optionsLabelItemPrefetchButton(label)}
             onClick={() => !isBreakpointMd && setNavigationOpen()}
           >
-            <div className='flex w-full flex-row  px-2 py-2'>
-              <SvgIcon
-                options={matchedSlug ? optionsLabelItemRouteMatched : optionsLabelItemRouteUnmatched}
-              />
-              <div className='max-w-[10.7rem] truncate pl-2 text-gray-600 group-hover:text-gray-900'>
-                {label.name}
-              </div>
-            </div>
+            <LabelItemButtonContent
+              label={label}
+              matchedSlug={matchedSlug}
+            />
           </PrefetchRouterButton>
         </div>
         <LabelItemDropdown
           label={label}
           options={optionsLabelItemDropdown(matchedSlug)}
-          menuContentOnClose={
-            <span className='absolute right-[0.73rem] top-1/2 -translate-y-2/4 select-none text-xs tracking-tighter text-slate-400 group-hover:invisible'>
-              <Suspense>
-                <TodosCount label={label} />
-              </Suspense>
-            </span>
-          }
+          menuContentOnClose={<DropdownContentOnClose label={label} />}
         />
       </div>
-      <LabelModalFragment>
+      <Suspense fallback={null}>
         <ItemLabelModal label={label} />
         <DeleteLabelConfirmModal label={label} />
-      </LabelModalFragment>
+      </Suspense>
     </Fragment>
   );
 };

--- a/components/label/labelList/labelItem/labelItemButtonContent/index.tsx
+++ b/components/label/labelList/labelItem/labelItemButtonContent/index.tsx
@@ -1,0 +1,16 @@
+import { SvgIcon } from '@icon/svgIcon';
+import { optionsLabelItemRouteMatched, optionsLabelItemRouteUnmatched } from '@label/label.const';
+import { TypesLabel } from '@label/label.types';
+
+type Props = { matchedSlug: boolean } & Pick<TypesLabel, 'label'>;
+
+export const LabelItemButtonContent = ({ matchedSlug, label }: Props) => {
+  return (
+    <div className='flex w-full flex-row  px-2 py-2'>
+      <SvgIcon options={matchedSlug ? optionsLabelItemRouteMatched : optionsLabelItemRouteUnmatched} />
+      <div className='max-w-[10.7rem] truncate pl-2 text-gray-600 group-hover:text-gray-900'>
+        {label.name}
+      </div>
+    </div>
+  );
+};

--- a/components/label/labelList/labelItem/labelItemDropdown/dropdownContentOnClose/index.tsx
+++ b/components/label/labelList/labelItem/labelItemDropdown/dropdownContentOnClose/index.tsx
@@ -1,0 +1,17 @@
+import { TypesLabel } from '@label/label.types';
+import dynamic from 'next/dynamic';
+import { Suspense } from 'react';
+
+const TodosCount = dynamic(() => import('@layouts/app/todosCount').then((mod) => mod.TodosCount));
+
+type Props = Pick<TypesLabel, 'label'>;
+
+export const DropdownContentOnClose = ({ label }: Props) => {
+  return (
+    <span className='absolute right-[0.73rem] top-1/2 -translate-y-2/4 select-none text-xs tracking-tighter text-slate-400 group-hover:invisible'>
+      <Suspense fallback={null}>
+        <TodosCount label={label} />
+      </Suspense>
+    </span>
+  );
+};

--- a/components/label/labelList/labelItem/labelItemDropdown/index.tsx
+++ b/components/label/labelList/labelItem/labelItemDropdown/index.tsx
@@ -1,13 +1,13 @@
 import { ICON_DELETE, ICON_EDIT_NOTE } from '@data/materialSymbols';
 import { Types } from 'lib/types';
-import { Dropdown } from './dropdown';
-import { DropdownMenuItem } from './dropdown/dropdownMenuItem';
 import { optionsDropdownLabelItem } from '@options/misc';
 import { ActiveDropdownMenuItemEffect } from '@effects/activeDropdownMenuItemEffect';
 import { useLabelModalStateOpen } from '@hooks/modals';
 import { TypesOptionsDropdown } from '@lib/types/options';
 import { TypesLabel } from '@label/label.types';
 import { useLabelRemoveItem } from '@label/label.hooks';
+import { Dropdown } from '@dropdowns/v1/dropdown';
+import { DropdownMenuItem } from '@dropdowns/v1/dropdown/dropdownMenuItem';
 
 type Props = { options: TypesOptionsDropdown } & Pick<TypesLabel, 'label'> &
   Partial<Pick<Types, 'menuContentOnClose'>>;


### PR DESCRIPTION
Decompose LabelItem component into smaller, more focused components to enhance readability, testability, and maintainability. Specific changes include:

- Abstract conditional className logic within LabelItem.
- Introduce LabelItemButtonContent as an isolated component.
- Move LabelItemDropdown component into LabelItem folder for better organization.
- Introduce DropdownContentOnClose as a specialized component within labelItemDropdown.