### PR TITLE
test: Extend LabelItemButtonContent Testing

### DIFF
--- a/__mock__/label/index.ts
+++ b/__mock__/label/index.ts
@@ -1,0 +1,9 @@
+import { STYLE_COLORS } from '@data/stylePreset';
+import { Labels } from '@label/label.types';
+
+export const mockedLabelItem: Labels = {
+  _id: '9999',
+  name: 'test-label',
+  title_id: ['1', '3', '7', '2'],
+  color: STYLE_COLORS[Math.floor(Math.random() * STYLE_COLORS.length)],
+};

--- a/components/icon/svgIcon/index.tsx
+++ b/components/icon/svgIcon/index.tsx
@@ -11,6 +11,7 @@ export const SvgIcon = memo(({ options = {} }: TypesPropsOptionsSvg) => {
       width={options.width ?? '24'}
       viewBox={options.viewBox ?? VIEWBOX['24']}
       className={options.className ?? 'h-5 w-5 fill-gray-500 hover:fill-gray-700'}
+      data-testid='svgIcon-testid'
     >
       <path d={options.path} />
     </svg>

--- a/components/label/labelList/labelItem/labelItemButtonContent/__test__/labelItemButtonContent.test.tsx
+++ b/components/label/labelList/labelItem/labelItemButtonContent/__test__/labelItemButtonContent.test.tsx
@@ -1,0 +1,48 @@
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { screen } from '@testing-library/react';
+import { mockedLabelItem } from '__mock__/label';
+import { LabelItemButtonContent } from '..';
+
+describe('LabelItemButtonContent', () => {
+  const renderWithLabelItemButtonContent = (matchedSlug?: boolean) => {
+    const options = { session: null };
+    return renderWithRecoilRootAndSession(
+      <LabelItemButtonContent
+        label={mockedLabelItem}
+        matchedSlug={matchedSlug as boolean}
+      />,
+      options,
+    );
+  };
+
+  const classNameOnMatchedSlug = 'h-5 w-5 fill-yellow-500';
+  const classNameOnUnmatchedSlug = 'h-5 w-5 fill-gray-500 group-hover:fill-yellow-500 ';
+
+  it('should render the label.name as text', () => {
+    const { container } = renderWithLabelItemButtonContent();
+    const labelName = screen.queryByText(mockedLabelItem.name);
+
+    expect(container).toBeInTheDocument();
+    expect(labelName).toBeInTheDocument();
+  });
+
+  it('should render the proper SvgIcon when matchedSlug is true', () => {
+    const { container } = renderWithLabelItemButtonContent(true);
+    const svgIconComponent = screen.queryByTestId('svgIcon-testid');
+
+    expect(container).toBeInTheDocument();
+    expect(svgIconComponent).toBeInTheDocument();
+    expect(svgIconComponent).toHaveClass(classNameOnMatchedSlug);
+    expect(svgIconComponent).not.toHaveClass(classNameOnUnmatchedSlug);
+  });
+
+  it('should render the proper SvgIcon when matchedSlug is false', () => {
+    const { container } = renderWithLabelItemButtonContent(false);
+    const svgIconComponent = screen.queryByTestId('svgIcon-testid');
+
+    expect(container).toBeInTheDocument();
+    expect(svgIconComponent).toBeInTheDocument();
+    expect(svgIconComponent).not.toHaveClass(classNameOnMatchedSlug);
+    expect(svgIconComponent).toHaveClass(classNameOnUnmatchedSlug);
+  });
+});


### PR DESCRIPTION
Expand the scope of testing for the LabelItemButtonContent component by introducing unit/integration tests. Utilizing a mockedLabelItem, located under the '/__mock__/label/', allows for effective mocking of labelItem.

In order to facilitate accurate testing, a 'data-testid' attribute has been introduced to the SvgIcon component. Recognizing that usage of 'data-testid' is typically reserved for cases where no other testing options are viable, it is necessary in this instance due to the SvgIcon being a decorative component without other distinct attributes or elements available for testing.