### PR TITLE
feat(test): Refine testing methodology for efficiency

### DIFF
--- a/components/label/labelList/__test__/labelList.test.tsx
+++ b/components/label/labelList/__test__/labelList.test.tsx
@@ -1,35 +1,22 @@
 import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
-import { atomLabelModalOpen } from '@states/modals';
 import { screen, waitFor } from '@testing-library/react';
-import { atomUserSession } from '@user/user.states';
+import { UserSessionEffect } from '@user/userSessionGroupEffect/userSessionEffect';
 import { Session } from 'next-auth';
-import { Suspense, useEffect } from 'react';
-import { RecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { Suspense } from 'react';
+import { RecoilState } from 'recoil';
 import { LabelList } from '..';
 
 type Props<T> = { session: Session | null; userSession: boolean; node?: RecoilState<T> };
 
-const UserSession = ({ userSession }: { userSession: boolean }) => {
-  const setUserSession = useSetRecoilState(atomUserSession);
-  const currentSession = useRecoilValue(atomLabelModalOpen(undefined));
-
-  useEffect(() => {
-    setUserSession(userSession);
-    currentSession;
-  }, [currentSession, setUserSession, userSession]);
-
-  return null;
-};
-
 describe('LabelList', () => {
-  const renderWithLabelList = <T,>({ session, userSession, node }: Props<T>) => {
+  const renderWithLabelList = <T,>({ session, node }: Props<T>) => {
     const options = { session: session, node: node };
     return renderWithRecoilRootAndSession(
       <>
         <Suspense fallback={null}>
           <LabelList />
         </Suspense>
-        <UserSession userSession={userSession} />
+        <UserSessionEffect />
       </>,
       options,
     );

--- a/components/label/labelList/labelItem/labelItemDropdown/dropdownContentOnClose/__test__/dropdownContentOnClose.test.tsx
+++ b/components/label/labelList/labelItem/labelItemDropdown/dropdownContentOnClose/__test__/dropdownContentOnClose.test.tsx
@@ -1,21 +1,10 @@
+import { DATA_DEMO_LABELS } from '@label/label.data';
 import { Labels } from '@label/label.types';
 import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
 import { screen, waitFor } from '@testing-library/react';
-import { DropdownContentOnClose } from '..';
 import { mockedLabelItem } from '__mock__/label';
-import { DATA_DEMO_LABELS } from '@label/label.data';
-import { useSetRecoilState } from 'recoil';
-import { atomUserSession } from '@user/user.states';
-import { useEffect } from 'react';
-
-const UserSessionEffect = () => {
-  const setUserSession = useSetRecoilState(atomUserSession);
-
-  useEffect(() => {
-    setUserSession(false);
-  }, [setUserSession]);
-  return null;
-};
+import { DropdownContentOnClose } from '..';
+import { UserSessionEffect } from '@user/userSessionGroupEffect/userSessionEffect';
 
 describe('DropdownContentOnClose', () => {
   const renderWithDropdownContentOnClose = (mockedLabelItem: Labels) => {


### PR DESCRIPTION
In an effort to streamline the testing process, the manual UserSessionEffect running alongside the test session has been removed. Given the existing `UserSessionEffect` component which effectively returns the Recoil state upon assessing the Next-Auth Session state, the need for manual repetition is eliminated.

While the presence of `UserSessionEffect` within the testing environment remains vital for accurate session state triggering, further inclusion proves redundant.