### PR TITLE
refactor: Refactor LabelItemDropdown component

### DIFF
--- a/components/label/label.const.ts
+++ b/components/label/label.const.ts
@@ -1,6 +1,16 @@
 import { PATH_APP } from '@constAssertions/data';
-import { ICON_LABEL, ICON_LABEL_FILL, ICON_NEW_LABEL } from '@data/materialSymbols';
-import { TypesOptionsButton, TypesOptionsPrefetchRouterButton } from '@lib/types/options';
+import {
+  ICON_DELETE,
+  ICON_EDIT_NOTE,
+  ICON_LABEL,
+  ICON_LABEL_FILL,
+  ICON_NEW_LABEL,
+} from '@data/materialSymbols';
+import {
+  TypesOptionsButton,
+  TypesOptionsDropdown,
+  TypesOptionsPrefetchRouterButton,
+} from '@lib/types/options';
 import { classNames, paths } from '@stateLogics/utils';
 import { TypesLabel } from './label.types';
 import { STYLE_HOVER_ENABLED_SLATE_DARK } from '@data/stylePreset';
@@ -42,4 +52,20 @@ export const optionsLabelItemDropdown = (matchedSlug: boolean) => {
     isInitiallyVisible: false,
     hoverBg: matchedSlug ? 'hover:bg-blue-900 hover:bg-opacity-[0.07]' : STYLE_HOVER_ENABLED_SLATE_DARK,
   };
+};
+
+/**
+ * LabelItem Dropdown
+ * */
+
+export const optionsLabelItemDropdownEditLabel: TypesOptionsDropdown = {
+  shouldKeepOpeningOnClick: false,
+  path: ICON_EDIT_NOTE,
+  tooltip: 'Edit',
+};
+
+export const optionsLabelItemDropdownDelete: TypesOptionsDropdown = {
+  shouldKeepOpeningOnClick: false,
+  path: ICON_DELETE,
+  tooltip: 'Delete',
 };

--- a/components/label/labelList/labelItem/labelItemDropdown/index.tsx
+++ b/components/label/labelList/labelItem/labelItemDropdown/index.tsx
@@ -1,13 +1,13 @@
-import { ICON_DELETE, ICON_EDIT_NOTE } from '@data/materialSymbols';
-import { Types } from 'lib/types';
-import { optionsDropdownLabelItem } from '@options/misc';
-import { ActiveDropdownMenuItemEffect } from '@effects/activeDropdownMenuItemEffect';
-import { useLabelModalStateOpen } from '@hooks/modals';
-import { TypesOptionsDropdown } from '@lib/types/options';
-import { TypesLabel } from '@label/label.types';
-import { useLabelRemoveItem } from '@label/label.hooks';
 import { Dropdown } from '@dropdowns/v1/dropdown';
 import { DropdownMenuItem } from '@dropdowns/v1/dropdown/dropdownMenuItem';
+import { ActiveDropdownMenuItemEffect } from '@effects/activeDropdownMenuItemEffect';
+import { useLabelModalStateOpen } from '@hooks/modals';
+import { optionsLabelItemDropdownDelete, optionsLabelItemDropdownEditLabel } from '@label/label.const';
+import { useLabelRemoveItem } from '@label/label.hooks';
+import { TypesLabel } from '@label/label.types';
+import { TypesOptionsDropdown } from '@lib/types/options';
+import { optionsDropdownLabelItem } from '@options/misc';
+import { Types } from 'lib/types';
 
 type Props = { options: TypesOptionsDropdown } & Pick<TypesLabel, 'label'> &
   Partial<Pick<Types, 'menuContentOnClose'>>;
@@ -25,11 +25,7 @@ export const LabelItemDropdown = ({ label, options, menuContentOnClose }: Props)
       {/* give menuItemId any ID: string to activate the keyboard navigation */}
       <div className='py-1'>
         <DropdownMenuItem
-          options={{
-            shouldKeepOpeningOnClick: false,
-            path: ICON_EDIT_NOTE,
-            tooltip: 'Edit',
-          }}
+          options={optionsLabelItemDropdownEditLabel}
           onClick={() => openModal()}
         >
           Edit label
@@ -37,11 +33,7 @@ export const LabelItemDropdown = ({ label, options, menuContentOnClose }: Props)
       </div>
       <div className='py-1'>
         <DropdownMenuItem
-          options={{
-            shouldKeepOpeningOnClick: false,
-            path: ICON_DELETE,
-            tooltip: 'Delete',
-          }}
+          options={optionsLabelItemDropdownDelete}
           onClick={() => removeLabel()}
         >
           Delete


### PR DESCRIPTION
Enhances readability and maintainability by abstracting options props within LabelItemDropdown. The resulting extracted values have been relocated to `label.const`. This change aids in code clarity and fosters a more modular approach.