### PR TITLE
test: Add unit test for LabelItemDropdown

### DIFF
--- a/components/label/label.const.ts
+++ b/components/label/label.const.ts
@@ -4,6 +4,7 @@ import {
   ICON_EDIT_NOTE,
   ICON_LABEL,
   ICON_LABEL_FILL,
+  ICON_MORE_VERT,
   ICON_NEW_LABEL,
 } from '@data/materialSymbols';
 import {
@@ -14,6 +15,7 @@ import {
 import { classNames, paths } from '@stateLogics/utils';
 import { TypesLabel } from './label.types';
 import { STYLE_HOVER_ENABLED_SLATE_DARK } from '@data/stylePreset';
+import { TypesStyleAttributes } from '@lib/types';
 
 /**
  * LabelList
@@ -68,4 +70,16 @@ export const optionsLabelItemDropdownDelete: TypesOptionsDropdown = {
   shouldKeepOpeningOnClick: false,
   path: ICON_DELETE,
   tooltip: 'Delete',
+};
+
+export const optionsDropdownLabelItem = (hoverBg?: TypesStyleAttributes['hoverBg']): TypesOptionsDropdown => {
+  return {
+    tooltip: 'Menu',
+    path: ICON_MORE_VERT,
+    padding: 'p-[0.3rem]',
+    color: 'fill-gray-500 group-hover:fill-gray-700',
+    isPortal: true,
+    isInitiallyVisible: false,
+    hoverBg: hoverBg,
+  };
 };

--- a/components/label/labelList/labelItem/labelItemDropdown/__test__/labelItemDropdown.test.tsx
+++ b/components/label/labelList/labelItem/labelItemDropdown/__test__/labelItemDropdown.test.tsx
@@ -1,0 +1,104 @@
+import { Labels } from '@label/label.types';
+import { Types } from '@lib/types';
+import { DeleteLabelConfirmModal } from '@modals/confirmModal/deleteConfirmModal/deleteLabelConfirmModal';
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { mockedLabelItem } from '__mock__/label';
+import { Suspense } from 'react';
+import { LabelItemDropdown } from '..';
+import { LabelItem } from '../..';
+
+type Props = Types['menuContentOnClose'];
+
+const mockDeleteFunction = jest.fn();
+
+jest.mock('../..', () => ({
+  LabelItem: ({ label }: { label: Labels }) => <div>{label.name}</div>,
+}));
+
+jest.mock('@modals/confirmModal/deleteConfirmModal/deleteLabelConfirmModal', () => ({
+  DeleteLabelConfirmModal: () => <button onClick={() => mockDeleteFunction()}>Delete item</button>,
+}));
+
+describe('LabelItemDropdown', () => {
+  const renderWithLabelItemDropdown = (menuContentOnClose?: Props) => {
+    return renderWithRecoilRootAndSession(
+      <>
+        <LabelItemDropdown
+          label={mockedLabelItem}
+          options={{}} // currently LabelItemDropdown only has CSS effect as option
+          menuContentOnClose={menuContentOnClose}
+        />
+        <LabelItem label={mockedLabelItem} />
+        <Suspense fallback={null}>
+          {/* <ItemLabelModal label={mockedLabelItem} /> */}
+          <DeleteLabelConfirmModal label={mockedLabelItem} />
+        </Suspense>
+      </>,
+      { session: null },
+    );
+  };
+
+  it('should not initially render the dropdown menu', () => {
+    const { container } = renderWithLabelItemDropdown();
+    const editLabel = screen.queryByText(/Edit label/i);
+    const deleteLabel = screen.queryByText('Delete');
+    const dropdownIcon = screen.getByTestId('svgIcon-testid');
+
+    expect(container).toBeInTheDocument();
+    expect(editLabel).not.toBeInTheDocument();
+    expect(deleteLabel).not.toBeInTheDocument();
+    expect(dropdownIcon).toBeInTheDocument();
+  });
+
+  it('should render the dropdown menu on clicking the dropdown icon', async () => {
+    const { container } = renderWithLabelItemDropdown();
+    const dropdownIcon = screen.getByTestId('svgIcon-testid');
+
+    expect(container).toBeInTheDocument();
+    expect(dropdownIcon).toBeInTheDocument();
+
+    fireEvent.click(dropdownIcon);
+
+    await waitFor(() => {
+      const deleteLabel = screen.queryByText('Delete');
+      expect(deleteLabel).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      const editLabel = screen.queryByText(/Edit label/i);
+      expect(editLabel).toBeInTheDocument();
+    });
+  });
+
+  it('should render the mocked labelItem correctly', async () => {
+    const { container } = renderWithLabelItemDropdown();
+    const labelItem = screen.getByText('test-label');
+
+    expect(container).toBeInTheDocument();
+    expect(labelItem).toBeInTheDocument();
+  });
+
+  it('should mockDelete function is called when Delete button for labelItem is clicked', () => {
+    const { container } = renderWithLabelItemDropdown();
+    const dropdownIcon = screen.getByTestId('svgIcon-testid');
+    const labelItem = screen.getByText('test-label');
+
+    expect(container).toBeInTheDocument();
+    expect(labelItem).toBeInTheDocument();
+
+    fireEvent.click(dropdownIcon);
+
+    const deleteLabel = screen.getByText('Delete');
+    expect(deleteLabel).toBeInTheDocument();
+
+    fireEvent.click(deleteLabel);
+
+    const confirmDeleteButton = screen.getByText('Delete item');
+    expect(confirmDeleteButton).toBeInTheDocument();
+
+    fireEvent.click(confirmDeleteButton);
+
+    expect(mockDeleteFunction).toHaveBeenCalled();
+  });
+});

--- a/components/label/labelList/labelItem/labelItemDropdown/index.tsx
+++ b/components/label/labelList/labelItem/labelItemDropdown/index.tsx
@@ -2,11 +2,14 @@ import { Dropdown } from '@dropdowns/v1/dropdown';
 import { DropdownMenuItem } from '@dropdowns/v1/dropdown/dropdownMenuItem';
 import { ActiveDropdownMenuItemEffect } from '@effects/activeDropdownMenuItemEffect';
 import { useLabelModalStateOpen } from '@hooks/modals';
-import { optionsLabelItemDropdownDelete, optionsLabelItemDropdownEditLabel } from '@label/label.const';
+import {
+  optionsDropdownLabelItem,
+  optionsLabelItemDropdownDelete,
+  optionsLabelItemDropdownEditLabel,
+} from '@label/label.const';
 import { useLabelRemoveItem } from '@label/label.hooks';
 import { TypesLabel } from '@label/label.types';
 import { TypesOptionsDropdown } from '@lib/types/options';
-import { optionsDropdownLabelItem } from '@options/misc';
 import { Types } from 'lib/types';
 
 type Props = { options: TypesOptionsDropdown } & Pick<TypesLabel, 'label'> &
@@ -18,7 +21,7 @@ export const LabelItemDropdown = ({ label, options, menuContentOnClose }: Props)
 
   return (
     <Dropdown
-      options={{ hoverBg: options.hoverBg, isInitiallyVisible: false, ...optionsDropdownLabelItem }}
+      options={optionsDropdownLabelItem(options.hoverBg)}
       menuContentOnClose={menuContentOnClose}
     >
       <ActiveDropdownMenuItemEffect menuItemId={null} />

--- a/lib/data/options/misc.tsx
+++ b/lib/data/options/misc.tsx
@@ -1,5 +1,5 @@
 import { POSITION_X, POSITION_Y } from '@constAssertions/ui';
-import { ICON_MORE_VERT, ICON_NEW_LABEL } from '@data/materialSymbols';
+import { ICON_NEW_LABEL } from '@data/materialSymbols';
 import { TypesOptionsDropdown, TypesOptionsMinimizedModalTransition } from '@lib/types/options';
 import { classNames } from '@stateLogics/utils';
 
@@ -23,14 +23,6 @@ export const optionsDropdownComboBox: TypesOptionsDropdown = {
   menuItemsWidth: 'w-72',
   isPortal: true,
   borderRadius: 'rounded-lg',
-};
-// labels
-export const optionsDropdownLabelItem: TypesOptionsDropdown = {
-  tooltip: 'Menu',
-  path: ICON_MORE_VERT,
-  padding: 'p-[0.3rem]',
-  color: 'fill-gray-500 group-hover:fill-gray-700',
-  isPortal: true,
 };
 
 /**


### PR DESCRIPTION
The optionsLabelItemDropdown prop has been relocated into label.const for better maintainability. A new unit test has been added for LabelItemDropdown. This test does not run all the functional logics of each dropdown item, as this is a unit test. The actual implementation and integration will be covered within the integration test.