### PR TITLE
test: Implement integration test for LabelItem

### DIFF
--- a/components/label/labelList/labelItem/__test__/labelItem.test.tsx
+++ b/components/label/labelList/labelItem/__test__/labelItem.test.tsx
@@ -1,0 +1,192 @@
+import { useInitialNavigation } from '@hooks/layouts';
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { atomNavigationOpen } from '@states/layouts';
+import { fireEvent, waitFor } from '@testing-library/dom';
+import { screen } from '@testing-library/react';
+import { UserSessionEffect } from '@user/userSessionGroupEffect/userSessionEffect';
+import { mockedLabelItem } from '__mock__/label';
+import mockRouter from 'next-router-mock';
+import { Suspense, useEffect } from 'react';
+import { RecoilState, useRecoilValue } from 'recoil';
+import { LabelItem } from '..';
+import { atomConfirmModalDelete, atomLabelModalOpen } from '@states/modals';
+
+jest.mock('@modals/labelModals/labelModal/itemLabelModal', () => ({
+  ItemLabelModal: () => {
+    const modalState = useRecoilValue(atomLabelModalOpen(mockedLabelItem._id));
+    const modalStateWithText = modalState ? 'labelItemModal is visible' : null;
+    return <div>{modalStateWithText}</div>;
+  },
+}));
+
+jest.mock('@modals/confirmModal/deleteConfirmModal/deleteLabelConfirmModal', () => ({
+  DeleteLabelConfirmModal: () => {
+    const deleteModalState = useRecoilValue(atomConfirmModalDelete(mockedLabelItem._id));
+    const deleteModalStateWithText = deleteModalState ? 'deleteModal is open' : null;
+    return <div>{deleteModalStateWithText}</div>;
+  },
+}));
+
+const InitialNavigationEffect = ({ isBreakpointMd }: { isBreakpointMd: boolean }) => {
+  const setInitial = useInitialNavigation({ layoutType: 'app' });
+  const mockValue = isBreakpointMd;
+
+  useEffect(() => {
+    !mockValue && setInitial();
+  }, [mockValue, setInitial]);
+  return null;
+};
+
+describe('LabelItem', () => {
+  const renderWithLabelItem = <T,>(node?: RecoilState<T>, isBreakpointMd?: boolean) => {
+    const options = { session: null, node: node };
+    return renderWithRecoilRootAndSession(
+      <>
+        <LabelItem label={mockedLabelItem} />
+        <UserSessionEffect />
+        <Suspense fallback={null}>
+          <InitialNavigationEffect isBreakpointMd={isBreakpointMd ?? false} />
+        </Suspense>
+      </>,
+      options,
+    );
+  };
+
+  it('should render the mockedLabel name', async () => {
+    const { container } = renderWithLabelItem();
+
+    expect(container).toBeInTheDocument();
+    await waitFor(() => {
+      const labelName = screen.queryByText(mockedLabelItem.name);
+      expect(labelName).toBeInTheDocument();
+    });
+  });
+
+  it('should render the correct className based on the slug matched to the id of label', async () => {
+    mockRouter.push('/');
+    const matchedPath = `/app/label/${mockedLabelItem._id}`;
+    const { container } = renderWithLabelItem();
+    const divElement = screen.getByTestId('labelItem-testid');
+    const baseClassName =
+      'group relative flex w-full cursor-pointer flex-row items-center justify-between rounded-lg pr-[0.20rem]';
+    const unmatchedSlugClassName = 'hover:bg-slate-200 hover:bg-opacity-80 ';
+    const matchedSlugClassName = 'bg-blue-100 font-semibold text-opacity-80';
+
+    expect(container).toBeInTheDocument();
+    expect(divElement).toBeInTheDocument();
+    expect(divElement).toHaveClass(baseClassName);
+    expect(divElement).toHaveClass(unmatchedSlugClassName);
+    expect(divElement).not.toHaveClass(matchedSlugClassName);
+
+    await waitFor(() => {
+      mockRouter.push(matchedPath);
+    });
+
+    expect(divElement).toBeInTheDocument();
+    expect(divElement).toHaveClass(baseClassName);
+    expect(divElement).not.toHaveClass(unmatchedSlugClassName);
+    expect(divElement).toHaveClass(matchedSlugClassName);
+  });
+
+  it('should route to the label id based slug when the label button is clicked', async () => {
+    mockRouter.push('/');
+    const expectedRoute = `/app/label/${mockedLabelItem._id}`;
+    const { container } = renderWithLabelItem();
+    const labelButton = screen.getByText(mockedLabelItem.name);
+
+    expect(container).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(labelButton).toBeInTheDocument();
+    });
+
+    expect(mockRouter).toMatchObject({ pathname: '/' });
+
+    fireEvent.click(labelButton);
+
+    expect(mockRouter).not.toMatchObject({ pathname: '/' });
+    expect(mockRouter).toMatchObject({ pathname: expectedRoute });
+  });
+
+  it('should show active text when media query is above medium width, 768px', async () => {
+    const layoutType = 'app';
+    const { container } = renderWithLabelItem(atomNavigationOpen(layoutType), false);
+    const labelButton = screen.getByText(mockedLabelItem.name);
+    const navigationOpen = screen.getByText('active');
+
+    expect(container).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(labelButton).toBeInTheDocument();
+    });
+    expect(navigationOpen).toBeInTheDocument();
+  });
+
+  it('should render the LabelItemDropdown correctly', async () => {
+    const { container } = renderWithLabelItem();
+    const labelItemDropdownName = screen.getByText(mockedLabelItem.name);
+
+    expect(container).toBeInTheDocument();
+    await waitFor(() => {
+      expect(labelItemDropdownName).toBeInTheDocument();
+    });
+  });
+
+  it('should render the mocked ItemLabelModal correctly when modal is triggered to open', async () => {
+    const { container } = renderWithLabelItem();
+    const itemLabelModalText = 'labelItemModal is visible';
+    const dropdownButton = screen.getByTestId('dropdown-svgIcon-testid');
+
+    expect(container).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(dropdownButton).toBeInTheDocument();
+    });
+
+    fireEvent.click(dropdownButton);
+
+    const modalButton = await screen.findByText('Edit label');
+    expect(modalButton).toBeInTheDocument();
+
+    await waitFor(() => {
+      const mockItemLabelModal = screen.queryByText(itemLabelModalText);
+      expect(mockItemLabelModal).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(modalButton);
+
+    await waitFor(() => {
+      const mockItemLabelModal = screen.queryByText(itemLabelModalText);
+      expect(mockItemLabelModal).toBeInTheDocument();
+    });
+  });
+
+  it('should render the mocked DeleteLabelConfirmModal correctly when modal is triggered to open', async () => {
+    const deleteLabelConfirmModalText = 'deleteModal is open';
+    const { container } = renderWithLabelItem();
+    const dropdownButton = screen.getByTestId('dropdown-svgIcon-testid');
+
+    expect(container).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(dropdownButton).toBeInTheDocument();
+    });
+
+    fireEvent.click(dropdownButton);
+
+    const modalButton = await screen.findByText('Delete');
+    expect(modalButton).toBeInTheDocument();
+
+    await waitFor(() => {
+      const mockItemLabelModal = screen.queryByText(deleteLabelConfirmModalText);
+      expect(mockItemLabelModal).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(modalButton);
+
+    await waitFor(() => {
+      const mockItemLabelModal = screen.queryByText(deleteLabelConfirmModalText);
+      expect(mockItemLabelModal).toBeInTheDocument();
+    });
+  });
+});

--- a/components/label/labelList/labelItem/index.tsx
+++ b/components/label/labelList/labelItem/index.tsx
@@ -35,7 +35,10 @@ export const LabelItem = ({ label }: Pick<TypesLabel, 'label'>) => {
 
   return (
     <Fragment>
-      <div className={labelItemClassName}>
+      <div
+        className={labelItemClassName}
+        data-testid='labelItem-testid'
+      >
         <div className='mr-[0.5rem] inline-block w-full'>
           <PrefetchRouterButton
             options={optionsLabelItemPrefetchButton(label)}

--- a/components/label/labelList/labelItem/labelItemDropdown/__test__/labelItemDropdown.test.tsx
+++ b/components/label/labelList/labelItem/labelItemDropdown/__test__/labelItemDropdown.test.tsx
@@ -43,7 +43,7 @@ describe('LabelItemDropdown', () => {
     const { container } = renderWithLabelItemDropdown();
     const editLabel = screen.queryByText(/Edit label/i);
     const deleteLabel = screen.queryByText('Delete');
-    const dropdownIcon = screen.getByTestId('svgIcon-testid');
+    const dropdownIcon = screen.getByTestId('dropdown-svgIcon-testid');
 
     expect(container).toBeInTheDocument();
     expect(editLabel).not.toBeInTheDocument();
@@ -53,7 +53,7 @@ describe('LabelItemDropdown', () => {
 
   it('should render the dropdown menu on clicking the dropdown icon', async () => {
     const { container } = renderWithLabelItemDropdown();
-    const dropdownIcon = screen.getByTestId('svgIcon-testid');
+    const dropdownIcon = screen.getByTestId('dropdown-svgIcon-testid');
 
     expect(container).toBeInTheDocument();
     expect(dropdownIcon).toBeInTheDocument();
@@ -81,7 +81,7 @@ describe('LabelItemDropdown', () => {
 
   it('should mockDelete function is called when Delete button for labelItem is clicked', () => {
     const { container } = renderWithLabelItemDropdown();
-    const dropdownIcon = screen.getByTestId('svgIcon-testid');
+    const dropdownIcon = screen.getByTestId('dropdown-svgIcon-testid');
     const labelItem = screen.getByText('test-label');
 
     expect(container).toBeInTheDocument();

--- a/components/ui/dropdowns/v1/dropdown/index.tsx
+++ b/components/ui/dropdowns/v1/dropdown/index.tsx
@@ -82,6 +82,7 @@ export const Dropdown = ({ menuButtonContent, menuContentOnClose, children, show
                           options.size ?? 'h-5 w-5',
                           options.color ?? 'fill-gray-500 group-hover:fill-gray-700',
                         ),
+                        testId: 'dropdown-svgIcon-testid',
                       }}
                     />
                     {menuButtonContent && (


### PR DESCRIPTION
Incorporate an integration test for LabelItem, validating functional integrity with its child components. Given the complexities of Portal utilization within modal rendering, associated modals like LabelItemModal and LabelDeleteConfirmModal are mocked to facilitate successful integration testing.