### PR TITLE
fix: Relocate comments for docker-image-deploy

### DIFF
--- a/.github/workflows/docker-image-deploy.yml
+++ b/.github/workflows/docker-image-deploy.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
 
+      # NOTE:
+      # --min-instances=1 \ #Set to more than 1 to reduce the cold starts
+      # --no-cpu-throttling \ #Set the CPU always on, which reduces the cost of CPU (25%) and memory (20%) usage. Only useful when min-instance is more than 1 or continuous CPU usage occurs. To set up 'CPU is only allocated during request processing', --cpu-throttling
+      # --cpu-boost \ # this feature does not provide benefit if there is min instances more than 0 as well as CPU always on (aka --no-cpu-throttling)
+
       - name: Deploy to Google Cloud Run
         run: |-
           gcloud run deploy ${{ github.event.repository.name }} \
@@ -29,9 +34,8 @@ jobs:
             --region ${{ secrets.GCR_DEPLOY_REGION }} \
             --platform ${{ secrets.GCR_PLATFORM }} \
             --allow-unauthenticated \
-            --min-instances=1 \ #Set to more than 1 to reduce the cold starts 
-            --no-cpu-throttling \ #Set the CPU always on, which reduces the cost of CPU and memory usage by 25%. Only useful when min-instance is more than 1 or continuous CPU usage occurs. To set up 'CPU is only allocated during request processing', --cpu-throttling
-            # --cpu-boost \ # this feature does not provide benefit if there is min instances more than 0 as well as CPU always on (aka --no-cpu-throttling)
+            --min-instances=1 \ 
+            --no-cpu-throttling \ 
             --vpc-connector ${{ secrets.GCR_VPC_CONNECTOR }} \
             --vpc-egress ${{ secrets.GCR_VPC_EGRESS }} \
             --region ${{ secrets.GCR_VPC_REGION }} \


### PR DESCRIPTION
The comments on the deploy arguments for Google Cloud Run were causing deployment failures due to unknown argument errors. This commit relocates the comments outside of the arguments, resolving the issue.