### PR TITLE
feat: Adjust Next.js configurations

### DIFF
--- a/configs/securityHeaders.js
+++ b/configs/securityHeaders.js
@@ -7,7 +7,7 @@ const ContentSecurityPolicy = `
   child-src 'self' youtube.com;
   font-src 'self';
   img-src 'self' ${process.env.NEXT_PUBLIC_IMAGE_DOMAIN} data:;
-  style-src 'self'; 
+  ${development ? `style-src 'self' 'unsafe-inline'` : `style-src 'self'`};
   ${
     development
       ? `script-src 'self' 'unsafe-eval' 'unsafe-inline' ${scriptSources}`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,31 +2,79 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@collections/*": ["lib/data/collections/*"],
-      "@constAssertions/*": ["lib/data/constAssertions/*"],
-      "@options/*": ["lib/data/options/*"],
-      "@effects/*": ["lib/stateLogics/effects/*"],
-      "@hooks/*": ["lib/stateLogics/hooks/*"],
-      "@states/*": ["lib/stateLogics/states/*"],
-      "@data/*": ["lib/data/*"],
-      "@stateLogics/*": ["lib/stateLogics/*"],
-      "@lib/*": ["lib/*"],
-      "@auth/*": ["components/auth/*"],
-      "@editor/*": ["components/editor/*"],
-      "@icon/*": ["components/icon/*"],
-      "@label/*": ["components/label/*"],
-      "@user/*": ["components/user/*"],
-      "@layouts/*": ["components/layouts/*"],
-      "@buttons/*": ["components/ui/buttons/*"],
-      "@dropdowns/*": ["components/ui/dropdowns/*"],
-      "@inputs/*": ["components/ui/inputs/*"],
-      "@modals/*": ["components/ui/modals/*"],
-      "@tooltips/*": ["components/ui/tooltips/*"],
-      "@ui/*": ["components/ui/*"],
-      "@components/*": ["components/*"]
+      "@collections/*": [
+        "lib/data/collections/*"
+      ],
+      "@constAssertions/*": [
+        "lib/data/constAssertions/*"
+      ],
+      "@options/*": [
+        "lib/data/options/*"
+      ],
+      "@effects/*": [
+        "lib/stateLogics/effects/*"
+      ],
+      "@hooks/*": [
+        "lib/stateLogics/hooks/*"
+      ],
+      "@states/*": [
+        "lib/stateLogics/states/*"
+      ],
+      "@data/*": [
+        "lib/data/*"
+      ],
+      "@stateLogics/*": [
+        "lib/stateLogics/*"
+      ],
+      "@lib/*": [
+        "lib/*"
+      ],
+      "@auth/*": [
+        "components/auth/*"
+      ],
+      "@editor/*": [
+        "components/editor/*"
+      ],
+      "@icon/*": [
+        "components/icon/*"
+      ],
+      "@label/*": [
+        "components/label/*"
+      ],
+      "@user/*": [
+        "components/user/*"
+      ],
+      "@layouts/*": [
+        "components/layouts/*"
+      ],
+      "@buttons/*": [
+        "components/ui/buttons/*"
+      ],
+      "@dropdowns/*": [
+        "components/ui/dropdowns/*"
+      ],
+      "@inputs/*": [
+        "components/ui/inputs/*"
+      ],
+      "@modals/*": [
+        "components/ui/modals/*"
+      ],
+      "@tooltips/*": [
+        "components/ui/tooltips/*"
+      ],
+      "@ui/*": [
+        "components/ui/*"
+      ],
+      "@components/*": [
+        "components/*"
+      ]
     },
     "target": "esnext",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -38,8 +86,22 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "global.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules", "__tests__"]
+  "include": [
+    "next-env.d.ts",
+    "global.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "__tests__"
+  ]
 }


### PR DESCRIPTION
In the development environment, `unsafe-inline` is added to the Next.js configuration under securityHeaders to ease debugging. Contrarily, it's removed in the production environment to enhance security.