### PR TITLE
feat: Add the alias path for Layout

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -33,6 +33,7 @@ const customJestConfig = {
     '^@editor/(.*)$': ['<rootDir>/components/editor/$1'],
     '^@icon/(.*)$': ['<rootDir>/components/icon/$1'],
     '^@label/(.*)$': ['<rootDir>/components/label/$1'],
+    '^@layout/(.*)$': ['<rootDir>/components/layout/$1'],
     '^@user/(.*)$': ['<rootDir>/components/user/$1'],
     '^@layouts/(.*)$': ['<rootDir>/components/layouts/$1'],
     '^@buttons/(.*)$': ['<rootDir>/components/ui/buttons/$1'],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,79 +2,32 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@collections/*": [
-        "lib/data/collections/*"
-      ],
-      "@constAssertions/*": [
-        "lib/data/constAssertions/*"
-      ],
-      "@options/*": [
-        "lib/data/options/*"
-      ],
-      "@effects/*": [
-        "lib/stateLogics/effects/*"
-      ],
-      "@hooks/*": [
-        "lib/stateLogics/hooks/*"
-      ],
-      "@states/*": [
-        "lib/stateLogics/states/*"
-      ],
-      "@data/*": [
-        "lib/data/*"
-      ],
-      "@stateLogics/*": [
-        "lib/stateLogics/*"
-      ],
-      "@lib/*": [
-        "lib/*"
-      ],
-      "@auth/*": [
-        "components/auth/*"
-      ],
-      "@editor/*": [
-        "components/editor/*"
-      ],
-      "@icon/*": [
-        "components/icon/*"
-      ],
-      "@label/*": [
-        "components/label/*"
-      ],
-      "@user/*": [
-        "components/user/*"
-      ],
-      "@layouts/*": [
-        "components/layouts/*"
-      ],
-      "@buttons/*": [
-        "components/ui/buttons/*"
-      ],
-      "@dropdowns/*": [
-        "components/ui/dropdowns/*"
-      ],
-      "@inputs/*": [
-        "components/ui/inputs/*"
-      ],
-      "@modals/*": [
-        "components/ui/modals/*"
-      ],
-      "@tooltips/*": [
-        "components/ui/tooltips/*"
-      ],
-      "@ui/*": [
-        "components/ui/*"
-      ],
-      "@components/*": [
-        "components/*"
-      ]
+      "@collections/*": ["lib/data/collections/*"],
+      "@constAssertions/*": ["lib/data/constAssertions/*"],
+      "@options/*": ["lib/data/options/*"],
+      "@effects/*": ["lib/stateLogics/effects/*"],
+      "@hooks/*": ["lib/stateLogics/hooks/*"],
+      "@states/*": ["lib/stateLogics/states/*"],
+      "@data/*": ["lib/data/*"],
+      "@stateLogics/*": ["lib/stateLogics/*"],
+      "@lib/*": ["lib/*"],
+      "@auth/*": ["components/auth/*"],
+      "@editor/*": ["components/editor/*"],
+      "@icon/*": ["components/icon/*"],
+      "@label/*": ["components/label/*"],
+      "@layout/*": ["components/layout/*"],
+      "@layouts/*": ["components/layouts/*"],
+      "@user/*": ["components/user/*"],
+      "@buttons/*": ["components/ui/buttons/*"],
+      "@dropdowns/*": ["components/ui/dropdowns/*"],
+      "@inputs/*": ["components/ui/inputs/*"],
+      "@modals/*": ["components/ui/modals/*"],
+      "@tooltips/*": ["components/ui/tooltips/*"],
+      "@ui/*": ["components/ui/*"],
+      "@components/*": ["components/*"]
     },
     "target": "esnext",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -93,15 +46,6 @@
       }
     ]
   },
-  "include": [
-    "next-env.d.ts",
-    "global.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "__tests__"
-  ]
+  "include": ["next-env.d.ts", "global.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules", "__tests__"]
 }


### PR DESCRIPTION
Add alias path for Layout in `tsconfig` and `jest.config`. Purpose of this
change is to facilitate modular restructuring of the layout component. The
modification ensures ease of reference and provides a solid base for
future restructuring enhancements.
