### PR TITLE
refactor: Rename `layoutType` and relocate type definition

### DIFF
--- a/components/label/labelList/labelItem/__test__/labelItem.test.tsx
+++ b/components/label/labelList/labelItem/__test__/labelItem.test.tsx
@@ -28,7 +28,7 @@ jest.mock('@modals/confirmModal/deleteConfirmModal/deleteLabelConfirmModal', () 
 }));
 
 const InitialNavigationEffect = ({ isBreakpointMd }: { isBreakpointMd: boolean }) => {
-  const setInitial = useInitialNavigation({ layoutType: 'app' });
+  const setInitial = useInitialNavigation({ path: 'app' });
   const mockValue = isBreakpointMd;
 
   useEffect(() => {
@@ -88,7 +88,7 @@ describe('LabelItem', () => {
     expect(divElement).toHaveClass(matchedSlugClassName);
   });
 
-  it('should route to the label id based slug when the label button is clicked', async () => {
+  it('should name to the label id based slug when the label button is clicked', async () => {
     mockRouter.push('/');
     const expectedRoute = `/app/label/${mockedLabelItem._id}`;
     const { container } = renderWithLabelItem();

--- a/components/layouts/app/index.tsx
+++ b/components/layouts/app/index.tsx
@@ -32,13 +32,13 @@ export const LayoutApp = ({ children }: Props) => {
       </Head>
       <HeaderFragment>
         <div className='flex h-screen flex-col'>
-          <LayoutHeader layoutType='app'>
+          <LayoutHeader path='app'>
             <SearchBar />
             <Suspense fallback={null}>
               <User />
             </Suspense>
           </LayoutHeader>
-          <LayoutFooter layoutType='app'>
+          <LayoutFooter path='app'>
             <FooterBody>{children}</FooterBody>
           </LayoutFooter>
         </div>

--- a/components/layouts/home/homeNavigation.tsx
+++ b/components/layouts/home/homeNavigation.tsx
@@ -2,18 +2,18 @@ import { PrefetchRouterButton } from '@buttons/button/prefetchRouterButton';
 import { DATA_HOME } from '@collections/home';
 import { PATH_HOME } from '@constAssertions/data';
 import { STYLE_BUTTON_NORMAL_BLACK, STYLE_LINK_NORMAL } from '@data/stylePreset';
+import { TypesLayout } from '@layouts/layout.types';
 import { SignInButton } from '@layouts/layoutHeader/signInButton';
-import { Types } from '@lib/types';
 import { classNames } from '@stateLogics/utils';
 import { DividerX } from '@ui/dividers/dividerX';
 import { DividerY } from '@ui/dividers/dividerY';
 import Link from 'next/link';
 
-type Props = Pick<Types, 'layoutType'>;
+type Props = Pick<TypesLayout, 'path'>;
 
-export const HomeNavigation = ({ layoutType }: Props) => {
-  const layoutApp = layoutType === 'app';
-  const layoutHome = layoutType === 'home';
+export const HomeNavigation = ({ path }: Props) => {
+  const layoutApp = path === 'app';
+  const layoutHome = path === 'home';
   const optionsRouter = {
     path: PATH_HOME['demo'],
     className: classNames(STYLE_BUTTON_NORMAL_BLACK, 'ml:ml-2 max-ml:w-full'),
@@ -27,12 +27,14 @@ export const HomeNavigation = ({ layoutType }: Props) => {
         layoutApp && 'flex-row items-center space-x-10 pr-3 sm:pr-8',
         layoutHome &&
           'flex-col bg-slate-50 max-ml:space-y-4 max-ml:rounded-b-xl max-ml:px-5 max-ml:pb-8 max-ml:pt-[6rem] ml:flex ml:flex-row ml:items-center ml:space-x-3 ml:bg-transparent ml:pr-0 lg:pr-3',
-      )}>
+      )}
+    >
       {DATA_HOME.map((path) => (
         <div key={path.name}>
           <Link
             href={path.path}
-            className={classNames(STYLE_LINK_NORMAL)}>
+            className={classNames(STYLE_LINK_NORMAL)}
+          >
             {path.name}
           </Link>
         </div>
@@ -41,7 +43,8 @@ export const HomeNavigation = ({ layoutType }: Props) => {
       <div>
         <Link
           href={PATH_HOME['contact']}
-          className={classNames(STYLE_LINK_NORMAL)}>
+          className={classNames(STYLE_LINK_NORMAL)}
+        >
           Contact
         </Link>
       </div>

--- a/components/layouts/home/index.tsx
+++ b/components/layouts/home/index.tsx
@@ -20,7 +20,7 @@ type Props = {
 
 export const LayoutHome = ({ children }: Props) => {
   const slug = useRecoilValue(atomHtmlTitleTag);
-  const layoutType = 'home';
+  const path = 'home';
 
   return (
     <LayoutFragment>
@@ -29,10 +29,10 @@ export const LayoutHome = ({ children }: Props) => {
       </Head>
       <main className='flex min-h-screen flex-col justify-between'>
         <div>
-          <LayoutHeader layoutType={layoutType}>
-            <HomeNavigation layoutType={layoutType} />
+          <LayoutHeader path={path}>
+            <HomeNavigation path={path} />
           </LayoutHeader>
-          <LayoutFooter layoutType={layoutType} />
+          <LayoutFooter path={path} />
           {children}
         </div>
         <Footer />

--- a/components/layouts/layout.types.ts
+++ b/components/layouts/layout.types.ts
@@ -1,0 +1,3 @@
+export interface TypesLayout {
+  path: 'app' | 'home';
+}

--- a/components/layouts/layoutFooter/footerNavigation.tsx
+++ b/components/layouts/layoutFooter/footerNavigation.tsx
@@ -1,4 +1,5 @@
 import { useNavigationOpen } from '@hooks/layouts';
+import { TypesLayout } from '@layouts/layout.types';
 import { Types } from '@lib/types';
 import { classNames } from '@stateLogics/utils';
 import { selectorNavigationOpenOnMobile } from '@states/layouts';
@@ -6,35 +7,34 @@ import { Backdrop } from '@ui/backdrops/backdrop';
 import { Fragment as FooterSidebarFragment, forwardRef } from 'react';
 import { useRecoilValue } from 'recoil';
 
-type Props = Pick<Types, 'children' | 'layoutType'>;
+type Props = Pick<Types, 'children'> & Pick<TypesLayout, 'path'>;
 
-export const FooterNavigation = forwardRef<HTMLDivElement, Props>(
-  ({ layoutType, children }: Props, ref) => {
-    const setNavigationOpen = useNavigationOpen();
-    const isSidebarMobileOpen = useRecoilValue(selectorNavigationOpenOnMobile);
-    const layoutHome = layoutType === 'home';
-    const layoutApp = layoutType === 'app';
+export const FooterNavigation = forwardRef<HTMLDivElement, Props>(({ path, children }: Props, ref) => {
+  const setNavigationOpen = useNavigationOpen();
+  const isSidebarMobileOpen = useRecoilValue(selectorNavigationOpenOnMobile);
+  const layoutHome = path === 'home';
+  const layoutApp = path === 'app';
 
-    return (
-      <FooterSidebarFragment>
-        <Backdrop
-          options={{ isPortal: false }}
-          show={isSidebarMobileOpen}
-          onClick={() => setNavigationOpen()}
-        />
-        <div
-          ref={ref}
-          className={classNames(
-            'fixed z-30 ml:z-auto',
-            layoutApp &&
-              'left-0 top-0 w-72 bg-slate-50 pl-2 pr-0 pt-3 md:top-[4.6rem] md:flex md:w-full md:max-w-[16.5rem] md:flex-col md:bg-transparent md:pl-2 md:pr-0 md:pt-0',
-            layoutHome && 'top-[0rem] w-full',
-          )}>
-          {children}
-        </div>
-      </FooterSidebarFragment>
-    );
-  },
-);
+  return (
+    <FooterSidebarFragment>
+      <Backdrop
+        options={{ isPortal: false }}
+        show={isSidebarMobileOpen}
+        onClick={() => setNavigationOpen()}
+      />
+      <div
+        ref={ref}
+        className={classNames(
+          'fixed z-30 ml:z-auto',
+          layoutApp &&
+            'left-0 top-0 w-72 bg-slate-50 pl-2 pr-0 pt-3 md:top-[4.6rem] md:flex md:w-full md:max-w-[16.5rem] md:flex-col md:bg-transparent md:pl-2 md:pr-0 md:pt-0',
+          layoutHome && 'top-[0rem] w-full',
+        )}
+      >
+        {children}
+      </div>
+    </FooterSidebarFragment>
+  );
+});
 
 FooterNavigation.displayName = 'FooterNavigation';

--- a/components/layouts/layoutFooter/index.tsx
+++ b/components/layouts/layoutFooter/index.tsx
@@ -7,20 +7,22 @@ import { selectorNavigationOpen } from '@states/layouts';
 import { Fragment as FooterBodyFragment, Fragment, Fragment as LayoutFooterFragment } from 'react';
 import { useRecoilValue } from 'recoil';
 import { FooterNavigation } from './footerNavigation';
+import { TypesLayout } from '@layouts/layout.types';
 
-type Props = Pick<Types, 'layoutType'> & Partial<Pick<Types, 'children'>>;
+type Props = Pick<TypesLayout, 'path'> & Partial<Pick<Types, 'children'>>;
 
-export const LayoutFooter = ({ children, layoutType }: Props) => {
+export const LayoutFooter = ({ children, path }: Props) => {
   const isSidebarOpen = useRecoilValue(selectorNavigationOpen);
-  const layoutApp = layoutType === 'app';
-  const layoutHome = layoutType === 'home';
+  const layoutApp = path === 'app';
+  const layoutHome = path === 'home';
 
   return (
     <LayoutFooterFragment>
       <div className='flex h-full flex-row'>
         <Transition.Root
           show={isSidebarOpen}
-          as='div'>
+          as='div'
+        >
           <Transition.Child
             as={isSidebarOpen ? Fragment : 'div'}
             enter='transition transform ease-in-out duration-200'
@@ -44,11 +46,12 @@ export const LayoutFooter = ({ children, layoutType }: Props) => {
               'transform opacity-0',
               layoutApp && '-translate-x-5',
               layoutHome && '-translate-y-5',
-            )}>
+            )}
+          >
             {isSidebarOpen && (
-              <FooterNavigation layoutType={layoutType}>
+              <FooterNavigation path={path}>
                 {layoutApp && <AppNavigation />}
-                {layoutHome && <HomeNavigation layoutType={layoutType} />}
+                {layoutHome && <HomeNavigation path={path} />}
               </FooterNavigation>
             )}
           </Transition.Child>

--- a/components/layouts/layoutHeader/index.tsx
+++ b/components/layouts/layoutHeader/index.tsx
@@ -13,17 +13,18 @@ import { useRecoilValue } from 'recoil';
 import { Logo } from './logo';
 import { NavigationButton } from './navigationButton';
 import { atomNavigationOpen } from '@states/layouts';
+import { TypesLayout } from '@layouts/layout.types';
 
 const UserSessionGroupEffect = dynamic(() =>
   import('@user/userSessionGroupEffect').then((mod) => mod.UserSessionGroupEffect),
 );
 
-type Props = Partial<Pick<Types, 'children'>> & Pick<Types, 'layoutType'>;
+type Props = Partial<Pick<Types, 'children'>> & Pick<TypesLayout, 'path'>;
 
-export const LayoutHeader = ({ children, layoutType }: Props) => {
-  const layoutHome = layoutType === 'home';
-  const layoutApp = layoutType === 'app';
-  const isSidebarOpen = useRecoilValue(atomNavigationOpen(layoutType));
+export const LayoutHeader = ({ children, path }: Props) => {
+  const layoutHome = path === 'home';
+  const layoutApp = path === 'app';
+  const isSidebarOpen = useRecoilValue(atomNavigationOpen(path));
   const scrollPosition = useVerticalScrollPosition();
   const homeSidebarClose = layoutHome && !isSidebarOpen && scrollPosition;
 

--- a/components/layouts/layoutHeader/signInButton.tsx
+++ b/components/layouts/layoutHeader/signInButton.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@buttons/button';
 import { PATH_HOME } from '@constAssertions/data';
 import { STYLE_BUTTON_NORMAL_BLUE } from '@data/stylePreset';
-import { Types } from '@lib/types';
+import { TypesLayout } from '@layouts/layout.types';
 import { TypesOptionsButton } from '@lib/types/options';
 import { classNames } from '@stateLogics/utils';
 import { atomLayoutType } from '@states/layouts';
@@ -12,8 +12,8 @@ import { useRecoilValue } from 'recoil';
 
 type Props = { options?: Partial<TypesOptionsButton> };
 
-const buttonOptionsHandler = (layoutType: Types['layoutType']) => {
-  const layoutHome = layoutType === 'home';
+const buttonOptionsHandler = (route: TypesLayout['path']) => {
+  const layoutHome = route === 'home';
   return {
     className: classNames('max-ml:w-full', STYLE_BUTTON_NORMAL_BLUE, layoutHome && 'max-ml:mb-3'),
     tooltip: 'Sign in',

--- a/lib/stateLogics/effects/layout.tsx
+++ b/lib/stateLogics/effects/layout.tsx
@@ -15,11 +15,11 @@ import { useRecoilValue } from 'recoil';
 import { GroupEffects } from './groupEffects';
 
 export const LayoutHomeGroupEffects = () => {
-  const layoutType = 'home';
+  const path = 'home';
   const filterPath = useFilterPathHome();
-  const setNavigation = useInitialNavigation({ layoutType: layoutType });
-  const setLayoutType = useLayoutType({ layoutType: layoutType });
-  const setBodyTagClass = useLayoutBodyTagClass({ layoutType: layoutType });
+  const setNavigation = useInitialNavigation({ path: path });
+  const setLayoutType = useLayoutType({ path: path });
+  const setBodyTagClass = useLayoutBodyTagClass({ path: path });
 
   return (
     <>
@@ -30,10 +30,10 @@ export const LayoutHomeGroupEffects = () => {
 
 export const LayoutAppGroupEffects = () => {
   const filterPath = useFilterPathApp();
-  const setNavigation = useInitialNavigation({ layoutType: 'app' });
-  const setLayoutType = useLayoutType({ layoutType: 'app' });
+  const setNavigation = useInitialNavigation({ path: 'app' });
+  const setLayoutType = useLayoutType({ path: 'app' });
   const catchTodoModal = useRecoilValue(atomCatch(CATCH.todoModal));
-  const setBodyTagClass = useLayoutBodyTagClass({ layoutType: 'app' });
+  const setBodyTagClass = useLayoutBodyTagClass({ path: 'app' });
 
   return (
     <>

--- a/lib/stateLogics/hooks/layouts.tsx
+++ b/lib/stateLogics/hooks/layouts.tsx
@@ -1,5 +1,8 @@
 import { PATH_APP, PATH_HOME, PATH_IMAGE_APP } from '@constAssertions/data';
 import { BREAKPOINT } from '@constAssertions/ui';
+import { atomLabelQuerySlug, selectorSessionLabels } from '@label/label.states';
+import { Labels } from '@label/label.types';
+import { TypesLayout } from '@layouts/layout.types';
 import { atomEffectMediaQuery } from '@states/atomEffects/misc';
 import { atomLayoutType, atomNavigationOpen } from '@states/layouts';
 import { atomFilterEffect, atomHtmlTitleTag, atomPathnameImage } from '@states/misc';
@@ -7,9 +10,6 @@ import { useRouter } from 'next/router';
 import { useCallback } from 'react';
 import { RecoilValue, useRecoilCallback, useRecoilValue } from 'recoil';
 import { useNextQuery } from './misc';
-import { atomLabelQuerySlug, selectorSessionLabels } from '@label/label.states';
-import { Labels } from '@label/label.types';
-import { Types } from '@lib/types';
 
 export const useNavigationOpen = () => {
   const layoutType = useRecoilValue(atomLayoutType);
@@ -68,11 +68,11 @@ export const useFilterPathApp = () => {
   });
 };
 
-export const useInitialNavigation = ({ layoutType }: Pick<Types, 'layoutType'>) => {
+export const useInitialNavigation = ({ path }: Pick<TypesLayout, 'path'>) => {
   const breakPointMd = useRecoilValue(atomEffectMediaQuery(BREAKPOINT['md']));
   const breakPointMl = useRecoilValue(atomEffectMediaQuery(BREAKPOINT['ml']));
   return useRecoilCallback(({ set }) => () => {
-    const breakpointMd = layoutType === 'app' ? breakPointMd : breakPointMl;
+    const breakpointMd = path === 'app' ? breakPointMd : breakPointMl;
 
     if (breakpointMd) {
       set(atomNavigationOpen('app'), true);
@@ -84,17 +84,17 @@ export const useInitialNavigation = ({ layoutType }: Pick<Types, 'layoutType'>) 
   });
 };
 
-export const useLayoutType = ({ layoutType }: Pick<Types, 'layoutType'>) => {
+export const useLayoutType = ({ path }: Pick<TypesLayout, 'path'>) => {
   return useRecoilCallback(({ set }) => () => {
-    set(atomLayoutType, layoutType);
+    set(atomLayoutType, path);
   });
 };
 
-export const useLayoutBodyTagClass = ({ layoutType }: Pick<Types, 'layoutType'>) => {
+export const useLayoutBodyTagClass = ({ path }: Pick<TypesLayout, 'path'>) => {
   const layoutBodyHandler = useCallback(() => {
-    if (layoutType === 'app') return document.body.classList.add('overflow-hidden');
+    if (path === 'app') return document.body.classList.add('overflow-hidden');
     return document.body.classList.remove('overflow-hidden');
-  }, [layoutType]);
+  }, [path]);
 
   return layoutBodyHandler;
 };

--- a/lib/stateLogics/states/layouts.tsx
+++ b/lib/stateLogics/states/layouts.tsx
@@ -1,12 +1,12 @@
-import { Types } from '@lib/types';
+import { BREAKPOINT } from '@constAssertions/ui';
+import { TypesLayout } from '@layouts/layout.types';
 import { atom, atomFamily, selector } from 'recoil';
 import { atomEffectMediaQuery } from './atomEffects/misc';
-import { BREAKPOINT } from '@constAssertions/ui';
 
 /**
  * Atoms
  **/
-export const atomNavigationOpen = atomFamily<boolean, Types['layoutType']>({
+export const atomNavigationOpen = atomFamily<boolean, TypesLayout['path']>({
   key: 'atomNavigationOpen',
   default: false,
 });
@@ -16,7 +16,7 @@ export const atomSearchInput = atom({
   default: '',
 });
 
-export const atomLayoutType = atom<Types['layoutType']>({
+export const atomLayoutType = atom<TypesLayout['path']>({
   key: 'atomLayoutType',
   default: 'app',
 });

--- a/lib/types/bases/ui.ts
+++ b/lib/types/bases/ui.ts
@@ -145,7 +145,6 @@ export interface TypesElement {
   onKeyDown: KeyboardEventHandler<HTMLElement>;
   positionX: POSITION_X;
   positionY: POSITION_Y;
-  layoutType: 'app' | 'home';
   minimizedModalPadding: string;
   isNoValidate: boolean;
   isAriaHidden: boolean;


### PR DESCRIPTION
Renaming `layoutType` to `path` enhances clarity and aligns with coding conventions. The associated type definition now resides in a new file, layout.type, under the TypesLayout interface for better organization and readability.