### PR TITLE
refactor: Update the layoutButtonOptionsHandler

### DIFF
--- a/components/layouts/layout.utils.ts
+++ b/components/layouts/layout.utils.ts
@@ -1,0 +1,11 @@
+import { STYLE_BUTTON_NORMAL_BLUE } from '@data/stylePreset';
+import { classNames } from '@stateLogics/utils';
+import { TypesLayout } from './layout.types';
+
+export const optionsSignInButton = (path: TypesLayout['path']) => {
+  const layoutHome = path === 'home';
+  return {
+    className: classNames('max-ml:w-full', STYLE_BUTTON_NORMAL_BLUE, layoutHome && 'max-ml:mb-3'),
+    tooltip: 'Sign in',
+  };
+};

--- a/components/layouts/layoutHeader/signInButton.tsx
+++ b/components/layouts/layoutHeader/signInButton.tsx
@@ -1,9 +1,7 @@
 import { Button } from '@buttons/button';
 import { PATH_HOME } from '@constAssertions/data';
-import { STYLE_BUTTON_NORMAL_BLUE } from '@data/stylePreset';
-import { TypesLayout } from '@layouts/layout.types';
+import { optionsSignInButton } from '@layouts/layout.utils';
 import { TypesOptionsButton } from '@lib/types/options';
-import { classNames } from '@stateLogics/utils';
 import { atomLayoutType } from '@states/layouts';
 import { signIn } from 'next-auth/react';
 import router from 'next/router';
@@ -12,31 +10,21 @@ import { useRecoilValue } from 'recoil';
 
 type Props = { options?: Partial<TypesOptionsButton> };
 
-const buttonOptionsHandler = (route: TypesLayout['path']) => {
-  const layoutHome = route === 'home';
-  return {
-    className: classNames('max-ml:w-full', STYLE_BUTTON_NORMAL_BLUE, layoutHome && 'max-ml:mb-3'),
-    tooltip: 'Sign in',
-  };
-};
-
 export const SignInButton = ({ options }: Props) => {
   const { signInButtonName = 'Sign in' } = options ?? {};
-  const layoutType = useRecoilValue(atomLayoutType);
-  const buttonOptions = buttonOptionsHandler(layoutType);
+  const layoutPath = useRecoilValue(atomLayoutType);
+  const optionsButton = optionsSignInButton(layoutPath);
 
   useEffect(() => {
     router.prefetch(PATH_HOME['auth']);
   }, []);
 
   return (
-    <>
-      <Button
-        options={options ?? buttonOptions}
-        onClick={() => signIn()}
-      >
-        {signInButtonName}
-      </Button>
-    </>
+    <Button
+      options={options ?? optionsButton}
+      onClick={() => signIn()}
+    >
+      {signInButtonName}
+    </Button>
   );
 };


### PR DESCRIPTION
Rename the `layoutButtonOptionsHandler` to `optionsSignInButton`, and move to the new location: /layout/layout.utils.ts for better management.