### PR TITLE
fix: Resolve Mobile Navigation Rendering Issue

### DIFF
--- a/components/layout/layout.hooks.ts
+++ b/components/layout/layout.hooks.ts
@@ -36,21 +36,19 @@ export const useInitialNavigation = ({ path }: Pick<TypesLayout, 'path'>) => {
   const breakPointMd = useRecoilValue(atomEffectMediaQuery(BREAKPOINT['md']));
   const breakPointMl = useRecoilValue(atomEffectMediaQuery(BREAKPOINT['ml']));
 
-  return useRecoilCallback(
-    ({ set }) =>
-      () => {
-        const breakpointMd = path === 'app' ? breakPointMd : breakPointMl;
+  return useRecoilCallback(({ set }) => () => {
+    const breakpointMd = path === 'app' ? breakPointMd : breakPointMl;
 
-        if (breakpointMd) {
-          set(atomNavigationOpen('app'), true);
-          set(atomNavigationOpen('home'), false);
-          return;
-        }
-        set(atomNavigationOpen('app'), false);
-        set(atomNavigationOpen('home'), false);
-      },
-    [breakPointMd, breakPointMl, path],
-  );
+    if (breakpointMd) {
+      set(atomNavigationOpen('app'), true);
+      set(atomNavigationOpen('home'), false);
+      return;
+    }
+    set(atomNavigationOpen('app'), false);
+    set(atomNavigationOpen('home'), false);
+  });
+  // should not use any dependency to create the hook on every rendering.
+  // This should reset the initial state on every route change.
 };
 
 export const useLayoutType = ({ path }: Pick<TypesLayout, 'path'>) => {


### PR DESCRIPTION
Address an issue where mobileNavigation remained open upon route changes. The cause was due to the `useInitialNavigation` hook having dependencies, which led to state caching and consequently, the mobileNavigation persisting in the open state.

As the purpose of `useInitialNavigation` is to set the initial state of navigation for each render in the home layout, removing the dependencies successfully resolves the issue.