### PR TITLE
fix: Refine homeMobileNavigation's rendering transition

### DIFF
--- a/components/layout/layoutFooter/footerNavigation/index.tsx
+++ b/components/layout/layoutFooter/footerNavigation/index.tsx
@@ -1,27 +1,16 @@
-import { useNavigationOpen } from '@layout/layout.hooks';
 import { TypesLayout } from '@layout/layout.types';
 import { Types } from '@lib/types';
 import { classNames } from '@stateLogics/utils';
-import { selectorNavigationOpenOnMobile } from '@states/layouts';
-import { Backdrop } from '@ui/backdrops/backdrop';
 import { Fragment as FooterSidebarFragment, forwardRef } from 'react';
-import { useRecoilValue } from 'recoil';
 
 type Props = Pick<Types, 'children'> & Pick<TypesLayout, 'path'>;
 
 export const FooterNavigation = forwardRef<HTMLDivElement, Props>(({ path, children }: Props, ref) => {
-  const setNavigationOpen = useNavigationOpen();
-  const isSidebarMobileOpen = useRecoilValue(selectorNavigationOpenOnMobile);
   const layoutHome = path === 'home';
   const layoutApp = path === 'app';
 
   return (
     <FooterSidebarFragment>
-      <Backdrop
-        options={{ isPortal: false }}
-        show={isSidebarMobileOpen}
-        onClick={() => setNavigationOpen()}
-      />
       <div
         ref={ref}
         className={classNames(

--- a/components/layout/layoutFooter/index.tsx
+++ b/components/layout/layoutFooter/index.tsx
@@ -1,18 +1,22 @@
 import { Transition } from '@headlessui/react';
 import { AppNavigation } from '@layout/app/appNavigation';
 import { HomeNavigation } from '@layout/home/homeNavigation';
+import { useNavigationOpen } from '@layout/layout.hooks';
+import { TypesLayout } from '@layout/layout.types';
 import { Types } from '@lib/types';
 import { classNames } from '@stateLogics/utils';
-import { selectorNavigationOpen } from '@states/layouts';
+import { selectorNavigationBreakpoint, selectorNavigationOpen } from '@states/layouts';
+import { Backdrop } from '@ui/backdrops/backdrop';
 import { Fragment as FooterBodyFragment, Fragment, Fragment as LayoutFooterFragment } from 'react';
 import { useRecoilValue } from 'recoil';
 import { FooterNavigation } from './footerNavigation';
-import { TypesLayout } from '@layout/layout.types';
 
 type Props = Pick<TypesLayout, 'path'> & Partial<Pick<Types, 'children'>>;
 
 export const LayoutFooter = ({ children, path }: Props) => {
   const isSidebarOpen = useRecoilValue(selectorNavigationOpen);
+  const breakpoint = useRecoilValue(selectorNavigationBreakpoint);
+  const setNavigationOpen = useNavigationOpen();
   const layoutApp = path === 'app';
   const layoutHome = path === 'home';
 
@@ -23,8 +27,14 @@ export const LayoutFooter = ({ children, path }: Props) => {
           show={isSidebarOpen}
           as='div'
         >
+          {!breakpoint ? (
+            <Backdrop
+              options={{ isPortal: false }}
+              onClick={() => setNavigationOpen()}
+            />
+          ) : null}
           <Transition.Child
-            as={isSidebarOpen ? Fragment : 'div'}
+            as={Fragment}
             enter='transition transform ease-in-out duration-200'
             enterFrom={classNames(
               'transform opacity-0',
@@ -36,7 +46,7 @@ export const LayoutFooter = ({ children, path }: Props) => {
               layoutApp && 'translate-x-0',
               layoutHome && 'translate-y-0',
             )}
-            leave='transition ease-in-out duration-150'
+            leave='transition ease-in-out duration-200'
             leaveFrom={classNames(
               'transform opacity-100',
               layoutApp && 'translate-x-0',
@@ -48,12 +58,10 @@ export const LayoutFooter = ({ children, path }: Props) => {
               layoutHome && '-translate-y-5',
             )}
           >
-            {isSidebarOpen && (
-              <FooterNavigation path={path}>
-                {layoutApp && <AppNavigation />}
-                {layoutHome && <HomeNavigation path={path} />}
-              </FooterNavigation>
-            )}
+            <FooterNavigation path={path}>
+              {layoutApp && <AppNavigation />}
+              {layoutHome && <HomeNavigation path={path} />}
+            </FooterNavigation>
           </Transition.Child>
         </Transition.Root>
         <FooterBodyFragment>{children}</FooterBodyFragment>

--- a/components/ui/backdrops/backdrop/index.tsx
+++ b/components/ui/backdrops/backdrop/index.tsx
@@ -3,44 +3,33 @@ import { Transition } from '@headlessui/react';
 import { Types } from '@lib/types';
 import { TypesOptionsBackdrop } from '@lib/types/options';
 import { classNames } from '@stateLogics/utils';
-import { Fragment as BackdropFragment, Fragment, useEffect, useRef, useState } from 'react';
+import { Fragment as BackdropFragment, Fragment, useEffect, useRef } from 'react';
 
-type Props = { options: TypesOptionsBackdrop } & Partial<
-  Pick<Types, 'onClick' | 'show' | 'onBlur' | 'onFocus'>
->;
+type Props = { options: TypesOptionsBackdrop } & Partial<Pick<Types, 'onClick' | 'onBlur' | 'onFocus'>>;
 
-export const Backdrop = ({ options, onClick, onBlur, onFocus, show }: Props) => {
-  const [isShow, setIsShow] = useState(false);
+export const Backdrop = ({ options, onClick, onBlur, onFocus }: Props) => {
   const divRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const currentRef = divRef && divRef.current;
-    !show && setIsShow(true);
 
     if (!currentRef) return;
     currentRef.blur();
     currentRef.focus();
-  }, [show]);
+  }, []);
 
   return (
     <BackdropFragment>
       <ConditionalPortal isPortal={options.isPortal ?? true}>
-        <Transition
-          show={show ?? isShow}
+        <Transition.Child
           as={Fragment}
-          appear={true}
-          enter={classNames(
-            'transition-opacity ease-in-out',
-            options.enterDuration ?? 'duration-500',
-          )}
+          enter={classNames('transition-opacity ease-in-out', options.enterDuration ?? 'duration-500')}
           enterFrom='opacity-0'
           enterTo='opacity-100'
-          leave={classNames(
-            'transition-opacity ease-in-out',
-            options.leaveDuration ?? 'duration-100',
-          )}
-          leaveFrom='opacity-100'
-          leaveTo='opacity-0'>
+          leave={classNames('transition-opacity ease-in-out', options.leaveDuration ?? 'duration-200')}
+          leaveFrom='opacity-0'
+          leaveTo='opacity-0'
+        >
           <div
             tabIndex={-1}
             className={classNames(
@@ -54,7 +43,7 @@ export const Backdrop = ({ options, onClick, onBlur, onFocus, show }: Props) => 
             onFocus={onFocus}
             ref={divRef}
           />
-        </Transition>
+        </Transition.Child>
       </ConditionalPortal>
     </BackdropFragment>
   );

--- a/lib/stateLogics/states/layouts.tsx
+++ b/lib/stateLogics/states/layouts.tsx
@@ -35,16 +35,16 @@ export const selectorNavigationOpen = selector({
   },
 });
 
-export const selectorNavigationOpenOnMobile = selector({
-  key: 'selectorNavigationOpenOnMobile',
+export const selectorNavigationBreakpoint = selector({
+  key: 'selectorNavigationBreakpoint',
   get: ({ get }) => {
     const layoutType = get(atomLayoutType);
-    const breakpointMedium =
+    const breakpoint =
       layoutType === 'app'
         ? get(atomEffectMediaQuery(BREAKPOINT['md']))
         : get(atomEffectMediaQuery(BREAKPOINT['ml']));
 
-    return !breakpointMedium && get(atomNavigationOpen(layoutType));
+    return breakpoint;
   },
   cachePolicy_UNSTABLE: {
     eviction: 'most-recent',


### PR DESCRIPTION
Amend the rendering transition behavior of homeMobileNavigation which is targeted for mobile-sized media queries. The primary issue addressed is the incorrect transition effect, notably the absence of the expected rendering duration, causing the navigation menu to appear instantaneously.

The root cause is identified as a structural problem where the backdrop wasn't rendered appropriately because its state wasn’t in sync with the navigation menu’s state. By restructuring the backdrop as a child transition of the navigation menu, the issue is mitigated.

Additionally, small rendering issues have been rectified by eliminating conditional rendering that was initially intended to suppress routing between the app and home route. The resolution for this will be fully effective with the subsequent commit.