### PR TITLE
fix: Resolve navigation transition glitch on mobile

### DIFF
--- a/components/layout/app/layoutAppLazy/index.tsx
+++ b/components/layout/app/layoutAppLazy/index.tsx
@@ -29,10 +29,10 @@ export const LayoutAppLazy = ({ path }: Pick<TypesLayout, 'path'>) => {
 
   return (
     <Suspense fallback={null}>
-      <FilterPathAppEffect />
       <LayoutTypeEffect path={path} />
-      <InitialNavigationEffect path={path} />
-      <BodyTagClassEffect path={path} />
+      <FilterPathAppEffect />
+      <InitialNavigationEffect />
+      <BodyTagClassEffect />
       <Notification />
       <TodoModal />
       <MinimizedModal />

--- a/components/layout/home/layoutHomeLazy/index.tsx
+++ b/components/layout/home/layoutHomeLazy/index.tsx
@@ -21,10 +21,10 @@ const BodyTagClassEffect = dynamic(() =>
 export const LayoutHomeLazy = ({ path }: Pick<TypesLayout, 'path'>) => {
   return (
     <Suspense fallback={null}>
-      <FilterPathHomeEffect />
       <LayoutTypeEffect path={path} />
-      <InitialNavigationEffect path={path} />
-      <BodyTagClassEffect path={path} />
+      <FilterPathHomeEffect />
+      <InitialNavigationEffect />
+      <BodyTagClassEffect />
     </Suspense>
   );
 };

--- a/components/layout/layoutEffects/bodyTagClassEffect/index.tsx
+++ b/components/layout/layoutEffects/bodyTagClassEffect/index.tsx
@@ -1,9 +1,11 @@
 import { useLayoutBodyTagClass } from '@layout/layout.hooks';
-import { TypesLayout } from '@layout/layout.types';
+import { atomLayoutType } from '@states/layouts';
 import { useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
 
-export const BodyTagClassEffect = ({ path }: Pick<TypesLayout, 'path'>) => {
-  const setBodyTagClass = useLayoutBodyTagClass({ path: path });
+export const BodyTagClassEffect = () => {
+  const layoutType = useRecoilValue(atomLayoutType);
+  const setBodyTagClass = useLayoutBodyTagClass({ path: layoutType });
 
   useEffect(() => {
     setBodyTagClass();

--- a/components/layout/layoutEffects/initialNavigationEffect/index.tsx
+++ b/components/layout/layoutEffects/initialNavigationEffect/index.tsx
@@ -1,9 +1,11 @@
 import { useInitialNavigation } from '@layout/layout.hooks';
-import { TypesLayout } from '@layout/layout.types';
+import { atomLayoutType } from '@states/layouts';
 import { useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
 
-export const InitialNavigationEffect = ({ path }: Pick<TypesLayout, 'path'>) => {
-  const setNavigation = useInitialNavigation({ path: path });
+export const InitialNavigationEffect = () => {
+  const layoutType = useRecoilValue(atomLayoutType);
+  const setNavigation = useInitialNavigation({ path: layoutType });
 
   useEffect(() => {
     setNavigation();

--- a/components/layout/layoutFooter/footerBody/index.tsx
+++ b/components/layout/layoutFooter/footerBody/index.tsx
@@ -1,7 +1,7 @@
 import { GRADIENT_POSITION, GRADIENT_TYPE } from '@constAssertions/ui';
 import { Types } from '@lib/types';
 import { classNames } from '@stateLogics/utils';
-import { selectorNavigationOpen } from '@states/layouts';
+import { atomLayoutType, atomNavigationOpen } from '@states/layouts';
 import { atomDisableScroll } from '@states/misc';
 import { GlobalVerticalGradient } from '@ui/gradients/globalVerticalGradient';
 import { useRecoilValue } from 'recoil';
@@ -9,7 +9,8 @@ import { useRecoilValue } from 'recoil';
 type Props = Pick<Types, 'children'>;
 
 export const FooterBody = ({ children }: Props) => {
-  const isSidebarOpen = useRecoilValue(selectorNavigationOpen);
+  const layoutType = useRecoilValue(atomLayoutType);
+  const isSidebarOpen = useRecoilValue(atomNavigationOpen(layoutType));
   const isScrollDisabled = useRecoilValue(atomDisableScroll);
 
   return (

--- a/components/layout/layoutFooter/sidebarTransition/index.tsx
+++ b/components/layout/layoutFooter/sidebarTransition/index.tsx
@@ -1,7 +1,7 @@
 import { Transition } from '@headlessui/react';
 import { useNavigationOpen } from '@layout/layout.hooks';
 import { classNames } from '@stateLogics/utils';
-import { selectorNavigationBreakpoint, selectorNavigationOpen } from '@states/layouts';
+import { atomNavigationOpen, selectorNavigationBreakpoint } from '@states/layouts';
 import { Backdrop } from '@ui/backdrops/backdrop';
 import { Fragment, ReactNode } from 'react';
 import { useRecoilValue } from 'recoil';
@@ -11,7 +11,7 @@ import { TypesLayout } from '@layout/layout.types';
 type Props = Pick<TypesLayout, 'path'> & { children: ReactNode };
 
 export const SidebarTransition = ({ path, children }: Props) => {
-  const isSidebarOpen = useRecoilValue(selectorNavigationOpen);
+  const isSidebarOpen = useRecoilValue(atomNavigationOpen(path));
   const breakpoint = useRecoilValue(selectorNavigationBreakpoint);
   const setNavigationOpen = useNavigationOpen();
   const layoutApp = path === 'app';

--- a/lib/stateLogics/states/layouts.tsx
+++ b/lib/stateLogics/states/layouts.tsx
@@ -24,16 +24,6 @@ export const atomLayoutType = atom<TypesLayout['path']>({
 /**
  * Selector
  **/
-export const selectorNavigationOpen = selector({
-  key: 'selectorNavigationOpen',
-  get: ({ get }) => {
-    const layoutType = get(atomLayoutType);
-    return get(atomNavigationOpen(layoutType));
-  },
-  cachePolicy_UNSTABLE: {
-    eviction: 'most-recent',
-  },
-});
 
 export const selectorNavigationBreakpoint = selector({
   key: 'selectorNavigationBreakpoint',


### PR DESCRIPTION
Resolve a flickering issue in the mobile navigation menu when transitioning between '/app' and '/' routes. The issue was traced back to a Recoil selector that was not updating promptly. Replacing the selector with atomNavigationOpen effectively mitigates the problem. Additionally, the commit streamlines the component props by utilizing atomLayoutType.