### PR TITLE
fix: Resolve homeNavigation transition backdrop flickering

### DIFF
--- a/components/layout/layoutFooter/sidebarTransition/index.tsx
+++ b/components/layout/layoutFooter/sidebarTransition/index.tsx
@@ -33,7 +33,7 @@ export const SidebarTransition = ({ path, children }: Props) => {
         enter='transition transform ease-in-out duration-200'
         enterFrom={classNames(
           'transform opacity-0',
-          layoutApp && 'md:-translate-x-0 -translate-x-5',
+          layoutApp && 'md:-translate-x-0 -translate-x-10',
           layoutHome && '-translate-y-5',
         )}
         enterTo={classNames(
@@ -41,7 +41,7 @@ export const SidebarTransition = ({ path, children }: Props) => {
           layoutApp && 'translate-x-0',
           layoutHome && 'translate-y-0',
         )}
-        leave='transition ease-in-out duration-200'
+        leave='transition transform ease-in-out duration-200'
         leaveFrom={classNames(
           'transform opacity-100',
           layoutApp && 'translate-x-0',
@@ -49,7 +49,7 @@ export const SidebarTransition = ({ path, children }: Props) => {
         )}
         leaveTo={classNames(
           'transform opacity-0',
-          layoutApp && '-translate-x-5',
+          layoutApp && '-translate-x-10',
           layoutHome && '-translate-y-5',
         )}
       >

--- a/components/ui/backdrops/backdrop/index.tsx
+++ b/components/ui/backdrops/backdrop/index.tsx
@@ -23,10 +23,10 @@ export const Backdrop = ({ options, onClick, onBlur, onFocus }: Props) => {
       <ConditionalPortal isPortal={options.isPortal ?? true}>
         <Transition.Child
           as={Fragment}
-          enter={classNames('transition-opacity ease-in-out', options.enterDuration ?? 'duration-500')}
+          enter={classNames('transition-opacity ease-in-out', options.enterDuration ?? 'duration-300')}
           enterFrom='opacity-0'
           enterTo='opacity-100'
-          leave={classNames('transition-opacity ease-in-out', options.leaveDuration ?? 'duration-200')}
+          leave={classNames('transition-opacity ease-in-out', options.leaveDuration ?? 'duration-100')}
           leaveFrom='opacity-0'
           leaveTo='opacity-0'
         >

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "mongoose": "^7.2.2",
         "next": "^13.4.4",
         "next-auth": "^4.22.1",
-        "next-router-mock": "^0.9.3",
+        "next-router-mock": "^0.9.6",
         "nodemailer": "^6.9.3",
         "react": "^18.2.0",
         "react-device-detect": "^2.2.3",
@@ -7418,9 +7418,9 @@
       }
     },
     "node_modules/next-router-mock": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/next-router-mock/-/next-router-mock-0.9.3.tgz",
-      "integrity": "sha512-jl8eFe71LpMVGeBMpoxILkGfEgGY7IfLy8XPyv05/o61p5oQRNpoMmk46VMxRIpt0fI8XcvznBZKpDK6vbYQcQ==",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/next-router-mock/-/next-router-mock-0.9.6.tgz",
+      "integrity": "sha512-ezX+4ZlnVPi63/wjvJ5Cnf+0k/H6VdjAitRs+UX+6rzOfuRLC6q72clAa43xIwBkAV3uHxWqzE9CK5S8h1c7tg==",
       "peerDependencies": {
         "next": ">=10.0.0",
         "react": ">=17.0.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "mongoose": "^7.2.2",
     "next": "^13.4.4",
     "next-auth": "^4.22.1",
-    "next-router-mock": "^0.9.3",
+    "next-router-mock": "^0.9.6",
     "nodemailer": "^6.9.3",
     "react": "^18.2.0",
     "react-device-detect": "^2.2.3",


### PR DESCRIPTION
The flickering of the homeNavigation transition backdrop stemmed from
a disparity in the leave duration of the backdrop transition compared to
the navigation transition. Reducing the leave duration of the backdrop
effectively mitigates the flickering. The commit also enhances the enter
and leave transition behavior of the navigationMenu.
