### PR TITLE
chore: Update securityHeaders with image source URL

### DIFF
--- a/configs/securityHeaders.js
+++ b/configs/securityHeaders.js
@@ -3,7 +3,8 @@ const scriptSources = require('./scriptSources');
 const development = process.env.NODE_ENV !== 'production';
 
 const ContentSecurityPolicy = `
-  default-src 'self'; connect-src 'self'; 
+  default-src 'self'; 
+  connect-src 'self' ${process.env.NEXT_PUBLIC_IMAGE_DOMAIN};  
   child-src 'self' youtube.com;
   font-src 'self';
   img-src 'self' ${process.env.NEXT_PUBLIC_IMAGE_DOMAIN} data:;


### PR DESCRIPTION
Add the image source URL to securityHeaders' 'connect-src' for pre-loading of external image URLs, enhancing webWorker's efficiency by fulfilling preloading requirements.