### PR TITLE
fix: Correct Routing Issue under '/app'

### DIFF
--- a/components/layout/layout.hooks.ts
+++ b/components/layout/layout.hooks.ts
@@ -3,13 +3,24 @@ import { BREAKPOINT } from '@constAssertions/ui';
 import { atomEffectMediaQuery } from '@states/atomEffects/misc';
 import { atomLayoutType, atomNavigationOpen } from '@states/layouts';
 import { atomFilterEffect, atomHtmlTitleTag, atomPathnameImage } from '@states/misc';
-import { useRouter } from 'next-router-mock';
 import { RecoilValue, useRecoilCallback, useRecoilValue } from 'recoil';
 import { TypesLayout } from './layout.types';
 import { useCallback } from 'react';
 import { useNextQuery } from '@hooks/misc';
 import { selectorSessionLabels, atomLabelQuerySlug } from '@label/label.states';
 import { Labels } from '@label/label.types';
+import { useRouter } from 'next/router';
+
+export const useNavigationOpen = () => {
+  const layoutType = useRecoilValue(atomLayoutType);
+  return useRecoilCallback(
+    ({ set }) =>
+      () => {
+        set(atomNavigationOpen(layoutType), (event) => !event);
+      },
+    [layoutType],
+  );
+};
 
 export const useFilterPathHome = () => {
   const { asPath } = useRouter();
@@ -66,17 +77,6 @@ export const useLayoutBodyTagClass = ({ path }: Pick<TypesLayout, 'path'>) => {
     if (path === 'app') return document.body.classList.add('overflow-hidden');
     return document.body.classList.remove('overflow-hidden');
   }, [path]);
-};
-
-export const useNavigationOpen = () => {
-  const layoutType = useRecoilValue(atomLayoutType);
-  return useRecoilCallback(
-    ({ set }) =>
-      () => {
-        set(atomNavigationOpen(layoutType), (event) => !event);
-      },
-    [layoutType],
-  );
 };
 
 export const useFilterPathApp = () => {

--- a/configs/securityHeaders.js
+++ b/configs/securityHeaders.js
@@ -3,7 +3,8 @@ const scriptSources = require('./scriptSources');
 const development = process.env.NODE_ENV !== 'production';
 
 const ContentSecurityPolicy = `
-  default-src 'self'; connect-src 'self'; 
+  default-src 'self'; 
+  connect-src 'self' ${process.env.NEXT_PUBLIC_IMAGE_DOMAIN};  
   child-src 'self' youtube.com;
   font-src 'self';
   img-src 'self' ${process.env.NEXT_PUBLIC_IMAGE_DOMAIN} data:;


### PR DESCRIPTION
Routing under '/app' was failing due to an incorrect module import.
'useRoute' was previously imported from 'next-router-mock' instead of
'next/router'. This has been corrected to restore proper routing for
'/app' and its related paths.
