### PR TITLE
feat: Add service-worker for static asset caching

### DIFF
--- a/components/serviceWorker/serviceWorkerRegister/index.tsx
+++ b/components/serviceWorker/serviceWorkerRegister/index.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+export const ServiceWorkerRegister = () => {
+  useEffect(() => {
+    const registerServiceWorker = async () => {
+      if ('serviceWorker' in navigator) {
+        try {
+          await navigator.serviceWorker.register('/service-worker.js');
+        } catch (error) {
+          console.error('Service Worker registration failed:', error);
+        }
+      }
+    };
+    registerServiceWorker();
+  }, []);
+
+  return null;
+};

--- a/configs/securityHeaders.js
+++ b/configs/securityHeaders.js
@@ -8,7 +8,7 @@ const ContentSecurityPolicy = `
   child-src 'self' youtube.com;
   font-src 'self';
   img-src 'self' ${process.env.NEXT_PUBLIC_IMAGE_DOMAIN} data:;
-  ${development ? `style-src 'self' 'unsafe-inline'` : `style-src 'self'`};
+  style-src 'self' 'unsafe-inline';
   ${
     development
       ? `script-src 'self' 'unsafe-eval' 'unsafe-inline' ${scriptSources}`

--- a/jest.config.js
+++ b/jest.config.js
@@ -30,6 +30,7 @@ const customJestConfig = {
     '^@data/(.*)$': ['<rootDir>/lib/data/$1'],
     '^@lib/(.*)$': ['<rootDir>/lib/$1'],
     '^@auth/(.*)$': ['<rootDir>/components/auth/$1'],
+    '^@serviceWorker/(.*)$': ['<rootDir>/components/serviceWorker/$1'],
     '^@editor/(.*)$': ['<rootDir>/components/editor/$1'],
     '^@icon/(.*)$': ['<rootDir>/components/icon/$1'],
     '^@label/(.*)$': ['<rootDir>/components/label/$1'],

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "postbuild": "node sw-postbuild.js",
     "start": "next start -p $PORT",
     "lint": "next lint",
     "prepare": "husky install",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,10 +2,11 @@ import { NextPage } from 'next';
 import { Session } from 'next-auth';
 import { SessionProvider } from 'next-auth/react';
 import type { AppProps } from 'next/app';
+import Head from 'next/head';
 import { ReactElement, ReactNode } from 'react';
 import { RecoilRoot } from 'recoil';
 import '../styles/globals.css';
-import Head from 'next/head';
+import { ServiceWorkerRegister } from '@serviceWorker/serviceWorkerRegister';
 
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
   getLayout?: (page: ReactElement) => ReactNode;
@@ -33,10 +34,12 @@ const MyApp = ({ Component, pageProps: { session, ...pageProps } }: AppPropsWith
         <SessionProvider
           session={session}
           basePath={process.env.NEXT_PUBLIC_NEXTAUTH_BASE_PATH}
-          refetchOnWindowFocus={false}>
+          refetchOnWindowFocus={false}
+        >
           {getLayout(<Component {...pageProps} />)}
         </SessionProvider>
       </RecoilRoot>
+      <ServiceWorkerRegister />
     </>
   );
 };

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,71 @@
+const version = 'v1686609637233';
+const IMAGE_CACHE_NAME = `image-assets-${version}`;
+const STATIC_CACHE_NAME = `static-assets-${version}`;
+const PRECACHE_URLS = []; // list the urls to pre-cache
+
+const isImageAsset = (url) => /\.(jpg|png|gif|webp|avif)$/i.test(url);
+const isStaticAsset = (url) => /_next\/static/i.test(url);
+
+const cacheAsset = async (request, cacheName, useStreamForStatic = false) => {
+  const cache = await caches.open(cacheName);
+  const cachedResponse = await cache.match(request);
+  if (cachedResponse) return cachedResponse;
+
+  const networkResponse = await fetch(request);
+  cache.put(request, networkResponse.clone());
+
+  if (useStreamForStatic && cacheName === STATIC_CACHE_NAME) {
+    return new Response(
+      new ReadableStream({
+        async start(controller) {
+          const reader = networkResponse.body.getReader();
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) {
+              controller.close();
+              break;
+            }
+            controller.enqueue(value);
+          }
+        },
+      }),
+    );
+  }
+  return networkResponse;
+};
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    (async () => {
+      const cache = await caches.open(STATIC_CACHE_NAME);
+      await cache.addAll(PRECACHE_URLS);
+    })(),
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const cacheNames = await caches.keys();
+      await Promise.all(
+        cacheNames.map((cacheName) => {
+          if (cacheName !== IMAGE_CACHE_NAME && cacheName !== STATIC_CACHE_NAME) {
+            return caches.delete(cacheName);
+          }
+        }),
+      );
+    })(),
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const url = event.request.url;
+
+  if (isImageAsset(url)) {
+    event.respondWith(cacheAsset(event.request, IMAGE_CACHE_NAME));
+  } else if (isStaticAsset(url)) {
+    event.respondWith(cacheAsset(event.request, STATIC_CACHE_NAME, true));
+  }
+});
+
+self.skipWaiting();

--- a/sw-postbuild.js
+++ b/sw-postbuild.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+
+const version = Date.now().toString();
+const filePath = './public/service-worker.js';
+
+fs.readFile(filePath, 'utf8', (error, data) => {
+  if (error) {
+    throw error;
+  }
+
+  const updatedData = data.replace(/const version = '[^']+';/, `const version = 'v${version}';`);
+
+  fs.writeFile(filePath, updatedData, 'utf8', (error) => {
+    if (error) {
+      throw error;
+    }
+    console.log('service-worker version updated successfully!');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
       "@auth/*": ["components/auth/*"],
       "@editor/*": ["components/editor/*"],
       "@icon/*": ["components/icon/*"],
+      "@serviceWorker/*": ["components/serviceWorker/*"],
       "@label/*": ["components/label/*"],
       "@layout/*": ["components/layout/*"],
       "@user/*": ["components/user/*"],


### PR DESCRIPTION
Incorporate a service-worker to handle caching of static assets. The assets being cached include files under the `/_next/static` directory and all images. The aforementioned directory contains assets generated during the build process.

To streamline cache versioning, the build process includes the generation of a new version identifier which is embedded in server-worker.js to invalidate the cache when necessary.