### PR TITLE
chore: Update databaseConnection config for deprecated options

### DIFF
--- a/lib/dataConnections/databaseConnection.ts
+++ b/lib/dataConnections/databaseConnection.ts
@@ -8,8 +8,6 @@ export const databaseConnect = async () => {
     const options: { [key: string]: boolean | number } = {
       useNewUrlParser: true,
       useUnifiedTopology: true,
-      keepAlive: true,
-      keepAliveInitialDelay: 300000, // in ms: 5 min total,
     };
     mongoose.set('strictQuery', false);
     cachedConnection = await mongoose.connect(uri, options);


### PR DESCRIPTION
Remove keepAlive and keepAliveInitialDelay options from databaseConnection configuration as they are deprecated. The removal avoids potential issues and maintains compatibility with updated database connection protocols.