### PR TITLE
feat: Update the `service-worker` with a new cache strategy

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,18 +1,29 @@
 const version = 'v1686609637233';
 const IMAGE_CACHE_NAME = `image-assets-${version}`;
 const STATIC_CACHE_NAME = `static-assets-${version}`;
-const PRECACHE_URLS = []; // list the urls to pre-cache
+const PRECACHE_URLS = [];
 
 const isImageAsset = (url) => /\.(jpg|png|gif|webp|avif)$/i.test(url);
 const isStaticAsset = (url) => /_next\/static/i.test(url);
 
-const cacheAsset = async (request, cacheName, useStreamForStatic = false) => {
+const staleWhileRevalidate = async (event, request, cacheName, useStreamForStatic = false) => {
   const cache = await caches.open(cacheName);
   const cachedResponse = await cache.match(request);
-  if (cachedResponse) return cachedResponse;
 
-  const networkResponse = await fetch(request);
-  cache.put(request, networkResponse.clone());
+  const fetchAndUpdateCache = async () => {
+    const networkResponse = await fetch(request);
+    if (networkResponse.ok) {
+      cache.put(request, networkResponse.clone());
+    }
+    return networkResponse;
+  };
+
+  if (cachedResponse) {
+    event.waitUntil(fetchAndUpdateCache());
+    return cachedResponse;
+  }
+
+  const networkResponse = await fetchAndUpdateCache();
 
   if (useStreamForStatic && cacheName === STATIC_CACHE_NAME) {
     return new Response(
@@ -31,30 +42,27 @@ const cacheAsset = async (request, cacheName, useStreamForStatic = false) => {
       }),
     );
   }
+
   return networkResponse;
 };
 
 self.addEventListener('install', (event) => {
-  event.waitUntil(
-    (async () => {
-      const cache = await caches.open(STATIC_CACHE_NAME);
-      await cache.addAll(PRECACHE_URLS);
-    })(),
-  );
+  event.waitUntil(caches.open(STATIC_CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS)));
 });
 
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    (async () => {
-      const cacheNames = await caches.keys();
-      await Promise.all(
-        cacheNames.map((cacheName) => {
-          if (cacheName !== IMAGE_CACHE_NAME && cacheName !== STATIC_CACHE_NAME) {
-            return caches.delete(cacheName);
-          }
-        }),
-      );
-    })(),
+    caches
+      .keys()
+      .then((cacheNames) =>
+        Promise.all(
+          cacheNames.map((cacheName) =>
+            cacheName !== IMAGE_CACHE_NAME && cacheName !== STATIC_CACHE_NAME
+              ? caches.delete(cacheName)
+              : undefined,
+          ),
+        ),
+      ),
   );
 });
 
@@ -62,9 +70,9 @@ self.addEventListener('fetch', (event) => {
   const url = event.request.url;
 
   if (isImageAsset(url)) {
-    event.respondWith(cacheAsset(event.request, IMAGE_CACHE_NAME));
+    event.respondWith(staleWhileRevalidate(event, event.request, IMAGE_CACHE_NAME));
   } else if (isStaticAsset(url)) {
-    event.respondWith(cacheAsset(event.request, STATIC_CACHE_NAME, true));
+    event.respondWith(staleWhileRevalidate(event, event.request, STATIC_CACHE_NAME, true));
   }
 });
 


### PR DESCRIPTION
Switch service-worker's caching strategy to `stale-while-revalidate` from `cache first then network`. This change enhances performance by synchronizing data efficiently. The new strategy prioritizes serving from cache, falls back to network if cache is unavailable, and asynchronously updates the cache with the latest data fetched from the network. Such an approach provides significant improvements in user experiences.