### PR TITLE
refactor: Update service-worker to omit image caching

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,9 +1,7 @@
-const version = 'v1686609637233';
-const IMAGE_CACHE_NAME = `image-assets-${version}`;
+const version = 'v1686728672690';
 const STATIC_CACHE_NAME = `static-assets-${version}`;
 const PRECACHE_URLS = [];
 
-const isImageAsset = (url) => /\.(jpg|png|gif|webp|avif)$/i.test(url);
 const isStaticAsset = (url) => /_next\/static/i.test(url);
 
 const staleWhileRevalidate = async (event, request, cacheName, useStreamForStatic = false) => {
@@ -12,9 +10,7 @@ const staleWhileRevalidate = async (event, request, cacheName, useStreamForStati
 
   const fetchAndUpdateCache = async () => {
     const networkResponse = await fetch(request);
-    if (networkResponse.ok) {
-      cache.put(request, networkResponse.clone());
-    }
+    if (networkResponse.ok) cache.put(request, networkResponse.clone());
     return networkResponse;
   };
 
@@ -57,9 +53,7 @@ self.addEventListener('activate', (event) => {
       .then((cacheNames) =>
         Promise.all(
           cacheNames.map((cacheName) =>
-            cacheName !== IMAGE_CACHE_NAME && cacheName !== STATIC_CACHE_NAME
-              ? caches.delete(cacheName)
-              : undefined,
+            cacheName !== STATIC_CACHE_NAME ? caches.delete(cacheName) : undefined,
           ),
         ),
       ),
@@ -69,9 +63,7 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
   const url = event.request.url;
 
-  if (isImageAsset(url)) {
-    event.respondWith(staleWhileRevalidate(event, event.request, IMAGE_CACHE_NAME));
-  } else if (isStaticAsset(url)) {
+  if (isStaticAsset(url)) {
     event.respondWith(staleWhileRevalidate(event, event.request, STATIC_CACHE_NAME, true));
   }
 });


### PR DESCRIPTION
Service-worker no longer caches images, delegating this task only to Cloudflare which optimizes and serves them via CDN. Despite potential response time improvements via service-worker caching, client storage size constraints, which vary for each client, make this approach less viable.