### PR TITLE
chore(merge): Introduce service-worker 

### DIFF
--- a/components/serviceWorker/serviceWorkerRegister/index.tsx
+++ b/components/serviceWorker/serviceWorkerRegister/index.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+export const ServiceWorkerRegister = () => {
+  useEffect(() => {
+    const registerServiceWorker = async () => {
+      if ('serviceWorker' in navigator) {
+        try {
+          await navigator.serviceWorker.register('/service-worker.js');
+        } catch (error) {
+          console.error('Service Worker registration failed:', error);
+        }
+      }
+    };
+    registerServiceWorker();
+  }, []);
+
+  return null;
+};

--- a/configs/securityHeaders.js
+++ b/configs/securityHeaders.js
@@ -8,7 +8,7 @@ const ContentSecurityPolicy = `
   child-src 'self' youtube.com;
   font-src 'self';
   img-src 'self' ${process.env.NEXT_PUBLIC_IMAGE_DOMAIN} data:;
-  ${development ? `style-src 'self' 'unsafe-inline'` : `style-src 'self'`};
+  style-src 'self' 'unsafe-inline';
   ${
     development
       ? `script-src 'self' 'unsafe-eval' 'unsafe-inline' ${scriptSources}`

--- a/jest.config.js
+++ b/jest.config.js
@@ -30,6 +30,7 @@ const customJestConfig = {
     '^@data/(.*)$': ['<rootDir>/lib/data/$1'],
     '^@lib/(.*)$': ['<rootDir>/lib/$1'],
     '^@auth/(.*)$': ['<rootDir>/components/auth/$1'],
+    '^@serviceWorker/(.*)$': ['<rootDir>/components/serviceWorker/$1'],
     '^@editor/(.*)$': ['<rootDir>/components/editor/$1'],
     '^@icon/(.*)$': ['<rootDir>/components/icon/$1'],
     '^@label/(.*)$': ['<rootDir>/components/label/$1'],

--- a/lib/dataConnections/databaseConnection.ts
+++ b/lib/dataConnections/databaseConnection.ts
@@ -8,8 +8,6 @@ export const databaseConnect = async () => {
     const options: { [key: string]: boolean | number } = {
       useNewUrlParser: true,
       useUnifiedTopology: true,
-      keepAlive: true,
-      keepAliveInitialDelay: 300000, // in ms: 5 min total,
     };
     mongoose.set('strictQuery', false);
     cachedConnection = await mongoose.connect(uri, options);

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "idb": "^7.1.1",
         "jest": "^29.5.0",
         "mongoose": "^7.2.2",
-        "next": "^13.4.4",
+        "next": "^13.4.5",
         "next-auth": "^4.22.1",
         "next-router-mock": "^0.9.6",
         "nodemailer": "^6.9.3",
@@ -1213,9 +1213,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.4.tgz",
-      "integrity": "sha512-q/y7VZj/9YpgzDe64Zi6rY1xPizx80JjlU2BTevlajtaE3w1LqweH1gGgxou2N7hdFosXHjGrI4OUvtFXXhGLg=="
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.5.tgz",
+      "integrity": "sha512-SG/gKH6eij4vwQy87b/3mbpQ1X3x2vUdnpwq6/qL2IQWjtq58EY/UuNAp9CoEZoC9sI4L9AD1r+73Z9r4d3uug=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "13.4.4",
@@ -1227,9 +1227,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.4.tgz",
-      "integrity": "sha512-xfjgXvp4KalNUKZMHmsFxr1Ug+aGmmO6NWP0uoh4G3WFqP/mJ1xxfww0gMOeMeSq/Jyr5k7DvoZ2Pv+XOITTtw==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.5.tgz",
+      "integrity": "sha512-XvTzi2ASUN5bECFIAAcBiSoDb0xsq+KLj4F0bof4d4rdc+FgOqLvseGQaOXwVi1TIh5bHa7o4b6droSJMO5+2g==",
       "cpu": [
         "arm64"
       ],
@@ -1242,9 +1242,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.4.tgz",
-      "integrity": "sha512-ZY9Ti1hkIwJsxGus3nlubIkvYyB0gNOYxKrfsOrLEqD0I2iCX8D7w8v6QQZ2H+dDl6UT29oeEUdDUNGk4UEpfg==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.5.tgz",
+      "integrity": "sha512-NQdqal/VKAqlJTuzhjZmNtdo8QSqwmfO7b2xJSAengTEVxQvsH76oGEzQeIv8Ci4NP6DysAFtFrJq++TmIxcUA==",
       "cpu": [
         "x64"
       ],
@@ -1257,9 +1257,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.4.tgz",
-      "integrity": "sha512-+KZnDeMShYkpkqAvGCEDeqYTRADJXc6SY1jWXz+Uo6qWQO/Jd9CoyhTJwRSxvQA16MoYzvILkGaDqirkRNctyA==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.5.tgz",
+      "integrity": "sha512-nB8TjtpJCXtzIFjYOMbnQu68ajkA8QK58TreHjTGojSQjsF0StDqo5zFHglVVVHrd8d3N/+EjC18yFNSWnd/ZA==",
       "cpu": [
         "arm64"
       ],
@@ -1272,9 +1272,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.4.tgz",
-      "integrity": "sha512-evC1twrny2XDT4uOftoubZvW3EG0zs0ZxMwEtu/dDGVRO5n5pT48S8qqEIBGBUZYu/Xx4zzpOkIxx1vpWdE+9A==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.5.tgz",
+      "integrity": "sha512-W126XUW599OV3giSH9Co40VpT8VAOT47xONVHXZaYEpeca0qEevjj6WUr5IJu/8u+XGWm5xI1S0DYWjR6W+olw==",
       "cpu": [
         "arm64"
       ],
@@ -1287,9 +1287,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.4.tgz",
-      "integrity": "sha512-PX706XcCHr2FfkyhP2lpf+pX/tUvq6/ke7JYnnr0ykNdEMo+sb7cC/o91gnURh4sPYSiZJhsF2gbIqg9rciOHQ==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.5.tgz",
+      "integrity": "sha512-ZbPLO/oztQdtjGmWvGhRmtkZ6j9kQqg65kiO7F7Ijj7ojTtu3hh/vY+XRsHa/4Cse6HgyJ8XGZJMGoLb8ecQfQ==",
       "cpu": [
         "x64"
       ],
@@ -1302,9 +1302,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.4.tgz",
-      "integrity": "sha512-TKUUx3Ftd95JlHV6XagEnqpT204Y+IsEa3awaYIjayn0MOGjgKZMZibqarK3B1FsMSPaieJf2FEAcu9z0yT5aA==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.5.tgz",
+      "integrity": "sha512-f+/h8KMNixVUoRB+2vza8I+jsthJ4KcvopGUsDIUHe7Q4t+m8nKwGFBeyNu9qNIenYK5g5QYEsSwYFEqZylrTQ==",
       "cpu": [
         "x64"
       ],
@@ -1317,9 +1317,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.4.tgz",
-      "integrity": "sha512-FP8AadgSq4+HPtim7WBkCMGbhr5vh9FePXiWx9+YOdjwdQocwoCK5ZVC3OW8oh3TWth6iJ0AXJ/yQ1q1cwSZ3A==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.5.tgz",
+      "integrity": "sha512-dvtPQZ5+J+zUE1uq7gP853Oj63e+n0T1ydZ/yRdVh7d8zW9ZFuC9fFrg3MqP1cv1NPPur8rrTqDKN2mRBkSSBw==",
       "cpu": [
         "arm64"
       ],
@@ -1332,9 +1332,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.4.tgz",
-      "integrity": "sha512-3WekVmtuA2MCdcAOrgrI+PuFiFURtSyyrN1I3UPtS0ckR2HtLqyqmS334Eulf15g1/bdwMteePdK363X/Y9JMg==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.5.tgz",
+      "integrity": "sha512-gK9zwGe25x31S4AjPy3Bf2niQvHIAbmwgkzmqWG3OmD4K2Z/Dh2ju4vuyzPzIt0pwQe4B520meP9NizTBmVWSg==",
       "cpu": [
         "ia32"
       ],
@@ -1347,9 +1347,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.4.tgz",
-      "integrity": "sha512-AHRITu/CrlQ+qzoqQtEMfaTu7GHaQ6bziQln/pVWpOYC1wU+Mq6VQQFlsDtMCnDztPZtppAXdvvbNS7pcfRzlw==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.5.tgz",
+      "integrity": "sha512-iyNQVc7eGehrik9RJt9xGcnO6b/pi8C7GCfg8RGenx1IlalEKbYRgBJloF7DQzwlrV47E9bQl8swT+JawaNcKA==",
       "cpu": [
         "x64"
       ],
@@ -4762,6 +4762,11 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+    },
     "node_modules/globals": {
       "version": "13.20.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
@@ -7342,16 +7347,17 @@
       "devOptional": true
     },
     "node_modules/next": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.4.4.tgz",
-      "integrity": "sha512-C5S0ysM0Ily9McL4Jb48nOQHT1BukOWI59uC3X/xCMlYIh9rJZCv7nzG92J6e1cOBqQbKovlpgvHWFmz4eKKEA==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.4.5.tgz",
+      "integrity": "sha512-pfNsRLVM9e5Y1/z02VakJRfD6hMQkr24FaN2xc9GbcZDBxoOgiNAViSg5cXwlWCoMhtm4U315D7XYhgOr96Q3Q==",
       "dependencies": {
-        "@next/env": "13.4.4",
+        "@next/env": "13.4.5",
         "@swc/helpers": "0.5.1",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
         "styled-jsx": "5.1.1",
+        "watchpack": "2.4.0",
         "zod": "3.21.4"
       },
       "bin": {
@@ -7361,15 +7367,15 @@
         "node": ">=16.8.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "13.4.4",
-        "@next/swc-darwin-x64": "13.4.4",
-        "@next/swc-linux-arm64-gnu": "13.4.4",
-        "@next/swc-linux-arm64-musl": "13.4.4",
-        "@next/swc-linux-x64-gnu": "13.4.4",
-        "@next/swc-linux-x64-musl": "13.4.4",
-        "@next/swc-win32-arm64-msvc": "13.4.4",
-        "@next/swc-win32-ia32-msvc": "13.4.4",
-        "@next/swc-win32-x64-msvc": "13.4.4"
+        "@next/swc-darwin-arm64": "13.4.5",
+        "@next/swc-darwin-x64": "13.4.5",
+        "@next/swc-linux-arm64-gnu": "13.4.5",
+        "@next/swc-linux-arm64-musl": "13.4.5",
+        "@next/swc-linux-x64-gnu": "13.4.5",
+        "@next/swc-linux-x64-musl": "13.4.5",
+        "@next/swc-win32-arm64-msvc": "13.4.5",
+        "@next/swc-win32-ia32-msvc": "13.4.5",
+        "@next/swc-win32-x64-msvc": "13.4.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -10068,6 +10074,18 @@
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/watchpack": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "react": "^18.2.0",
         "react-device-detect": "^2.2.3",
         "react-dom": "^18.2.0",
-        "react-error-boundary": "^4.0.9",
+        "react-error-boundary": "^4.0.10",
         "react-popper-tooltip": "^4.4.2",
         "recoil": "^0.7.7",
         "sharp": "^0.32.1",
@@ -8448,9 +8448,9 @@
       }
     },
     "node_modules/react-error-boundary": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.9.tgz",
-      "integrity": "sha512-f6DcHVdTDZmc9ixmRmuLDZpkdghYR/HKZdUzMLHD58s4cR2C4R6y4ktYztCosM6pyeK4/C8IofwqxgID25W6kw==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.10.tgz",
+      "integrity": "sha512-pvVKdi77j2OoPHo+p3rorgE43OjDWiqFkaqkJz8sJKK6uf/u8xtzuaVfj5qJ2JnDLIgF1De3zY5AJDijp+LVPA==",
       "dependencies": {
         "@babel/runtime": "^7.12.5"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "fast-deep-equal": "^3.1.3",
         "idb": "^7.1.1",
         "jest": "^29.5.0",
-        "mongoose": "^7.2.2",
+        "mongoose": "^7.2.4",
         "next": "^13.4.5",
         "next-auth": "^4.22.1",
         "next-router-mock": "^0.9.6",
@@ -7214,9 +7214,9 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.2.2.tgz",
-      "integrity": "sha512-JPBMTF+oYfLGVFWbHSZ/H+f1GajNanGLYH6c/P0nE3bNJfwGhX573vieGR0kNlNhj3cZk8WCPrnVsTNeUmFUag==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.2.4.tgz",
+      "integrity": "sha512-BWcgShV2WH1rspICiJKLPi7QssTebpGJ23Nyk7qG0TMEE/OEAlsQKEhI7VlrXg4ZnoOcHgG+N+upW9tj17TTQg==",
       "dependencies": {
         "bson": "^5.3.0",
         "kareem": "2.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@types/node": "20.2.5",
         "@types/react": "^18.2.12",
         "@types/validator": "^13.7.17",
-        "@typescript-eslint/eslint-plugin": "^5.59.9",
+        "@typescript-eslint/eslint-plugin": "^5.59.11",
         "@typescript-eslint/parser": "^5.59.8",
         "eslint": "8.41.0",
         "eslint-config-next": "13.4.4",
@@ -1831,15 +1831,15 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.59.9",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.9.tgz",
-      "integrity": "sha512-4uQIBq1ffXd2YvF7MAvehWKW3zVv/w+mSfRAu+8cKbfj3nwzyqJLNcZJpQ/WZ1HLbJDiowwmQ6NO+63nCA+fqA==",
+      "version": "5.59.11",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.11.tgz",
+      "integrity": "sha512-XxuOfTkCUiOSyBWIvHlUraLw/JT/6Io1365RO6ZuI88STKMavJZPNMU0lFcUTeQXEhHiv64CbxYxBNoDVSmghg==",
       "devOptional": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.59.9",
-        "@typescript-eslint/type-utils": "5.59.9",
-        "@typescript-eslint/utils": "5.59.9",
+        "@typescript-eslint/scope-manager": "5.59.11",
+        "@typescript-eslint/type-utils": "5.59.11",
+        "@typescript-eslint/utils": "5.59.11",
         "debug": "^4.3.4",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
@@ -1865,13 +1865,13 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.59.9",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.9.tgz",
-      "integrity": "sha512-8RA+E+w78z1+2dzvK/tGZ2cpGigBZ58VMEHDZtpE1v+LLjzrYGc8mMaTONSxKyEkz3IuXFM0IqYiGHlCsmlZxQ==",
+      "version": "5.59.11",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.11.tgz",
+      "integrity": "sha512-dHFOsxoLFtrIcSj5h0QoBT/89hxQONwmn3FOQ0GOQcLOOXm+MIrS8zEAhs4tWl5MraxCY3ZJpaXQQdFMc2Tu+Q==",
       "devOptional": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.9",
-        "@typescript-eslint/visitor-keys": "5.59.9"
+        "@typescript-eslint/types": "5.59.11",
+        "@typescript-eslint/visitor-keys": "5.59.11"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1882,9 +1882,9 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
-      "version": "5.59.9",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.9.tgz",
-      "integrity": "sha512-uW8H5NRgTVneSVTfiCVffBb8AbwWSKg7qcA4Ot3JI3MPCJGsB4Db4BhvAODIIYE5mNj7Q+VJkK7JxmRhk2Lyjw==",
+      "version": "5.59.11",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.11.tgz",
+      "integrity": "sha512-epoN6R6tkvBYSc+cllrz+c2sOFWkbisJZWkOE+y3xHtvYaOE6Wk6B8e114McRJwFRjGvYdJwLXQH5c9osME/AA==",
       "devOptional": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1895,12 +1895,12 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.59.9",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.9.tgz",
-      "integrity": "sha512-bT7s0td97KMaLwpEBckbzj/YohnvXtqbe2XgqNvTl6RJVakY5mvENOTPvw5u66nljfZxthESpDozs86U+oLY8Q==",
+      "version": "5.59.11",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.11.tgz",
+      "integrity": "sha512-KGYniTGG3AMTuKF9QBD7EIrvufkB6O6uX3knP73xbKLMpH+QRPcgnCxjWXSHjMRuOxFLovljqQgQpR0c7GvjoA==",
       "devOptional": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.9",
+        "@typescript-eslint/types": "5.59.11",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -1956,13 +1956,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.59.9",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.9.tgz",
-      "integrity": "sha512-ksEsT0/mEHg9e3qZu98AlSrONAQtrSTljL3ow9CGej8eRo7pe+yaC/mvTjptp23Xo/xIf2mLZKC6KPv4Sji26Q==",
+      "version": "5.59.11",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.11.tgz",
+      "integrity": "sha512-LZqVY8hMiVRF2a7/swmkStMYSoXMFlzL6sXV6U/2gL5cwnLWQgLEG8tjWPpaE4rMIdZ6VKWwcffPlo1jPfk43g==",
       "devOptional": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.59.9",
-        "@typescript-eslint/utils": "5.59.9",
+        "@typescript-eslint/typescript-estree": "5.59.11",
+        "@typescript-eslint/utils": "5.59.11",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -1983,9 +1983,9 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
-      "version": "5.59.9",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.9.tgz",
-      "integrity": "sha512-uW8H5NRgTVneSVTfiCVffBb8AbwWSKg7qcA4Ot3JI3MPCJGsB4Db4BhvAODIIYE5mNj7Q+VJkK7JxmRhk2Lyjw==",
+      "version": "5.59.11",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.11.tgz",
+      "integrity": "sha512-epoN6R6tkvBYSc+cllrz+c2sOFWkbisJZWkOE+y3xHtvYaOE6Wk6B8e114McRJwFRjGvYdJwLXQH5c9osME/AA==",
       "devOptional": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1996,13 +1996,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.59.9",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.9.tgz",
-      "integrity": "sha512-pmM0/VQ7kUhd1QyIxgS+aRvMgw+ZljB3eDb+jYyp6d2bC0mQWLzUDF+DLwCTkQ3tlNyVsvZRXjFyV0LkU/aXjA==",
+      "version": "5.59.11",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.11.tgz",
+      "integrity": "sha512-YupOpot5hJO0maupJXixi6l5ETdrITxeo5eBOeuV7RSKgYdU3G5cxO49/9WRnJq9EMrB7AuTSLH/bqOsXi7wPA==",
       "devOptional": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.9",
-        "@typescript-eslint/visitor-keys": "5.59.9",
+        "@typescript-eslint/types": "5.59.11",
+        "@typescript-eslint/visitor-keys": "5.59.11",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2023,12 +2023,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.59.9",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.9.tgz",
-      "integrity": "sha512-bT7s0td97KMaLwpEBckbzj/YohnvXtqbe2XgqNvTl6RJVakY5mvENOTPvw5u66nljfZxthESpDozs86U+oLY8Q==",
+      "version": "5.59.11",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.11.tgz",
+      "integrity": "sha512-KGYniTGG3AMTuKF9QBD7EIrvufkB6O6uX3knP73xbKLMpH+QRPcgnCxjWXSHjMRuOxFLovljqQgQpR0c7GvjoA==",
       "devOptional": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.9",
+        "@typescript-eslint/types": "5.59.11",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -2080,16 +2080,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.59.9",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.9.tgz",
-      "integrity": "sha512-1PuMYsju/38I5Ggblaeb98TOoUvjhRvLpLa1DoTOFaLWqaXl/1iQ1eGurTXgBY58NUdtfTXKP5xBq7q9NDaLKg==",
+      "version": "5.59.11",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.11.tgz",
+      "integrity": "sha512-didu2rHSOMUdJThLk4aZ1Or8IcO3HzCw/ZvEjTTIfjIrcdd5cvSIwwDy2AOlE7htSNp7QIZ10fLMyRCveesMLg==",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.59.9",
-        "@typescript-eslint/types": "5.59.9",
-        "@typescript-eslint/typescript-estree": "5.59.9",
+        "@typescript-eslint/scope-manager": "5.59.11",
+        "@typescript-eslint/types": "5.59.11",
+        "@typescript-eslint/typescript-estree": "5.59.11",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
       },
@@ -2105,12 +2105,12 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.59.9",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.9.tgz",
-      "integrity": "sha512-8RA+E+w78z1+2dzvK/tGZ2cpGigBZ58VMEHDZtpE1v+LLjzrYGc8mMaTONSxKyEkz3IuXFM0IqYiGHlCsmlZxQ==",
+      "version": "5.59.11",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.11.tgz",
+      "integrity": "sha512-dHFOsxoLFtrIcSj5h0QoBT/89hxQONwmn3FOQ0GOQcLOOXm+MIrS8zEAhs4tWl5MraxCY3ZJpaXQQdFMc2Tu+Q==",
       "dependencies": {
-        "@typescript-eslint/types": "5.59.9",
-        "@typescript-eslint/visitor-keys": "5.59.9"
+        "@typescript-eslint/types": "5.59.11",
+        "@typescript-eslint/visitor-keys": "5.59.11"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2121,9 +2121,9 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-      "version": "5.59.9",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.9.tgz",
-      "integrity": "sha512-uW8H5NRgTVneSVTfiCVffBb8AbwWSKg7qcA4Ot3JI3MPCJGsB4Db4BhvAODIIYE5mNj7Q+VJkK7JxmRhk2Lyjw==",
+      "version": "5.59.11",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.11.tgz",
+      "integrity": "sha512-epoN6R6tkvBYSc+cllrz+c2sOFWkbisJZWkOE+y3xHtvYaOE6Wk6B8e114McRJwFRjGvYdJwLXQH5c9osME/AA==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -2133,12 +2133,12 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.59.9",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.9.tgz",
-      "integrity": "sha512-pmM0/VQ7kUhd1QyIxgS+aRvMgw+ZljB3eDb+jYyp6d2bC0mQWLzUDF+DLwCTkQ3tlNyVsvZRXjFyV0LkU/aXjA==",
+      "version": "5.59.11",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.11.tgz",
+      "integrity": "sha512-YupOpot5hJO0maupJXixi6l5ETdrITxeo5eBOeuV7RSKgYdU3G5cxO49/9WRnJq9EMrB7AuTSLH/bqOsXi7wPA==",
       "dependencies": {
-        "@typescript-eslint/types": "5.59.9",
-        "@typescript-eslint/visitor-keys": "5.59.9",
+        "@typescript-eslint/types": "5.59.11",
+        "@typescript-eslint/visitor-keys": "5.59.11",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2159,11 +2159,11 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.59.9",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.9.tgz",
-      "integrity": "sha512-bT7s0td97KMaLwpEBckbzj/YohnvXtqbe2XgqNvTl6RJVakY5mvENOTPvw5u66nljfZxthESpDozs86U+oLY8Q==",
+      "version": "5.59.11",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.11.tgz",
+      "integrity": "sha512-KGYniTGG3AMTuKF9QBD7EIrvufkB6O6uX3knP73xbKLMpH+QRPcgnCxjWXSHjMRuOxFLovljqQgQpR0c7GvjoA==",
       "dependencies": {
-        "@typescript-eslint/types": "5.59.9",
+        "@typescript-eslint/types": "5.59.11",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@types/jest": "^29.5.2",
-        "@types/node": "20.2.5",
+        "@types/node": "20.3.1",
         "@types/react": "^18.2.12",
         "@types/validator": "^13.7.17",
         "@typescript-eslint/eslint-plugin": "^5.59.11",
@@ -1731,9 +1731,9 @@
       "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg=="
     },
     "node_modules/@types/node": {
-      "version": "20.2.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
-      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ=="
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
+      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg=="
     },
     "node_modules/@types/prettier": {
       "version": "2.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@typescript-eslint/eslint-plugin": "^5.59.11",
         "@typescript-eslint/parser": "^5.59.11",
         "eslint": "8.41.0",
-        "eslint-config-next": "13.4.4",
+        "eslint-config-next": "13.4.5",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-testing-library": "^5.11.0",
@@ -1218,9 +1218,9 @@
       "integrity": "sha512-SG/gKH6eij4vwQy87b/3mbpQ1X3x2vUdnpwq6/qL2IQWjtq58EY/UuNAp9CoEZoC9sI4L9AD1r+73Z9r4d3uug=="
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.4.4.tgz",
-      "integrity": "sha512-5jnh7q6I15efnjR/rR+/TGTc9hn53g3JTbEjAMjmeQiExKqEUgIXqrHI5zlTNlNyzCPkBB860/ctxXheZaF2Vw==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.4.5.tgz",
+      "integrity": "sha512-/xD/kyJhXmBZq+0xGKOdjL22c9/4i3mBAXaU9aOGEHTXqqFeOz8scJbScWF13aMqigeoFCsDqngIB2MIatcn4g==",
       "dev": true,
       "dependencies": {
         "glob": "7.1.7"
@@ -3740,12 +3740,12 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.4.4.tgz",
-      "integrity": "sha512-z/PMbm6L0iC/fwISULxe8IVy4DtNqZk2wQY711o35klenq70O6ns82A8yuMVCFjHC0DIyB2lyugesRtuk9u8dQ==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.4.5.tgz",
+      "integrity": "sha512-7qgJmRp9ClRzPgkzEz7ahK+Rasiv4k2aU3eqkkORzseNUGdtImZVYomcXUhUheHwkxzdN2p//nbIA7zJrCxsCg==",
       "dev": true,
       "dependencies": {
-        "@next/eslint-plugin-next": "13.4.4",
+        "@next/eslint-plugin-next": "13.4.5",
         "@rushstack/eslint-patch": "^1.1.3",
         "@typescript-eslint/parser": "^5.42.0",
         "eslint-import-resolver-node": "^0.3.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
         "@headlessui/react": "^1.7.15",
         "@headlessui/tailwindcss": "^0.1.3",
         "@next-auth/mongodb-adapter": "^1.1.3",
-        "@next/bundle-analyzer": "^13.4.4",
+        "@next/bundle-analyzer": "^13.4.5",
         "@tailwindcss/aspect-ratio": "^0.4.2",
         "@tailwindcss/forms": "^0.5.3",
         "@tailwindcss/typography": "^0.5.9",
@@ -1205,9 +1205,9 @@
       }
     },
     "node_modules/@next/bundle-analyzer": {
-      "version": "13.4.4",
-      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-13.4.4.tgz",
-      "integrity": "sha512-OxdqGfzElMjcLDw3XkUTqpEjyB/R2n3sOjiWuOGm414j5hAD2AIcXWv4q6FTN9rERgojrkw+g3z5yeLZgJ3YKg==",
+      "version": "13.4.5",
+      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-13.4.5.tgz",
+      "integrity": "sha512-jrjJ/m7YHqYDuLSXaAWv6eUEgH0gTSFaNCLRxnO6wSJODNV6BMbfYZsa5RJFVGzApPHj4DTPrz0rxn/9flIAXA==",
       "dependencies": {
         "webpack-bundle-analyzer": "4.7.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@testing-library/react": "^14.0.0",
         "@types/jest": "^29.5.2",
         "@types/node": "20.2.5",
-        "@types/react": "^18.2.9",
+        "@types/react": "^18.2.12",
         "@types/validator": "^13.7.17",
         "@typescript-eslint/eslint-plugin": "^5.59.9",
         "@typescript-eslint/parser": "^5.59.8",
@@ -1747,9 +1747,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.9",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.9.tgz",
-      "integrity": "sha512-pL3JAesUkF7PEQGxh5XOwdXGV907te6m1/Qe1ERJLgomojS6Ne790QiA7GUl434JEkFA2aAaB6qJ5z4e1zJn/w==",
+      "version": "18.2.12",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.12.tgz",
+      "integrity": "sha512-ndmBMLCgn38v3SntMeoJaIrO6tGHYKMEBohCUmw8HoLLQdRMOIGXfeYaBTLe2lsFaSB3MOK1VXscYFnmLtTSmw==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@types/react": "^18.2.12",
         "@types/validator": "^13.7.17",
         "@typescript-eslint/eslint-plugin": "^5.59.11",
-        "@typescript-eslint/parser": "^5.59.8",
+        "@typescript-eslint/parser": "^5.59.11",
         "eslint": "8.41.0",
         "eslint-config-next": "13.4.4",
         "eslint-config-prettier": "^8.8.0",
@@ -1864,62 +1864,15 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.59.11",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.11.tgz",
-      "integrity": "sha512-dHFOsxoLFtrIcSj5h0QoBT/89hxQONwmn3FOQ0GOQcLOOXm+MIrS8zEAhs4tWl5MraxCY3ZJpaXQQdFMc2Tu+Q==",
-      "devOptional": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.59.11",
-        "@typescript-eslint/visitor-keys": "5.59.11"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
-      "version": "5.59.11",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.11.tgz",
-      "integrity": "sha512-epoN6R6tkvBYSc+cllrz+c2sOFWkbisJZWkOE+y3xHtvYaOE6Wk6B8e114McRJwFRjGvYdJwLXQH5c9osME/AA==",
-      "devOptional": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.59.11",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.11.tgz",
-      "integrity": "sha512-KGYniTGG3AMTuKF9QBD7EIrvufkB6O6uX3knP73xbKLMpH+QRPcgnCxjWXSHjMRuOxFLovljqQgQpR0c7GvjoA==",
-      "devOptional": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.59.11",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.59.8",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.8.tgz",
-      "integrity": "sha512-AnR19RjJcpjoeGojmwZtCwBX/RidqDZtzcbG3xHrmz0aHHoOcbWnpDllenRDmDvsV0RQ6+tbb09/kyc+UT9Orw==",
+      "version": "5.59.11",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.11.tgz",
+      "integrity": "sha512-s9ZF3M+Nym6CAZEkJJeO2TFHHDsKAM3ecNkLuH4i4s8/RCPnF5JRip2GyviYkeEAcwGMJxkqG9h2dAsnA1nZpA==",
       "devOptional": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.59.8",
-        "@typescript-eslint/types": "5.59.8",
-        "@typescript-eslint/typescript-estree": "5.59.8",
+        "@typescript-eslint/scope-manager": "5.59.11",
+        "@typescript-eslint/types": "5.59.11",
+        "@typescript-eslint/typescript-estree": "5.59.11",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1939,13 +1892,12 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.59.8",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.8.tgz",
-      "integrity": "sha512-/w08ndCYI8gxGf+9zKf1vtx/16y8MHrZs5/tnjHhMLNSixuNcJavSX4wAiPf4aS5x41Es9YPCn44MIe4cxIlig==",
-      "devOptional": true,
+      "version": "5.59.11",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.11.tgz",
+      "integrity": "sha512-dHFOsxoLFtrIcSj5h0QoBT/89hxQONwmn3FOQ0GOQcLOOXm+MIrS8zEAhs4tWl5MraxCY3ZJpaXQQdFMc2Tu+Q==",
       "dependencies": {
-        "@typescript-eslint/types": "5.59.8",
-        "@typescript-eslint/visitor-keys": "5.59.8"
+        "@typescript-eslint/types": "5.59.11",
+        "@typescript-eslint/visitor-keys": "5.59.11"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1982,68 +1934,10 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+    "node_modules/@typescript-eslint/types": {
       "version": "5.59.11",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.11.tgz",
       "integrity": "sha512-epoN6R6tkvBYSc+cllrz+c2sOFWkbisJZWkOE+y3xHtvYaOE6Wk6B8e114McRJwFRjGvYdJwLXQH5c9osME/AA==",
-      "devOptional": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.59.11",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.11.tgz",
-      "integrity": "sha512-YupOpot5hJO0maupJXixi6l5ETdrITxeo5eBOeuV7RSKgYdU3G5cxO49/9WRnJq9EMrB7AuTSLH/bqOsXi7wPA==",
-      "devOptional": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.59.11",
-        "@typescript-eslint/visitor-keys": "5.59.11",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.59.11",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.11.tgz",
-      "integrity": "sha512-KGYniTGG3AMTuKF9QBD7EIrvufkB6O6uX3knP73xbKLMpH+QRPcgnCxjWXSHjMRuOxFLovljqQgQpR0c7GvjoA==",
-      "devOptional": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.59.11",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "5.59.8",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.8.tgz",
-      "integrity": "sha512-+uWuOhBTj/L6awoWIg0BlWy0u9TyFpCHrAuQ5bNfxDaZ1Ppb3mx6tUigc74LHcbHpOHuOTOJrBoAnhdHdaea1w==",
-      "devOptional": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -2053,13 +1947,12 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.59.8",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.8.tgz",
-      "integrity": "sha512-Jy/lPSDJGNow14vYu6IrW790p7HIf/SOV1Bb6lZ7NUkLc2iB2Z9elESmsaUtLw8kVqogSbtLH9tut5GCX1RLDg==",
-      "devOptional": true,
+      "version": "5.59.11",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.11.tgz",
+      "integrity": "sha512-YupOpot5hJO0maupJXixi6l5ETdrITxeo5eBOeuV7RSKgYdU3G5cxO49/9WRnJq9EMrB7AuTSLH/bqOsXi7wPA==",
       "dependencies": {
-        "@typescript-eslint/types": "5.59.8",
-        "@typescript-eslint/visitor-keys": "5.59.8",
+        "@typescript-eslint/types": "5.59.11",
+        "@typescript-eslint/visitor-keys": "5.59.11",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2104,83 +1997,12 @@
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.59.11",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.11.tgz",
-      "integrity": "sha512-dHFOsxoLFtrIcSj5h0QoBT/89hxQONwmn3FOQ0GOQcLOOXm+MIrS8zEAhs4tWl5MraxCY3ZJpaXQQdFMc2Tu+Q==",
-      "dependencies": {
-        "@typescript-eslint/types": "5.59.11",
-        "@typescript-eslint/visitor-keys": "5.59.11"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-      "version": "5.59.11",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.11.tgz",
-      "integrity": "sha512-epoN6R6tkvBYSc+cllrz+c2sOFWkbisJZWkOE+y3xHtvYaOE6Wk6B8e114McRJwFRjGvYdJwLXQH5c9osME/AA==",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.59.11",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.11.tgz",
-      "integrity": "sha512-YupOpot5hJO0maupJXixi6l5ETdrITxeo5eBOeuV7RSKgYdU3G5cxO49/9WRnJq9EMrB7AuTSLH/bqOsXi7wPA==",
-      "dependencies": {
-        "@typescript-eslint/types": "5.59.11",
-        "@typescript-eslint/visitor-keys": "5.59.11",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+    "node_modules/@typescript-eslint/visitor-keys": {
       "version": "5.59.11",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.11.tgz",
       "integrity": "sha512-KGYniTGG3AMTuKF9QBD7EIrvufkB6O6uX3knP73xbKLMpH+QRPcgnCxjWXSHjMRuOxFLovljqQgQpR0c7GvjoA==",
       "dependencies": {
         "@typescript-eslint/types": "5.59.11",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.59.8",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.8.tgz",
-      "integrity": "sha512-pJhi2ms0x0xgloT7xYabil3SGGlojNNKjK/q6dB3Ey0uJLMjK2UDGJvHieiyJVW/7C3KI+Z4Q3pEHkm4ejA+xQ==",
-      "devOptional": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.59.8",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/node": "20.2.5",
     "@types/react": "^18.2.12",
     "@types/validator": "^13.7.17",
-    "@typescript-eslint/eslint-plugin": "^5.59.9",
+    "@typescript-eslint/eslint-plugin": "^5.59.11",
     "@typescript-eslint/parser": "^5.59.8",
     "eslint": "8.41.0",
     "eslint-config-next": "13.4.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react": "^18.2.0",
     "react-device-detect": "^2.2.3",
     "react-dom": "^18.2.0",
-    "react-error-boundary": "^4.0.9",
+    "react-error-boundary": "^4.0.10",
     "react-popper-tooltip": "^4.4.2",
     "recoil": "^0.7.7",
     "sharp": "^0.32.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@types/react": "^18.2.12",
     "@types/validator": "^13.7.17",
     "@typescript-eslint/eslint-plugin": "^5.59.11",
-    "@typescript-eslint/parser": "^5.59.8",
+    "@typescript-eslint/parser": "^5.59.11",
     "eslint": "8.41.0",
     "eslint-config-next": "13.4.4",
     "eslint-config-prettier": "^8.8.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "idb": "^7.1.1",
     "jest": "^29.5.0",
     "mongoose": "^7.2.2",
-    "next": "^13.4.4",
+    "next": "^13.4.5",
     "next-auth": "^4.22.1",
     "next-router-mock": "^0.9.6",
     "nodemailer": "^6.9.3",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@types/jest": "^29.5.2",
-    "@types/node": "20.2.5",
+    "@types/node": "20.3.1",
     "@types/react": "^18.2.12",
     "@types/validator": "^13.7.17",
     "@typescript-eslint/eslint-plugin": "^5.59.11",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@typescript-eslint/eslint-plugin": "^5.59.11",
     "@typescript-eslint/parser": "^5.59.11",
     "eslint": "8.41.0",
-    "eslint-config-next": "13.4.4",
+    "eslint-config-next": "13.4.5",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-testing-library": "^5.11.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "postbuild": "node sw-postbuild.js",
     "start": "next start -p $PORT",
     "lint": "next lint",
     "prepare": "husky install",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "fast-deep-equal": "^3.1.3",
     "idb": "^7.1.1",
     "jest": "^29.5.0",
-    "mongoose": "^7.2.2",
+    "mongoose": "^7.2.4",
     "next": "^13.4.5",
     "next-auth": "^4.22.1",
     "next-router-mock": "^0.9.6",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@testing-library/react": "^14.0.0",
     "@types/jest": "^29.5.2",
     "@types/node": "20.2.5",
-    "@types/react": "^18.2.9",
+    "@types/react": "^18.2.12",
     "@types/validator": "^13.7.17",
     "@typescript-eslint/eslint-plugin": "^5.59.9",
     "@typescript-eslint/parser": "^5.59.8",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@headlessui/react": "^1.7.15",
     "@headlessui/tailwindcss": "^0.1.3",
     "@next-auth/mongodb-adapter": "^1.1.3",
-    "@next/bundle-analyzer": "^13.4.4",
+    "@next/bundle-analyzer": "^13.4.5",
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/typography": "^0.5.9",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,10 +2,11 @@ import { NextPage } from 'next';
 import { Session } from 'next-auth';
 import { SessionProvider } from 'next-auth/react';
 import type { AppProps } from 'next/app';
+import Head from 'next/head';
 import { ReactElement, ReactNode } from 'react';
 import { RecoilRoot } from 'recoil';
 import '../styles/globals.css';
-import Head from 'next/head';
+import { ServiceWorkerRegister } from '@serviceWorker/serviceWorkerRegister';
 
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
   getLayout?: (page: ReactElement) => ReactNode;
@@ -33,10 +34,12 @@ const MyApp = ({ Component, pageProps: { session, ...pageProps } }: AppPropsWith
         <SessionProvider
           session={session}
           basePath={process.env.NEXT_PUBLIC_NEXTAUTH_BASE_PATH}
-          refetchOnWindowFocus={false}>
+          refetchOnWindowFocus={false}
+        >
           {getLayout(<Component {...pageProps} />)}
         </SessionProvider>
       </RecoilRoot>
+      <ServiceWorkerRegister />
     </>
   );
 };

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,9 +1,7 @@
-const version = 'v1686609637233';
-const IMAGE_CACHE_NAME = `image-assets-${version}`;
+const version = 'v1686728672690';
 const STATIC_CACHE_NAME = `static-assets-${version}`;
 const PRECACHE_URLS = [];
 
-const isImageAsset = (url) => /\.(jpg|png|gif|webp|avif)$/i.test(url);
 const isStaticAsset = (url) => /_next\/static/i.test(url);
 
 const staleWhileRevalidate = async (event, request, cacheName, useStreamForStatic = false) => {
@@ -12,9 +10,7 @@ const staleWhileRevalidate = async (event, request, cacheName, useStreamForStati
 
   const fetchAndUpdateCache = async () => {
     const networkResponse = await fetch(request);
-    if (networkResponse.ok) {
-      cache.put(request, networkResponse.clone());
-    }
+    if (networkResponse.ok) cache.put(request, networkResponse.clone());
     return networkResponse;
   };
 
@@ -57,9 +53,7 @@ self.addEventListener('activate', (event) => {
       .then((cacheNames) =>
         Promise.all(
           cacheNames.map((cacheName) =>
-            cacheName !== IMAGE_CACHE_NAME && cacheName !== STATIC_CACHE_NAME
-              ? caches.delete(cacheName)
-              : undefined,
+            cacheName !== STATIC_CACHE_NAME ? caches.delete(cacheName) : undefined,
           ),
         ),
       ),
@@ -69,9 +63,7 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
   const url = event.request.url;
 
-  if (isImageAsset(url)) {
-    event.respondWith(staleWhileRevalidate(event, event.request, IMAGE_CACHE_NAME));
-  } else if (isStaticAsset(url)) {
+  if (isStaticAsset(url)) {
     event.respondWith(staleWhileRevalidate(event, event.request, STATIC_CACHE_NAME, true));
   }
 });

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,18 +1,29 @@
 const version = 'v1686609637233';
 const IMAGE_CACHE_NAME = `image-assets-${version}`;
 const STATIC_CACHE_NAME = `static-assets-${version}`;
-const PRECACHE_URLS = []; // list the urls to pre-cache
+const PRECACHE_URLS = [];
 
 const isImageAsset = (url) => /\.(jpg|png|gif|webp|avif)$/i.test(url);
 const isStaticAsset = (url) => /_next\/static/i.test(url);
 
-const cacheAsset = async (request, cacheName, useStreamForStatic = false) => {
+const staleWhileRevalidate = async (event, request, cacheName, useStreamForStatic = false) => {
   const cache = await caches.open(cacheName);
   const cachedResponse = await cache.match(request);
-  if (cachedResponse) return cachedResponse;
 
-  const networkResponse = await fetch(request);
-  cache.put(request, networkResponse.clone());
+  const fetchAndUpdateCache = async () => {
+    const networkResponse = await fetch(request);
+    if (networkResponse.ok) {
+      cache.put(request, networkResponse.clone());
+    }
+    return networkResponse;
+  };
+
+  if (cachedResponse) {
+    event.waitUntil(fetchAndUpdateCache());
+    return cachedResponse;
+  }
+
+  const networkResponse = await fetchAndUpdateCache();
 
   if (useStreamForStatic && cacheName === STATIC_CACHE_NAME) {
     return new Response(
@@ -31,30 +42,27 @@ const cacheAsset = async (request, cacheName, useStreamForStatic = false) => {
       }),
     );
   }
+
   return networkResponse;
 };
 
 self.addEventListener('install', (event) => {
-  event.waitUntil(
-    (async () => {
-      const cache = await caches.open(STATIC_CACHE_NAME);
-      await cache.addAll(PRECACHE_URLS);
-    })(),
-  );
+  event.waitUntil(caches.open(STATIC_CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS)));
 });
 
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    (async () => {
-      const cacheNames = await caches.keys();
-      await Promise.all(
-        cacheNames.map((cacheName) => {
-          if (cacheName !== IMAGE_CACHE_NAME && cacheName !== STATIC_CACHE_NAME) {
-            return caches.delete(cacheName);
-          }
-        }),
-      );
-    })(),
+    caches
+      .keys()
+      .then((cacheNames) =>
+        Promise.all(
+          cacheNames.map((cacheName) =>
+            cacheName !== IMAGE_CACHE_NAME && cacheName !== STATIC_CACHE_NAME
+              ? caches.delete(cacheName)
+              : undefined,
+          ),
+        ),
+      ),
   );
 });
 
@@ -62,9 +70,9 @@ self.addEventListener('fetch', (event) => {
   const url = event.request.url;
 
   if (isImageAsset(url)) {
-    event.respondWith(cacheAsset(event.request, IMAGE_CACHE_NAME));
+    event.respondWith(staleWhileRevalidate(event, event.request, IMAGE_CACHE_NAME));
   } else if (isStaticAsset(url)) {
-    event.respondWith(cacheAsset(event.request, STATIC_CACHE_NAME, true));
+    event.respondWith(staleWhileRevalidate(event, event.request, STATIC_CACHE_NAME, true));
   }
 });
 

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,71 @@
+const version = 'v1686609637233';
+const IMAGE_CACHE_NAME = `image-assets-${version}`;
+const STATIC_CACHE_NAME = `static-assets-${version}`;
+const PRECACHE_URLS = []; // list the urls to pre-cache
+
+const isImageAsset = (url) => /\.(jpg|png|gif|webp|avif)$/i.test(url);
+const isStaticAsset = (url) => /_next\/static/i.test(url);
+
+const cacheAsset = async (request, cacheName, useStreamForStatic = false) => {
+  const cache = await caches.open(cacheName);
+  const cachedResponse = await cache.match(request);
+  if (cachedResponse) return cachedResponse;
+
+  const networkResponse = await fetch(request);
+  cache.put(request, networkResponse.clone());
+
+  if (useStreamForStatic && cacheName === STATIC_CACHE_NAME) {
+    return new Response(
+      new ReadableStream({
+        async start(controller) {
+          const reader = networkResponse.body.getReader();
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) {
+              controller.close();
+              break;
+            }
+            controller.enqueue(value);
+          }
+        },
+      }),
+    );
+  }
+  return networkResponse;
+};
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    (async () => {
+      const cache = await caches.open(STATIC_CACHE_NAME);
+      await cache.addAll(PRECACHE_URLS);
+    })(),
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const cacheNames = await caches.keys();
+      await Promise.all(
+        cacheNames.map((cacheName) => {
+          if (cacheName !== IMAGE_CACHE_NAME && cacheName !== STATIC_CACHE_NAME) {
+            return caches.delete(cacheName);
+          }
+        }),
+      );
+    })(),
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const url = event.request.url;
+
+  if (isImageAsset(url)) {
+    event.respondWith(cacheAsset(event.request, IMAGE_CACHE_NAME));
+  } else if (isStaticAsset(url)) {
+    event.respondWith(cacheAsset(event.request, STATIC_CACHE_NAME, true));
+  }
+});
+
+self.skipWaiting();

--- a/sw-postbuild.js
+++ b/sw-postbuild.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+
+const version = Date.now().toString();
+const filePath = './public/service-worker.js';
+
+fs.readFile(filePath, 'utf8', (error, data) => {
+  if (error) {
+    throw error;
+  }
+
+  const updatedData = data.replace(/const version = '[^']+';/, `const version = 'v${version}';`);
+
+  fs.writeFile(filePath, updatedData, 'utf8', (error) => {
+    if (error) {
+      throw error;
+    }
+    console.log('service-worker version updated successfully!');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
       "@auth/*": ["components/auth/*"],
       "@editor/*": ["components/editor/*"],
       "@icon/*": ["components/icon/*"],
+      "@serviceWorker/*": ["components/serviceWorker/*"],
       "@label/*": ["components/label/*"],
       "@layout/*": ["components/layout/*"],
       "@user/*": ["components/user/*"],


### PR DESCRIPTION
## Summary:
Service workers have been significantly enhanced with new caching 
strategies and stream fallback support. Additionally, project dependencies
have been updated, and database configuration options have been revised
to address deprecation.

## Added:
- feat: Update the `service-worker` with a new cache strategy (#798)
- feat: Add service-worker for static asset caching (#786)

## Changed:
- refactor: Enhance service-worker stream with fallback (#800)
- refactor: Update service-worker to omit image caching (#799)

## Updated:
- chore: Update databaseConnection config for deprecated options (#797)
- build(deps): Bump @next/bundle-analyzer from 13.4.4 to 13.4.5 (#789)
- build(deps-dev): Bump eslint-config-next from 13.4.4 to 13.4.5 (#787)
- build(deps-dev): Bump @typescript-eslint/parser from 5.59.8 to 5.59.11 (#794)
- build(deps): Bump mongoose from 7.2.2 to 7.2.4 (#793)
- build(deps-dev): Bump @types/node from 20.2.5 to 20.3.1 (#788)
- build(deps): Bump react-error-boundary from 4.0.9 to 4.0.10 (#792)
- build(deps): Bump next from 13.4.4 to 13.4.5 (#796)
- build(deps-dev): Bump @typescript-eslint/eslint-plugin from 5.59.9 to 5.59.11 (#795)
- build(deps-dev): Bump @types/react from 18.2.9 to 18.2.12 (#790)
