### PR TITLE
chore: Update the docker-image-deploy workflow run

### DIFF
--- a/.github/workflows/docker-image-deploy.yml
+++ b/.github/workflows/docker-image-deploy.yml
@@ -35,7 +35,6 @@ jobs:
             --platform ${{ secrets.GCR_PLATFORM }} \
             --allow-unauthenticated \
             --min-instances=1 \
-            --no-cpu-throttling \
             --vpc-connector ${{ secrets.GCR_VPC_CONNECTOR }} \
             --vpc-egress ${{ secrets.GCR_VPC_EGRESS }} \
             --region ${{ secrets.GCR_VPC_REGION }} \


### PR DESCRIPTION
Revise docker-image-deploy workflow by removing the "Always on allocated" option (also known as "no-cpu-throttling"). This adjustment aims to decrease costs. Even though "Always on allocated" grants a discount on CPU and memory utilization, its pricing advantage is insignificant without a substantial number of requests.