### PR TITLE
fix: Correct font instability in labelModal

### DIFF
--- a/components/ui/modals/labelModals/labelModal/index.tsx
+++ b/components/ui/modals/labelModals/labelModal/index.tsx
@@ -50,7 +50,7 @@ export const LabelModal = ({
       >
         <ModalTransitionChild className='h-40 px-2 pb-4 pt-2 sm:relative sm:bottom-24 sm:h-40 sm:max-w-lg'>
           <div className='flex flex-row items-center justify-between sm:inline-block'>
-            <div className='flex w-full flex-row items-center justify-between pl-3 text-base font-semibold text-gray-600 sm:mb-1 '>
+            <div className='flex w-full flex-row items-center justify-between pl-3 text-base font-semibold text-gray-600 will-change-transform sm:mb-1'>
               {menuButtonContent}
               <IconButton
                 options={optionsButtonTodoModalClose}
@@ -64,7 +64,7 @@ export const LabelModal = ({
           <div className='h-full w-full overflow-scroll pl-2 pr-3'>
             <input
               className={classNames(
-                'w-full rounded-lg border-0 bg-transparent py-1 pl-2 outline-none focus:ring-0 focus:ring-offset-0',
+                'w-full rounded-lg border-0 bg-transparent py-1 pl-2 outline-none will-change-transform focus:ring-0 focus:ring-offset-0',
               )}
               placeholder='Enter new label'
               type='text'


### PR DESCRIPTION
Address issue of font instability in labelModal during and post-transition. Observed behavior was font exhibiting a shaking or slight movement once transition completed. Root cause was element unpreparedness for impending transition. Solution applied: addition of 'will-transition-transform', successfully resolving the issue.