### PR TITLE
refactor: Relocate and rename states in layout components

### DIFF
--- a/components/label/labelList/labelItem/__test__/labelItem.test.tsx
+++ b/components/label/labelList/labelItem/__test__/labelItem.test.tsx
@@ -1,5 +1,4 @@
 import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
-import { atomNavigationOpen } from '@states/layouts';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import { screen } from '@testing-library/react';
 import { UserSessionEffect } from '@user/userSessionGroupEffect/userSessionEffect';
@@ -10,6 +9,7 @@ import { RecoilState, useRecoilValue } from 'recoil';
 import { LabelItem } from '..';
 import { atomConfirmModalDelete, atomLabelModalOpen } from '@states/modals';
 import { useInitialNavigation } from '@layout/layout.hooks';
+import { atomLayoutNavigationOpen } from '@layout/layout.states';
 
 jest.mock('@modals/labelModals/labelModal/itemLabelModal', () => ({
   ItemLabelModal: () => {
@@ -110,7 +110,7 @@ describe('LabelItem', () => {
 
   it('should show active text when media query is above medium width, 768px', async () => {
     const layoutType = 'app';
-    const { container } = renderWithLabelItem(atomNavigationOpen(layoutType), false);
+    const { container } = renderWithLabelItem(atomLayoutNavigationOpen(layoutType), false);
     const labelButton = screen.getByText(mockedLabelItem.name);
     const navigationOpen = screen.getByText('active');
 

--- a/components/layout/layout.hooks.ts
+++ b/components/layout/layout.hooks.ts
@@ -1,7 +1,6 @@
 import { PATH_APP, PATH_HOME, PATH_IMAGE_APP } from '@constAssertions/data';
 import { BREAKPOINT } from '@constAssertions/ui';
 import { atomEffectMediaQuery } from '@states/atomEffects/misc';
-import { atomLayoutType, atomNavigationOpen } from '@states/layouts';
 import { atomFilterEffect, atomHtmlTitleTag, atomPathnameImage } from '@states/misc';
 import { RecoilValue, useRecoilCallback, useRecoilValue } from 'recoil';
 import { TypesLayout } from './layout.types';
@@ -10,13 +9,14 @@ import { useNextQuery } from '@hooks/misc';
 import { selectorSessionLabels, atomLabelQuerySlug } from '@label/label.states';
 import { Labels } from '@label/label.types';
 import { useRouter } from 'next/router';
+import { atomLayoutType, atomLayoutNavigationOpen } from './layout.states';
 
 export const useNavigationOpen = () => {
   const layoutType = useRecoilValue(atomLayoutType);
   return useRecoilCallback(
     ({ set }) =>
       () => {
-        set(atomNavigationOpen(layoutType), (event) => !event);
+        set(atomLayoutNavigationOpen(layoutType), (event) => !event);
       },
     [layoutType],
   );
@@ -51,12 +51,12 @@ export const useInitialNavigation = ({ path }: Pick<TypesLayout, 'path'>) => {
     const breakpointMd = path === 'app' ? breakPointMd : breakPointMl;
 
     if (breakpointMd) {
-      set(atomNavigationOpen('app'), true);
-      set(atomNavigationOpen('home'), false);
+      set(atomLayoutNavigationOpen('app'), true);
+      set(atomLayoutNavigationOpen('home'), false);
       return;
     }
-    set(atomNavigationOpen('app'), false);
-    set(atomNavigationOpen('home'), false);
+    set(atomLayoutNavigationOpen('app'), false);
+    set(atomLayoutNavigationOpen('home'), false);
   });
   // should not use any dependency to create the hook on every rendering.
   // This should reset the initial state on every route change.

--- a/components/layout/layout.states.ts
+++ b/components/layout/layout.states.ts
@@ -1,18 +1,18 @@
 import { BREAKPOINT } from '@constAssertions/ui';
 import { TypesLayout } from '@layout/layout.types';
+import { atomEffectMediaQuery } from '@states/atomEffects/misc';
 import { atom, atomFamily, selector } from 'recoil';
-import { atomEffectMediaQuery } from './atomEffects/misc';
 
 /**
  * Atoms
  **/
-export const atomNavigationOpen = atomFamily<boolean, TypesLayout['path']>({
-  key: 'atomNavigationOpen',
+export const atomLayoutNavigationOpen = atomFamily<boolean, TypesLayout['path']>({
+  key: 'atomLayoutNavigationOpen',
   default: false,
 });
 
-export const atomSearchInput = atom({
-  key: 'atomSearchInput',
+export const atomLayoutSearch = atom({
+  key: 'atomLayoutSearch',
   default: '',
 });
 

--- a/components/layout/layoutEffects/bodyTagClassEffect/index.tsx
+++ b/components/layout/layoutEffects/bodyTagClassEffect/index.tsx
@@ -1,5 +1,5 @@
 import { useLayoutBodyTagClass } from '@layout/layout.hooks';
-import { atomLayoutType } from '@states/layouts';
+import { atomLayoutType } from '@layout/layout.states';
 import { useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
 

--- a/components/layout/layoutEffects/initialNavigationEffect/index.tsx
+++ b/components/layout/layoutEffects/initialNavigationEffect/index.tsx
@@ -1,5 +1,5 @@
 import { useInitialNavigation } from '@layout/layout.hooks';
-import { atomLayoutType } from '@states/layouts';
+import { atomLayoutType } from '@layout/layout.states';
 import { useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
 

--- a/components/layout/layoutFooter/footerBody/index.tsx
+++ b/components/layout/layoutFooter/footerBody/index.tsx
@@ -1,7 +1,7 @@
 import { GRADIENT_POSITION, GRADIENT_TYPE } from '@constAssertions/ui';
+import { atomLayoutType, atomLayoutNavigationOpen } from '@layout/layout.states';
 import { Types } from '@lib/types';
 import { classNames } from '@stateLogics/utils';
-import { atomLayoutType, atomNavigationOpen } from '@states/layouts';
 import { atomDisableScroll } from '@states/misc';
 import { GlobalVerticalGradient } from '@ui/gradients/globalVerticalGradient';
 import { useRecoilValue } from 'recoil';
@@ -10,7 +10,7 @@ type Props = Pick<Types, 'children'>;
 
 export const FooterBody = ({ children }: Props) => {
   const layoutType = useRecoilValue(atomLayoutType);
-  const isSidebarOpen = useRecoilValue(atomNavigationOpen(layoutType));
+  const isSidebarOpen = useRecoilValue(atomLayoutNavigationOpen(layoutType));
   const isScrollDisabled = useRecoilValue(atomDisableScroll);
 
   return (

--- a/components/layout/layoutFooter/sidebarTransition/index.tsx
+++ b/components/layout/layoutFooter/sidebarTransition/index.tsx
@@ -1,17 +1,17 @@
 import { Transition } from '@headlessui/react';
 import { useNavigationOpen } from '@layout/layout.hooks';
 import { classNames } from '@stateLogics/utils';
-import { atomNavigationOpen, selectorNavigationBreakpoint } from '@states/layouts';
 import { Backdrop } from '@ui/backdrops/backdrop';
 import { Fragment, ReactNode } from 'react';
 import { useRecoilValue } from 'recoil';
 import { SidebarNavigationWrapper } from '../sidebarNavigationWrapper';
 import { TypesLayout } from '@layout/layout.types';
+import { atomLayoutNavigationOpen, selectorNavigationBreakpoint } from '@layout/layout.states';
 
 type Props = Pick<TypesLayout, 'path'> & { children: ReactNode };
 
 export const SidebarTransition = ({ path, children }: Props) => {
-  const isSidebarOpen = useRecoilValue(atomNavigationOpen(path));
+  const isSidebarOpen = useRecoilValue(atomLayoutNavigationOpen(path));
   const breakpoint = useRecoilValue(selectorNavigationBreakpoint);
   const setNavigationOpen = useNavigationOpen();
   const layoutApp = path === 'app';

--- a/components/layout/layoutHeader/index.tsx
+++ b/components/layout/layoutHeader/index.tsx
@@ -12,8 +12,8 @@ import {
 import { useRecoilValue } from 'recoil';
 import { Logo } from './logo';
 import { NavigationButton } from './navigationButton';
-import { atomNavigationOpen } from '@states/layouts';
 import { TypesLayout } from '@layout/layout.types';
+import { atomLayoutNavigationOpen } from '@layout/layout.states';
 
 const UserSessionGroupEffect = dynamic(() =>
   import('@user/userSessionGroupEffect').then((mod) => mod.UserSessionGroupEffect),
@@ -24,7 +24,7 @@ type Props = Partial<Pick<Types, 'children'>> & Pick<TypesLayout, 'path'>;
 export const LayoutHeader = ({ children, path }: Props) => {
   const layoutHome = path === 'home';
   const layoutApp = path === 'app';
-  const isSidebarOpen = useRecoilValue(atomNavigationOpen(path));
+  const isSidebarOpen = useRecoilValue(atomLayoutNavigationOpen(path));
   const scrollPosition = useVerticalScrollPosition();
   const homeSidebarClose = layoutHome && !isSidebarOpen && scrollPosition;
 

--- a/components/layout/layoutHeader/searchBar/index.tsx
+++ b/components/layout/layoutHeader/searchBar/index.tsx
@@ -1,15 +1,15 @@
 import { IconButton } from '@buttons/iconButton';
 import { ICON_SEARCH, ICON_CLOSE } from '@data/materialSymbols';
 import { SvgIcon } from '@icon/svgIcon';
+import { atomLayoutSearch } from '@layout/layout.states';
 import { classNames } from '@stateLogics/utils';
-import { atomSearchInput } from '@states/layouts';
 import { Fragment as ResetSearchFragment, Fragment as SearchBarFragment } from 'react';
 import { useSetRecoilState, useRecoilValue, useResetRecoilState } from 'recoil';
 
 export const SearchBar = () => {
-  const setSearchInput = useSetRecoilState(atomSearchInput);
-  const searchInputValue = useRecoilValue(atomSearchInput);
-  const resetSearchInput = useResetRecoilState(atomSearchInput);
+  const setSearchInput = useSetRecoilState(atomLayoutSearch);
+  const searchInputValue = useRecoilValue(atomLayoutSearch);
+  const resetSearchInput = useResetRecoilState(atomLayoutSearch);
 
   return (
     <SearchBarFragment>

--- a/components/layout/layoutHeader/signInButton/index.tsx
+++ b/components/layout/layoutHeader/signInButton/index.tsx
@@ -1,8 +1,8 @@
 import { Button } from '@buttons/button';
 import { PATH_HOME } from '@constAssertions/data';
+import { atomLayoutType } from '@layout/layout.states';
 import { optionsSignInButton } from '@layout/layout.utils';
 import { TypesOptionsButton } from '@lib/types/options';
-import { atomLayoutType } from '@states/layouts';
 import { signIn } from 'next-auth/react';
 import router from 'next/router';
 import { useEffect } from 'react';


### PR DESCRIPTION
Relocate states associated with Layout components to `layout.states` for the purpose of code structure enhancement. Simultaneously, renames states within `layout.states` to ensure naming consistency.