### PR TITLE
test: Add navigationButton component testing

### DIFF
--- a/components/layout/layoutHeader/navigationButton/__test__/navigationButton.test.tsx
+++ b/components/layout/layoutHeader/navigationButton/__test__/navigationButton.test.tsx
@@ -1,0 +1,41 @@
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { RecoilState } from 'recoil';
+import { NavigationButton } from '..';
+import { atomLayoutNavigationOpen } from '@layout/layout.states';
+
+describe('NavigationButton', () => {
+  const renderWithNavigationButton = <T,>({ node }: { node?: RecoilState<T> }) => {
+    const options = { session: null, node };
+    return renderWithRecoilRootAndSession(<NavigationButton />, options);
+  };
+
+  it('should render the screen reader only text of NavigationButton', () => {
+    const { container } = renderWithNavigationButton({});
+    const screenReaderText = screen.getByText('Open sidebar');
+
+    expect(container).toBeInTheDocument();
+    expect(screenReaderText).toBeInTheDocument();
+  });
+
+  it('should update atomLayoutNavigationOpen state upon clicking the button', async () => {
+    const path = 'app';
+    const { container } = renderWithNavigationButton({ node: atomLayoutNavigationOpen(path) });
+    const screenReaderText = screen.getByText('Open sidebar');
+
+    expect(container).toBeInTheDocument();
+    expect(screenReaderText).toBeInTheDocument();
+
+    await waitFor(() => {
+      const inactiveState = screen.queryByText('inactive');
+      expect(inactiveState).toBeInTheDocument();
+    });
+
+    fireEvent.click(screenReaderText);
+
+    await waitFor(() => {
+      const inactiveState = screen.queryByText('active');
+      expect(inactiveState).toBeInTheDocument();
+    });
+  });
+});

--- a/components/layout/layoutHeader/navigationButton/index.tsx
+++ b/components/layout/layoutHeader/navigationButton/index.tsx
@@ -10,8 +10,9 @@ export const NavigationButton = () => {
       <IconButton
         options={optionsButtonSidebarToggle}
         onClick={() => setNavigationOpen()}
-      />
-      <span className='sr-only'>Open sidebar</span>
+      >
+        <span className='sr-only'>Open sidebar</span>
+      </IconButton>
     </>
   );
 };

--- a/components/layout/layoutHeader/searchBar/__test__/searchBar.test.tsx
+++ b/components/layout/layoutHeader/searchBar/__test__/searchBar.test.tsx
@@ -1,0 +1,7 @@
+/* eslint-disable jest/no-disabled-tests */
+describe('SearchBar', () => {
+  it.skip('should skip the test for future refactor', () => {
+    // Skip test for SearchBar as it's currently a placeholder.
+    // Actual search functionality not yet implemented.
+  });
+});


### PR DESCRIPTION
Incorporate unit tests for the navigationButton component, evaluating both the rendering process and the state updates upon button clicks. As part of these tests, modifications have been made to navigationButton to embed screen-reader only text within iconButton.

Additionally, tests for the searchBar component are deliberately omitted at this time, as the component is currently serving as a placeholder and does not possess its final implementation.