### PR TITLE
test: Implement unit test for LayoutTypeEffect component

### DIFF
--- a/components/layout/layoutEffects/layoutTypeEffect/__test__/layoutTypeEffect.test.tsx
+++ b/components/layout/layoutEffects/layoutTypeEffect/__test__/layoutTypeEffect.test.tsx
@@ -1,0 +1,31 @@
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { LayoutTypeEffect } from '..';
+import { useRecoilValue } from 'recoil';
+import { atomLayoutType } from '@layout/layout.states';
+import { screen } from '@testing-library/react';
+
+const CheckLayoutPath = () => {
+  const layoutPath = useRecoilValue(atomLayoutType);
+  return <div>{layoutPath}</div>;
+};
+
+describe('LayoutTypeEffect', () => {
+  const renderWithLayoutTypeEffect = () => {
+    const options = { session: null };
+    return renderWithRecoilRootAndSession(
+      <>
+        <LayoutTypeEffect path='app' />
+        <CheckLayoutPath />
+      </>,
+      options,
+    );
+  };
+
+  it('should render the correct layout path as text', () => {
+    const { container } = renderWithLayoutTypeEffect();
+    const layoutPath = screen.getByText('app');
+
+    expect(container).toBeInTheDocument();
+    expect(layoutPath).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Add a unit test for the LayoutTypeEffect component to validate whether it mounts properly as an effect component and to ascertain that the state is set accurately for the layout path. By ensuring the component's successful mounting and state accuracy, the functionality of the effect component is verified to meet expectations.