### PR TITLE
fix: Resolve overflow-scroll and transition anomalies

### DIFF
--- a/components/ui/modals/confirmModal/index.tsx
+++ b/components/ui/modals/confirmModal/index.tsx
@@ -43,7 +43,7 @@ export const ConfirmModal = ({ itemIds, ...props }: Props) => {
               </div>
             </div>
           </div>
-          <div className='mt-8 flex justify-end'>
+          <div className='mt-8 flex justify-end will-change-transform'>
             <CancelButton
               options={optionsButtonConfirmModalCancel}
               onClick={() => cancelConfirmModal()}

--- a/components/ui/modals/labelModals/labelModal/index.tsx
+++ b/components/ui/modals/labelModals/labelModal/index.tsx
@@ -61,7 +61,7 @@ export const LabelModal = ({
               <DividerX />
             </div>
           </div>
-          <div className='h-full w-full overflow-scroll pl-2 pr-3'>
+          <div className='h-full w-full overflow-auto pl-2 pr-3'>
             <input
               className={classNames(
                 'w-full rounded-lg border-0 bg-transparent py-1 pl-2 outline-none will-change-transform focus:ring-0 focus:ring-offset-0',

--- a/components/ui/modals/modal/modalHeaders/headerDescription.tsx
+++ b/components/ui/modals/modal/modalHeaders/headerDescription.tsx
@@ -8,7 +8,7 @@ export const HeaderDescription = ({
   return (
     <Dialog.Description
       as='div'
-      className={className || 'p-1 text-base text-gray-600'}
+      className={className || 'p-1 text-base text-gray-600 will-change-transform'}
     >
       <p>{children}</p>
     </Dialog.Description>

--- a/components/ui/modals/modal/modalHeaders/headerTitle.tsx
+++ b/components/ui/modals/modal/modalHeaders/headerTitle.tsx
@@ -1,14 +1,11 @@
 import { Dialog } from '@headlessui/react';
 import { Types } from 'lib/types';
 
-export const HeaderTitle = ({
-  children,
-  className,
-}: Partial<Pick<Types, 'children' | 'className'>>) => {
+export const HeaderTitle = ({ children, className }: Partial<Pick<Types, 'children' | 'className'>>) => {
   return (
     <Dialog.Title
       as='div'
-      className={className || 'text-lg font-medium leading-6 text-gray-800'}
+      className={className || 'text-lg font-medium leading-6 text-gray-800 will-change-transform'}
     >
       {children}
     </Dialog.Title>

--- a/components/ui/modals/todoModals/todoModal/index.tsx
+++ b/components/ui/modals/todoModals/todoModal/index.tsx
@@ -97,7 +97,7 @@ export const TodoModal = ({ todo, menuButtonContent, headerButtons, footerButton
               />
             </div>
           </div>
-          <div className='h-full w-full overflow-scroll will-change-transform'>
+          <div className='h-full w-full overflow-auto will-change-transform'>
             <TodoEditors todo={todo} />
           </div>
           <div className='flex flex-row justify-end pt-4 will-change-transform'>

--- a/lib/data/options/button.tsx
+++ b/lib/data/options/button.tsx
@@ -1,21 +1,21 @@
 import { MODIFIER_KBD } from '@constAssertions/misc';
 import {
-    ICON_CHEVRON_LEFT,
-    ICON_CHEVRON_RIGHT,
-    ICON_CLOSE,
-    ICON_DELETE,
-    ICON_MAXIMIZE,
-    ICON_MENU,
-    ICON_MINIMIZE,
-    ICON_OPEN_IN_FULL,
-    ICON_UNFOLD_MORE
+  ICON_CHEVRON_LEFT,
+  ICON_CHEVRON_RIGHT,
+  ICON_CLOSE,
+  ICON_DELETE,
+  ICON_MAXIMIZE,
+  ICON_MENU,
+  ICON_MINIMIZE,
+  ICON_OPEN_IN_FULL,
+  ICON_UNFOLD_MORE,
 } from '@data/materialSymbols';
 import {
-    STYLE_BUTTON_LARGE_BLUE,
-    STYLE_BUTTON_NORMAL_BLUE,
-    STYLE_BUTTON_NORMAL_RED,
-    STYLE_BUTTON_NORMAL_WHITE,
-    STYLE_HOVER_ENABLED_SLATE_DARK,
+  STYLE_BUTTON_LARGE_BLUE,
+  STYLE_BUTTON_NORMAL_BLUE,
+  STYLE_BUTTON_NORMAL_RED,
+  STYLE_BUTTON_NORMAL_WHITE,
+  STYLE_HOVER_ENABLED_SLATE_DARK,
 } from '@data/stylePreset';
 import { TypesOptionsButton } from '@lib/types/options';
 import { classNames } from '@stateLogics/utils';
@@ -84,7 +84,7 @@ export const optionsButtonConfirmModalDelete: TypesOptionsButton = {
 };
 
 export const optionsButtonConfirmModalDiscard: TypesOptionsButton = {
-  className: STYLE_BUTTON_NORMAL_RED,
+  className: classNames(STYLE_BUTTON_NORMAL_RED, 'will-change-transform'),
   tooltip: 'Discard',
   kbd: 'Enter',
 };
@@ -96,7 +96,7 @@ export const optionsButtonConfirmModalCancelIcon: TypesOptionsButton = {
 };
 
 export const optionsButtonConfirmModalCancel: TypesOptionsButton = {
-  className: classNames(STYLE_BUTTON_NORMAL_WHITE, 'mr-3'),
+  className: classNames(STYLE_BUTTON_NORMAL_WHITE, 'mr-3 will-change-transform'),
   tooltip: 'Cancel',
   kbd: 'Escape',
 };


### PR DESCRIPTION
Switch from overflow-scroll to overflow-auto to eliminate the visibility of the outline. Additionally, append `will-change: transform` property to the element that exhibits slight movement during transitions.