### PR TITLE
fix: Correct misuse of useRouter hook and add missing component

### DIFF
--- a/components/auth/authForm/index.tsx
+++ b/components/auth/authForm/index.tsx
@@ -9,13 +9,17 @@ import { classNames, validateEmailFormat } from '@stateLogics/utils';
 import { atomLoadingSpinner } from '@states/misc';
 import { DividerX } from '@ui/dividers/dividerX';
 import dynamic from 'next/dynamic';
-import { Fragment } from 'react';
+import { Fragment, Suspense } from 'react';
 import { useRecoilValue } from 'recoil';
 import { Logo } from '@layout/layoutHeader/logo';
 import { AuthErrorMessage } from '@auth/authErrorMessage';
 import { atomAuthErrorMessage, atomAuthUser } from '@auth/auth.states';
 import { useAuthFormSubmit, useAuthUserValueUpdate } from '@auth/auth.hooks';
 import { USER } from '@auth/auth.const';
+
+const UserSessionEffect = dynamic(() =>
+  import('@user/userSessionGroupEffect/userSessionEffect').then((mod) => mod.UserSessionEffect),
+);
 
 const AuthErrorMessageEffect = dynamic(() =>
   import('@auth/authEffect/authErrorMessageEffect').then((mod) => mod.AuthErrorMessageEffect),
@@ -74,7 +78,10 @@ export const AuthForm = () => {
           </form>
         </section>
       </div>
-      <AuthErrorMessageEffect />
+      <Suspense fallback={null}>
+        <AuthErrorMessageEffect />
+        <UserSessionEffect />
+      </Suspense>
     </Fragment>
   );
 };

--- a/components/ui/buttons/button/svgLogoButton.tsx
+++ b/components/ui/buttons/button/svgLogoButton.tsx
@@ -1,8 +1,8 @@
 import { TypesPropsOptionsSvg, TypesSvgLogos } from '@icon/icon.types';
 import { signIn } from 'next-auth/react';
-import { useRouter } from 'next-router-mock';
 import { Button } from '.';
 import { DATA_SVG_PROVIDERS } from '@icon/icon.data';
+import { useRouter } from 'next/router';
 
 export const SvgLogoButton = ({ options = {} }: TypesPropsOptionsSvg) => {
   const router = useRouter();

--- a/components/user/user.hooks.ts
+++ b/components/user/user.hooks.ts
@@ -4,7 +4,7 @@ import { Types } from '@lib/types';
 import { delSessionStorage, getSessionStorage, setSessionStorage } from '@stateLogics/utils';
 import { atomUserSession } from '@user/user.states';
 import { useSession } from 'next-auth/react';
-import { useRouter } from 'next-router-mock';
+import { useRouter } from 'next/router';
 import { useRecoilCallback } from 'recoil';
 
 export const useUserSession = () => {


### PR DESCRIPTION
Misuse of the `useRouter` hook from `next-router-mock` has been corrected. Previously, the hook was mistaken for another with the same name from a different module.

The missing `UserSessionEffect` component in the `authForm` component has been added to the appropriate place, ensuring the correct functioning of the component.