### PR TITLE
test: Implement unit test for FilterPathHomeEffect

### DIFF
--- a/components/layout/layoutEffects/filterPathHomeEffect/__test__/filterPathHomeEffect.test.tsx
+++ b/components/layout/layoutEffects/filterPathHomeEffect/__test__/filterPathHomeEffect.test.tsx
@@ -1,0 +1,47 @@
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { FilterPathHomeEffect } from '..';
+import mockRouter from 'next-router-mock';
+import { screen, waitFor } from '@testing-library/react';
+import { useRecoilValue } from 'recoil';
+import { atomHtmlTitleTag } from '@states/misc';
+
+const HtmlTitleTag = () => {
+  const htmlTitleTag = useRecoilValue(atomHtmlTitleTag);
+  return <div>{htmlTitleTag}</div>;
+};
+
+describe('FilterPathHomeEffect', () => {
+  const renderWithFilterPathHomeEffect = () => {
+    const options = { session: null };
+    return renderWithRecoilRootAndSession(
+      <>
+        <FilterPathHomeEffect />
+        <HtmlTitleTag />
+      </>,
+      options,
+    );
+  };
+
+  const testTextPresence = async (pathname: string, text: string) => {
+    await waitFor(() => {
+      mockRouter.push(pathname);
+    });
+
+    const pricingText = screen.getByText(text);
+
+    expect(mockRouter).toMatchObject({ pathname: pathname });
+    expect(pricingText).toBeInTheDocument();
+  };
+
+  it('should render the correct text based on the correct pathname', async () => {
+    const { container } = renderWithFilterPathHomeEffect();
+
+    expect(container).toBeInTheDocument();
+
+    await testTextPresence('/', 'Todo list to automate your tasks');
+    await testTextPresence('/pricing', 'Pricing');
+    await testTextPresence('/features', 'Features');
+    await testTextPresence('/implementations', 'Implementations');
+    await testTextPresence('/contact', 'Contact');
+  });
+});


### PR DESCRIPTION
A unit test for FilterPathHomeEffect has been added. The test focuses on validating the correct rendering of text based on the pathname. This ensures that the htmlTitleTag is correctly displayed.