### PR TITLE
test: Add unit test for BodyTagClassEffect rendering

### DIFF
--- a/components/layout/layoutEffects/bodyTagClassEffect/__test__/bodyTagClassEffect.test.tsx
+++ b/components/layout/layoutEffects/bodyTagClassEffect/__test__/bodyTagClassEffect.test.tsx
@@ -1,0 +1,28 @@
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { BodyTagClassEffect } from '..';
+import { LayoutTypeEffect } from '@layout/layoutEffects/layoutTypeEffect';
+import { TypesLayout } from '@layout/layout.types';
+
+describe('BodyTagClassEffect', () => {
+  const renderWithBodyTagClassEffect = (path: TypesLayout['path']) => {
+    const options = { session: null };
+    return renderWithRecoilRootAndSession(
+      <>
+        <BodyTagClassEffect />
+        <LayoutTypeEffect path={path} />
+      </>,
+      options,
+    );
+  };
+
+  it('should render either the className "overflow-hidden" based on the layoutType', () => {
+    const { container } = renderWithBodyTagClassEffect('app');
+    const bodyElement = document.body;
+
+    expect(container).toBeInTheDocument();
+    expect(bodyElement).toHaveClass('overflow-hidden');
+
+    renderWithBodyTagClassEffect('home');
+    expect(bodyElement).not.toHaveClass('overflow-hidden');
+  });
+});


### PR DESCRIPTION
Incorporate a unit test for BodyTagClassEffect to verify the accurate rendering of className based on layoutType. Ensures proper application of className to the body document.