### PR TITLE
refactor: Revise test command and associated workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,4 +40,4 @@ jobs:
         run: npm ci
 
       - name: Run tests
-        run: npm run test
+        run: npm run test:once

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "lint": "next lint",
     "prepare": "husky install",
     "pre-commit": "npm run lint --fix",
-    "test:watch": "jest --watch",
-    "test": "jest"
+    "test:once": "jest",
+    "test": "jest --watch"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.15",


### PR DESCRIPTION
Modify Package.json to establish `test --watch` as default test command. For single-run tests, `test:once` is now available and `test:watch` has been removed Workflow for executing unit/integration tests updated to utilize `test:once`.