### PR TITLE
test: Augment HomeNavigation with new integration test

### DIFF
--- a/components/layout/home/homeNavigation/__test__/homeNavigation.test.tsx
+++ b/components/layout/home/homeNavigation/__test__/homeNavigation.test.tsx
@@ -1,0 +1,61 @@
+import { TypesLayout } from '@layout/layout.types';
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import mockRouter from 'next-router-mock';
+import { HomeNavigation } from '..';
+
+describe('HomeNavigation', () => {
+  const renderWithHomeNavigation = (path: TypesLayout['path']) => {
+    const options = { session: null };
+    return renderWithRecoilRootAndSession(<HomeNavigation path={path} />, options);
+  };
+
+  const TEXTS = [
+    { name: 'features', text: 'Features', path: '/features' },
+    { name: 'implementations', text: 'Implementations', path: '/implementations' },
+    { name: 'pricing', text: 'Pricing', path: '/pricing' },
+    { name: 'signIn', text: 'Sign in', path: '/auth' },
+    { name: 'tryDemo', text: 'Try Demo', path: '/demo' },
+  ];
+
+  it('should render the home navigation text', () => {
+    const { container } = renderWithHomeNavigation('home');
+
+    expect(container).toBeInTheDocument();
+
+    TEXTS.forEach((item) => {
+      const textElement = screen.getByText(item.text);
+      expect(textElement).toBeInTheDocument();
+    });
+  });
+
+  it('should route to the correct pathname when the link button is clicked', () => {
+    mockRouter.push('/');
+    renderWithHomeNavigation('home');
+
+    expect(mockRouter).toMatchObject({ pathname: '/' });
+
+    TEXTS.forEach(async (item) => {
+      if (item.name === 'signIn') return; // due to the nature of next-auth signIn with next-router-mock does not work in test environment. Also next-auth is expected to be well tested already.
+      const textElement = screen.getByText(item.text);
+      fireEvent.click(textElement);
+      await waitFor(() => {
+        expect(mockRouter).toMatchObject({ pathname: item.path });
+      });
+    });
+  });
+
+  it('should use the correct classNames when layoutType equals to "home"', () => {
+    renderWithHomeNavigation('home');
+    const navElement = screen.getByTestId('homeNavigation');
+    expect(navElement).toHaveClass(
+      'flex-col bg-slate-50 max-ml:space-y-4 max-ml:rounded-b-xl max-ml:px-5 max-ml:pb-8 max-ml:pt-[6rem] ml:flex ml:flex-row ml:items-center ml:space-x-3 ml:bg-transparent ml:pr-0 lg:pr-3',
+    );
+  });
+
+  it('should use the correct classNames when layoutType equals to "app"', () => {
+    renderWithHomeNavigation('app');
+    const navElement = screen.getByTestId('homeNavigation');
+    expect(navElement).toHaveClass('flex-row items-center space-x-10 pr-3 sm:pr-8');
+  });
+});

--- a/components/layout/home/homeNavigation/index.tsx
+++ b/components/layout/home/homeNavigation/index.tsx
@@ -28,6 +28,7 @@ export const HomeNavigation = ({ path }: Props) => {
         layoutHome &&
           'flex-col bg-slate-50 max-ml:space-y-4 max-ml:rounded-b-xl max-ml:px-5 max-ml:pb-8 max-ml:pt-[6rem] ml:flex ml:flex-row ml:items-center ml:space-x-3 ml:bg-transparent ml:pr-0 lg:pr-3',
       )}
+      data-testid='homeNavigation'
     >
       {DATA_HOME.map((path) => (
         <div key={path.name}>

--- a/lib/stateLogics/utils/testUtils.tsx
+++ b/lib/stateLogics/utils/testUtils.tsx
@@ -3,6 +3,7 @@ import { Session } from 'next-auth';
 import { SessionProvider } from 'next-auth/react';
 import { ReactElement, ReactNode, useEffect } from 'react';
 import { RecoilRoot, RecoilState, atom, useRecoilSnapshot, useSetRecoilState } from 'recoil';
+import { MemoryRouterProvider } from 'next-router-mock/MemoryRouterProvider';
 
 interface TypesRecoilRootProvider<T> extends TypesRecoilObserver<T> {
   children: ReactNode;
@@ -29,13 +30,15 @@ export const RecoilObserver = <T,>({ node, state }: TypesRecoilObserver<T>) => {
 
 const RecoilRootProvider = <T,>({ children, session, node, state }: TypesRecoilRootProvider<T>) => {
   return (
-    <RecoilRoot>
-      <SessionProvider session={session}>{children}</SessionProvider>
-      <RecoilObserver
-        node={node}
-        state={state}
-      />
-    </RecoilRoot>
+    <MemoryRouterProvider>
+      <RecoilRoot>
+        <SessionProvider session={session}>{children}</SessionProvider>
+        <RecoilObserver
+          node={node}
+          state={state}
+        />
+      </RecoilRoot>
+    </MemoryRouterProvider>
   );
 };
 


### PR DESCRIPTION
HomeNavigation component now possesses a data-testid for integration testing. `<MemoryRouterProvider>` has been appended to the default renderFunction to enable testing of next.js link component. Rendering, routing, and conditional classNames form the core areas of testing.