### PR TITLE
test: Add integration test for LayoutHome component

### DIFF
--- a/components/layout/home/__test__/home.test.tsx
+++ b/components/layout/home/__test__/home.test.tsx
@@ -1,0 +1,67 @@
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import 'fake-indexeddb/auto';
+import { LayoutHome } from '..';
+import { screen } from '@testing-library/react';
+import mockRouter from 'next-router-mock';
+
+jest.mock('next/head', () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return <title>mocked-title</title>;
+    },
+  };
+});
+
+describe('LayoutHome', () => {
+  const renderWithLayoutHome = () => {
+    const options = { session: null };
+    return renderWithRecoilRootAndSession(
+      <>
+        <LayoutHome>
+          <></>
+        </LayoutHome>
+      </>,
+      options,
+    );
+  };
+
+  it('should render the title tag', () => {
+    const { container } = renderWithLayoutHome();
+    const titleTag = document.title;
+
+    expect(container).toBeInTheDocument();
+    expect(titleTag).toBe('mocked-title');
+  });
+
+  it('should mount the homeNavigation component', () => {
+    renderWithLayoutHome();
+    const homeNavigationTestId = screen.getByTestId('homeNavigation');
+
+    expect(homeNavigationTestId).toBeInTheDocument();
+  });
+
+  it('should mount the layoutFooter component', () => {
+    renderWithLayoutHome();
+    const layoutFooterTestId = screen.getByTestId('layoutFooter');
+
+    expect(layoutFooterTestId).toBeInTheDocument();
+  });
+
+  it('should mount the footer component', () => {
+    renderWithLayoutHome();
+    const footerText = screen.getByLabelText('Footer');
+
+    expect(footerText).toBeInTheDocument();
+  });
+
+  it('should not have className "overflow-hidden" when the "home" is the pathname', async () => {
+    mockRouter.push('/');
+    renderWithLayoutHome();
+
+    const bodyElement = document.body;
+
+    expect(mockRouter).toMatchObject({ pathname: '/' });
+    expect(bodyElement).not.toHaveClass('overflow-hidden');
+  });
+});

--- a/components/layout/layoutFooter/index.tsx
+++ b/components/layout/layoutFooter/index.tsx
@@ -13,7 +13,10 @@ export const LayoutFooter = ({ children, path }: Props) => {
 
   return (
     <LayoutFooterFragment>
-      <div className='flex h-full flex-row'>
+      <div
+        className='flex h-full flex-row'
+        data-testid='layoutFooter'
+      >
         <SidebarTransition path={path}>
           {layoutApp && <AppNavigation />}
           {layoutHome && <HomeNavigation path={path} />}


### PR DESCRIPTION
Add integration test ensuring child components render correctly within LayoutHome. Mock next/head in the test due to its inability to render in testing environment. For accurate testing, testid is added to LayoutFooter component.