### PR TITLE
refactor: Revert to original npm test configurations

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,4 +40,4 @@ jobs:
         run: npm ci
 
       - name: Run tests
-        run: npm run test:once
+        run: npm run test

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "lint": "next lint",
     "prepare": "husky install",
     "pre-commit": "npm run lint --fix",
-    "test:once": "jest",
-    "test": "jest --watch"
+    "test:watch": "jest --watch",
+    "test": "jest"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.15",


### PR DESCRIPTION
Restore npm test configurations to their initial state. Running `npm run test` executes the test suite a single time. For continuous testing during development, employ `npm run test:watch`.