### PR TITLE
chore: Update test configs to execute default test once

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,4 +40,4 @@ jobs:
         run: npm ci
 
       - name: Run tests
-        run: npm run test:once
+        run: npm run test

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "lint": "next lint",
     "prepare": "husky install",
     "pre-commit": "npm run lint --fix",
-    "test:once": "jest",
-    "test": "jest --watch"
+    "test:watch": "jest --watch",
+    "test": "jest"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.15",


### PR DESCRIPTION
Revert test configurations to execute the default test solely one time. Now, running `npm run test` triggers the test once. The subsequent workflows for executing unit and integration tests have been modified to reflect these alterations. For continuous monitoring of the test, employ `npm run test:watch`.