### PR TITLE
refactor: Reorganize mock component and rename for clarity

### DIFF
--- a/components/auth/authEffect/__test__/__mock__/mockErrorMessageObserver.tsx
+++ b/components/auth/authEffect/__test__/__mock__/mockErrorMessageObserver.tsx
@@ -1,0 +1,13 @@
+import { atomAuthErrorMessage } from '@auth/auth.states';
+import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+
+export const MockErrorMessageObserver = () => {
+  const [message, setMessage] = useRecoilState(atomAuthErrorMessage);
+  const defaultError = 'Something went wrong';
+
+  useEffect(() => {
+    setMessage(defaultError);
+  }, [setMessage]);
+  return <>{message}</>;
+};

--- a/components/auth/authEffect/__test__/authErrorMessageEffect.test.tsx
+++ b/components/auth/authEffect/__test__/authErrorMessageEffect.test.tsx
@@ -1,21 +1,11 @@
-import { atomAuthErrorMessage, atomAuthUser } from '@auth/auth.states';
+import { atomAuthUser } from '@auth/auth.states';
 import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
 import { screen } from '@testing-library/react';
-import { useEffect } from 'react';
-import { RecoilState, useRecoilState } from 'recoil';
+import { RecoilState } from 'recoil';
 import { AuthErrorMessageEffect } from '../authErrorMessageEffect';
+import { MockErrorMessageObserver } from './__mock__/mockErrorMessageObserver';
 
 type Props<T> = { node?: RecoilState<T>; state?: T };
-
-const ErrorMessageObserver = () => {
-  const [message, setMessage] = useRecoilState(atomAuthErrorMessage);
-  const defaultError = 'Something went wrong';
-
-  useEffect(() => {
-    setMessage(defaultError);
-  }, [setMessage]);
-  return <>{message}</>;
-};
 
 describe('AuthErrorMessageEffect', () => {
   const renderAuthConfirmation = <T,>({ node, state }: Props<T>) => {
@@ -23,7 +13,7 @@ describe('AuthErrorMessageEffect', () => {
     return renderWithRecoilRootAndSession(
       <>
         <AuthErrorMessageEffect />
-        <ErrorMessageObserver />
+        <MockErrorMessageObserver />
       </>,
       options,
     );

--- a/components/label/labelList/labelItem/__test__/__mock__/mockInitialNavigationEffect.tsx
+++ b/components/label/labelList/labelItem/__test__/__mock__/mockInitialNavigationEffect.tsx
@@ -1,0 +1,12 @@
+import { useInitialNavigation } from '@layout/layout.hooks';
+import { useEffect } from 'react';
+
+export const MockInitialNavigationEffect = ({ isBreakpointMd }: { isBreakpointMd: boolean }) => {
+  const setInitial = useInitialNavigation({ path: 'app' });
+  const mockValue = isBreakpointMd;
+
+  useEffect(() => {
+    !mockValue && setInitial();
+  }, [mockValue, setInitial]);
+  return null;
+};

--- a/components/label/labelList/labelItem/__test__/labelItem.test.tsx
+++ b/components/label/labelList/labelItem/__test__/labelItem.test.tsx
@@ -4,12 +4,12 @@ import { screen } from '@testing-library/react';
 import { UserSessionEffect } from '@user/userSessionGroupEffect/userSessionEffect';
 import { mockedLabelItem } from '__mock__/label';
 import mockRouter from 'next-router-mock';
-import { Suspense, useEffect } from 'react';
+import { Suspense } from 'react';
 import { RecoilState, useRecoilValue } from 'recoil';
 import { LabelItem } from '..';
 import { atomConfirmModalDelete, atomLabelModalOpen } from '@states/modals';
-import { useInitialNavigation } from '@layout/layout.hooks';
 import { atomLayoutNavigationOpen } from '@layout/layout.states';
+import { MockInitialNavigationEffect } from './__mock__/mockInitialNavigationEffect';
 
 jest.mock('@modals/labelModals/labelModal/itemLabelModal', () => ({
   ItemLabelModal: () => {
@@ -27,16 +27,6 @@ jest.mock('@modals/confirmModal/deleteConfirmModal/deleteLabelConfirmModal', () 
   },
 }));
 
-const InitialNavigationEffect = ({ isBreakpointMd }: { isBreakpointMd: boolean }) => {
-  const setInitial = useInitialNavigation({ path: 'app' });
-  const mockValue = isBreakpointMd;
-
-  useEffect(() => {
-    !mockValue && setInitial();
-  }, [mockValue, setInitial]);
-  return null;
-};
-
 describe('LabelItem', () => {
   const renderWithLabelItem = <T,>(node?: RecoilState<T>, isBreakpointMd?: boolean) => {
     const options = { session: null, node: node };
@@ -45,7 +35,7 @@ describe('LabelItem', () => {
         <LabelItem label={mockedLabelItem} />
         <UserSessionEffect />
         <Suspense fallback={null}>
-          <InitialNavigationEffect isBreakpointMd={isBreakpointMd ?? false} />
+          <MockInitialNavigationEffect isBreakpointMd={isBreakpointMd ?? false} />
         </Suspense>
       </>,
       options,

--- a/components/layout/app/layoutAppLazy/__test__/__mock__/mockStateEffect.tsx
+++ b/components/layout/app/layoutAppLazy/__test__/__mock__/mockStateEffect.tsx
@@ -18,7 +18,7 @@ export type PropsMockStateEffect<T> = {
   node?: RecoilState<T>;
 };
 
-export const MockStateEffect = <T,>({
+export const MockLayoutAppLazyEffect = <T,>({
   mediaQueryState,
   notificationId,
   isTodoModalOpen,
@@ -29,7 +29,6 @@ export const MockStateEffect = <T,>({
   const htmlTitleTag = useRecoilValue(atomHtmlTitleTag);
   const isNavigationOpen = useRecoilValue(atomLayoutNavigationOpen('app'));
   const setMediaQuery = useSetRecoilState(atomEffectMediaQuery(BREAKPOINT['md']));
-  const notificationIdIsSet = useRecoilValue(atomNotificationID);
   const setNotificationId = useSetRecoilState(atomNotificationID);
   const setNotificationOpen = useSetRecoilState(atomNotificationOpen);
   const setTodoModalOpen = useSetRecoilState(atomTodoModalOpen(undefined));
@@ -40,7 +39,7 @@ export const MockStateEffect = <T,>({
   useEffect(() => {
     setMediaQuery(mediaQueryState ?? false);
     setNotificationId(notificationId ?? 'updatedTodo');
-    !!notificationIdIsSet && setNotificationOpen(true);
+    !!notificationId && setNotificationOpen(true);
     setTodoModalOpen(isTodoModalOpen ?? false);
     setMinimizedTodoModalOpen(isMinimizedTodoModalOpen ?? false);
     !!isMinimizedTodoModalOpen && setTodoNew({ title: 'test-title' } as Todos);
@@ -51,7 +50,6 @@ export const MockStateEffect = <T,>({
     isTodoModalOpen,
     mediaQueryState,
     notificationId,
-    notificationIdIsSet,
     setLabelModalOpen,
     setMediaQuery,
     setMinimizedTodoModalOpen,

--- a/components/layout/app/layoutAppLazy/__test__/layoutAppLazy.test.tsx
+++ b/components/layout/app/layoutAppLazy/__test__/layoutAppLazy.test.tsx
@@ -1,10 +1,9 @@
 import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
 import { LayoutAppLazy } from '..';
-import { screen, waitFor } from '@testing-library/react';
+import { PropsMockStateEffect, MockLayoutAppLazyEffect } from './__mock__/mockStateEffect';
+import { atomTodoModalOpen, atomLabelModalOpen } from '@states/modals';
+import { screen, waitFor } from '@testing-library/dom';
 import mockRouter from 'next-router-mock';
-import { MockStateEffect, PropsMockStateEffect } from './mockStateEffect';
-import { UserSessionEffect } from '@user/userSessionGroupEffect/userSessionEffect';
-import { atomLabelModalOpen, atomTodoModalOpen } from '@states/modals';
 
 describe('LayoutAppLazy', () => {
   const renderWithLayoutAppLazy = <T,>({
@@ -19,48 +18,56 @@ describe('LayoutAppLazy', () => {
     return renderWithRecoilRootAndSession(
       <>
         <LayoutAppLazy path='app' />
-        <MockStateEffect
+        <MockLayoutAppLazyEffect
           mediaQueryState={mediaQueryState}
           notificationId={notificationId}
           isTodoModalOpen={isTodoModalOpen}
           isMinimizedTodoModalOpen={isMinimizedTodoModalOpen}
           isLabelModalOpen={isLabelModalOpen}
         />
-        <UserSessionEffect />
       </>,
       options,
     );
   };
 
-  it('should set the atomLayoutType correctly when path is app', () => {
+  it('should set the atomLayoutType correctly when path is app', async () => {
     const { container } = renderWithLayoutAppLazy({});
-    const layoutTypeText = screen.getByText('Layout Type: app');
-
     expect(container).toBeInTheDocument();
-    expect(layoutTypeText).toBeInTheDocument();
+
+    await waitFor(() => {
+      const layoutTypeText = screen.queryByText('Layout Type: app');
+      expect(layoutTypeText).toBeInTheDocument();
+    });
   });
 
-  it('should render the correct htmlTitleTag text when route equals to urgent', () => {
+  it('should render the correct htmlTitleTag text when route equals to urgent', async () => {
     mockRouter.push('/app/urgent');
     renderWithLayoutAppLazy({});
-    const htmlTitleTagText = screen.getByText('Html Title Tag: Priority | Urgent');
 
     expect(mockRouter).toMatchObject({ pathname: '/app/urgent' });
-    expect(htmlTitleTagText).toBeInTheDocument();
+
+    await waitFor(() => {
+      const htmlTitleTagText = screen.queryByText('Html Title Tag: Priority | Urgent');
+      expect(htmlTitleTagText).toBeInTheDocument();
+    });
   });
 
-  it('should navigation close (or false) when layout type equals to app and breakpoint is above medium', () => {
+  it('should navigation close (or false) when layout type equals to app and breakpoint is above medium', async () => {
     renderWithLayoutAppLazy({ mediaQueryState: false });
-    const navigationOpenTextFalse = screen.getByText('Navigation state: false');
 
-    expect(navigationOpenTextFalse).toBeInTheDocument();
+    await waitFor(() => {
+      const navigationOpenTextFalse = screen.queryByText('Navigation state: false');
+      expect(navigationOpenTextFalse).toBeInTheDocument();
+    });
   });
 
-  it('should navigation open (or true) when layout type equals to app and breakpoint is not above medium', () => {
+  it('should navigation open (or true) when layout type equals to app and breakpoint is not above medium', async () => {
     renderWithLayoutAppLazy({ mediaQueryState: true });
-    const navigationOpenTextFalse = screen.getByText('Navigation state: true');
 
-    expect(navigationOpenTextFalse).toBeInTheDocument();
+    await waitFor(() => {
+      const navigationOpenTextFalse = screen.queryByText('Navigation state: true');
+      expect(navigationOpenTextFalse).toBeInTheDocument();
+    });
   });
 
   it('should have the class "overflow-hidden" on the body element when layoutType is app', () => {
@@ -70,11 +77,13 @@ describe('LayoutAppLazy', () => {
     expect(bodyElement).toHaveClass('overflow-hidden');
   });
 
-  it('should show the notification message when notification is open', () => {
+  it('should show the notification message when notification is open', async () => {
     renderWithLayoutAppLazy({ notificationId: 'updatedTodo' });
-    const notificationText = screen.getByText('Todo updated');
 
-    expect(notificationText).toBeInTheDocument();
+    await waitFor(() => {
+      const notificationText = screen.queryByText('Todo updated');
+      expect(notificationText).toBeInTheDocument();
+    });
   });
 
   it('should render the correct modal text when todoModal is open', async () => {

--- a/components/layout/home/layoutHomeLazy/__test__/__mock__/mockStateEffect.tsx
+++ b/components/layout/home/layoutHomeLazy/__test__/__mock__/mockStateEffect.tsx
@@ -1,0 +1,17 @@
+import { atomLayoutType, atomLayoutNavigationOpen } from '@layout/layout.states';
+import { atomHtmlTitleTag } from '@states/misc';
+import { useRecoilValue } from 'recoil';
+
+export const MockStateEffect = () => {
+  const layoutType = useRecoilValue(atomLayoutType);
+  const htmlTitleTag = useRecoilValue(atomHtmlTitleTag);
+  const layoutNavigationOpen = useRecoilValue(atomLayoutNavigationOpen('home'));
+
+  return (
+    <>
+      <div>LayoutType: {layoutType}</div>
+      <div>HtmlTitleTag: {htmlTitleTag}</div>
+      <div>LayoutNavigation: {layoutNavigationOpen ? 'True' : 'false'}</div>
+    </>
+  );
+};

--- a/components/layout/home/layoutHomeLazy/__test__/layoutHomeLazy.test.tsx
+++ b/components/layout/home/layoutHomeLazy/__test__/layoutHomeLazy.test.tsx
@@ -1,23 +1,7 @@
 import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
 import { LayoutHomeLazy } from '..';
-import { useRecoilValue } from 'recoil';
-import { atomLayoutNavigationOpen, atomLayoutType } from '@layout/layout.states';
 import { screen } from '@testing-library/react';
-import { atomHtmlTitleTag } from '@states/misc';
-
-const StateEffect = () => {
-  const layoutType = useRecoilValue(atomLayoutType);
-  const htmlTitleTag = useRecoilValue(atomHtmlTitleTag);
-  const layoutNavigationOpen = useRecoilValue(atomLayoutNavigationOpen('home'));
-
-  return (
-    <>
-      <div>LayoutType: {layoutType}</div>
-      <div>HtmlTitleTag: {htmlTitleTag}</div>
-      <div>LayoutNavigation: {layoutNavigationOpen ? 'True' : 'false'}</div>
-    </>
-  );
-};
+import { MockStateEffect } from './__mock__/mockStateEffect';
 
 describe('LayoutHomeLazy', () => {
   const renderWithLayoutHomeLazy = () => {
@@ -25,7 +9,7 @@ describe('LayoutHomeLazy', () => {
     return renderWithRecoilRootAndSession(
       <>
         <LayoutHomeLazy path='home' />
-        <StateEffect />
+        <MockStateEffect />
       </>,
       options,
     );

--- a/components/layout/layoutEffects/initialNavigationEffect/__test__/__mock__/mockNavigationEffect.tsx
+++ b/components/layout/layoutEffects/initialNavigationEffect/__test__/__mock__/mockNavigationEffect.tsx
@@ -1,0 +1,22 @@
+import { BREAKPOINT } from '@constAssertions/ui';
+import { atomLayoutNavigationOpen } from '@layout/layout.states';
+import { atomEffectMediaQuery } from '@states/atomEffects/misc';
+import { useEffect } from 'react';
+import { useSetRecoilState, useRecoilValue } from 'recoil';
+
+export const MockNavigationEffect = ({ isBreakpoint }: { isBreakpoint: boolean }) => {
+  const setBreakpoint = useSetRecoilState(atomEffectMediaQuery(BREAKPOINT['md']));
+  const appNavigation = useRecoilValue(atomLayoutNavigationOpen('app'));
+  const homeNavigation = useRecoilValue(atomLayoutNavigationOpen('home'));
+
+  useEffect(() => {
+    setBreakpoint(isBreakpoint ?? false);
+  }, [isBreakpoint, setBreakpoint]);
+
+  return (
+    <>
+      {appNavigation ? 'appNavigationOpen' : null}
+      {homeNavigation ? 'homeNavigationOpen' : null}
+    </>
+  );
+};

--- a/components/layout/layoutEffects/initialNavigationEffect/__test__/initialNavigationEffect.test.tsx
+++ b/components/layout/layoutEffects/initialNavigationEffect/__test__/initialNavigationEffect.test.tsx
@@ -1,28 +1,7 @@
-import { BREAKPOINT } from '@constAssertions/ui';
-import { atomLayoutNavigationOpen } from '@layout/layout.states';
 import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
-import { atomEffectMediaQuery } from '@states/atomEffects/misc';
-import { useEffect } from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { InitialNavigationEffect } from '..';
 import { screen, waitFor } from '@testing-library/react';
-
-const MockNavigationEffect = ({ isBreakpoint }: { isBreakpoint: boolean }) => {
-  const setBreakpoint = useSetRecoilState(atomEffectMediaQuery(BREAKPOINT['md']));
-  const appNavigation = useRecoilValue(atomLayoutNavigationOpen('app'));
-  const homeNavigation = useRecoilValue(atomLayoutNavigationOpen('home'));
-
-  useEffect(() => {
-    setBreakpoint(isBreakpoint ?? false);
-  }, [isBreakpoint, setBreakpoint]);
-
-  return (
-    <>
-      {appNavigation ? 'appNavigationOpen' : null}
-      {homeNavigation ? 'homeNavigationOpen' : null}
-    </>
-  );
-};
+import { MockNavigationEffect } from './__mock__/mockNavigationEffect';
 
 describe('InitialNavigationEffect', () => {
   const renderWithInitialNavigationEffect = (isBreakpoint: boolean) => {

--- a/components/layout/layoutFooter/__test__/__mock__/mockSidebarOpenEffect.tsx
+++ b/components/layout/layoutFooter/__test__/__mock__/mockSidebarOpenEffect.tsx
@@ -1,0 +1,16 @@
+import { atomLayoutNavigationOpen } from '@layout/layout.states';
+import { TypesLayout } from '@layout/layout.types';
+import { useEffect } from 'react';
+import { useSetRecoilState } from 'recoil';
+
+export type PropsSidebarOpenEffect = Pick<TypesLayout, 'path'> & { isSidebarOpen: boolean };
+
+export const MockSidebarOpenEffect = ({ isSidebarOpen, path }: PropsSidebarOpenEffect) => {
+  const setSidebarOpen = useSetRecoilState(atomLayoutNavigationOpen(path));
+
+  useEffect(() => {
+    setSidebarOpen(isSidebarOpen ?? false);
+  }, [isSidebarOpen, setSidebarOpen]);
+
+  return null;
+};

--- a/components/layout/layoutFooter/__test__/layoutFooter.test.tsx
+++ b/components/layout/layoutFooter/__test__/layoutFooter.test.tsx
@@ -1,22 +1,7 @@
-import { TypesLayout } from '@layout/layout.types';
 import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
 import { LayoutFooter } from '..';
-import { useEffect } from 'react';
-import { useSetRecoilState } from 'recoil';
-import { atomLayoutNavigationOpen } from '@layout/layout.states';
 import { screen, waitFor } from '@testing-library/react';
-
-type Props = Pick<TypesLayout, 'path'> & { isSidebarOpen: boolean };
-
-const SidebarOpenEffect = ({ isSidebarOpen, path }: Props) => {
-  const setSidebarOpen = useSetRecoilState(atomLayoutNavigationOpen(path));
-
-  useEffect(() => {
-    setSidebarOpen(isSidebarOpen ?? false);
-  }, [isSidebarOpen, setSidebarOpen]);
-
-  return null;
-};
+import { PropsSidebarOpenEffect, MockSidebarOpenEffect } from './__mock__/mockSidebarOpenEffect';
 
 const testTextPresence = async ({ text, isTextPresent }: { text: string; isTextPresent: boolean }) => {
   await waitFor(() => {
@@ -30,12 +15,12 @@ const appText = 'Create todo';
 const homeText = 'Contact';
 
 describe('LayoutFooter', () => {
-  const renderWithLayoutFooter = ({ isSidebarOpen, path }: Props) => {
+  const renderWithLayoutFooter = ({ isSidebarOpen, path }: PropsSidebarOpenEffect) => {
     const options = { session: null };
     return renderWithRecoilRootAndSession(
       <>
         <LayoutFooter path={path}>LayoutFooter-text</LayoutFooter>
-        <SidebarOpenEffect
+        <MockSidebarOpenEffect
           path={path}
           isSidebarOpen={isSidebarOpen}
         />

--- a/components/layout/layoutFooter/footerBody/__test__/__mock__/mockFooterStateEffect.tsx
+++ b/components/layout/layoutFooter/footerBody/__test__/__mock__/mockFooterStateEffect.tsx
@@ -1,0 +1,21 @@
+import { atomLayoutNavigationOpen } from '@layout/layout.states';
+import { atomDisableScroll } from '@states/misc';
+import { useEffect } from 'react';
+import { useSetRecoilState } from 'recoil';
+
+export type PropsFooterStateEffect = {
+  isSidebarOpen?: boolean;
+  isScrollDisabled?: boolean;
+};
+
+export const MockFooterStateEffect = ({ isSidebarOpen, isScrollDisabled }: PropsFooterStateEffect) => {
+  const setSideBarOpen = useSetRecoilState(atomLayoutNavigationOpen('app'));
+  const setScrollBar = useSetRecoilState(atomDisableScroll);
+
+  useEffect(() => {
+    setSideBarOpen(isSidebarOpen ?? false);
+    isScrollDisabled ? setScrollBar(isScrollDisabled) : null;
+  }, [isScrollDisabled, isSidebarOpen, setScrollBar, setSideBarOpen]);
+
+  return null;
+};

--- a/components/layout/layoutFooter/footerBody/__test__/footerBody.test.tsx
+++ b/components/layout/layoutFooter/footerBody/__test__/footerBody.test.tsx
@@ -1,41 +1,21 @@
-import { atomLayoutNavigationOpen } from '@layout/layout.states';
 import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
-import { atomDisableScroll } from '@states/misc';
 import { screen } from '@testing-library/react';
-import { useEffect } from 'react';
-import { useSetRecoilState } from 'recoil';
 import { FooterBody } from '..';
+import { MockFooterStateEffect, PropsFooterStateEffect } from './__mock__/mockFooterStateEffect';
 
 jest.mock('@ui/gradients/globalVerticalGradient', () => ({
   GlobalVerticalGradient: () => <div>Top Gradient</div>,
 }));
 
-type Props = {
-  isSidebarOpen?: boolean;
-  isScrollDisabled?: boolean;
-};
-
-const MockStateEffect = ({ isSidebarOpen, isScrollDisabled }: Props) => {
-  const setSideBarOpen = useSetRecoilState(atomLayoutNavigationOpen('app'));
-  const setScrollBar = useSetRecoilState(atomDisableScroll);
-
-  useEffect(() => {
-    setSideBarOpen(isSidebarOpen ?? false);
-    isScrollDisabled ? setScrollBar(isScrollDisabled) : null;
-  }, [isScrollDisabled, isSidebarOpen, setScrollBar, setSideBarOpen]);
-
-  return null;
-};
-
 describe('FooterBody', () => {
-  const renderWithFooterBody = ({ isSidebarOpen, isScrollDisabled }: Props) => {
+  const renderWithFooterBody = ({ isSidebarOpen, isScrollDisabled }: PropsFooterStateEffect) => {
     const options = { session: null };
     return renderWithRecoilRootAndSession(
       <>
         <FooterBody>
           <></>
         </FooterBody>
-        <MockStateEffect
+        <MockFooterStateEffect
           isSidebarOpen={isSidebarOpen}
           isScrollDisabled={isScrollDisabled}
         />

--- a/components/layout/layoutFooter/sidebarTransition/__test__/__mock__/mockSidebarTransition.tsx
+++ b/components/layout/layoutFooter/sidebarTransition/__test__/__mock__/mockSidebarTransition.tsx
@@ -1,0 +1,22 @@
+import { BREAKPOINT } from '@constAssertions/ui';
+import { atomLayoutNavigationOpen } from '@layout/layout.states';
+import { TypesLayout } from '@layout/layout.types';
+import { atomEffectMediaQuery } from '@states/atomEffects/misc';
+import { useEffect } from 'react';
+import { useSetRecoilState } from 'recoil';
+
+export type PropsSidebarTransition = Pick<TypesLayout, 'path'> & {
+  isSidebarOpen?: boolean;
+  isBreakpoint?: boolean;
+};
+
+export const MockSidebarTransition = ({ isSidebarOpen, isBreakpoint, path }: PropsSidebarTransition) => {
+  const setSidebarOpen = useSetRecoilState(atomLayoutNavigationOpen(path));
+  const setBreakpoint = useSetRecoilState(atomEffectMediaQuery(BREAKPOINT['md']));
+
+  useEffect(() => {
+    setSidebarOpen(isSidebarOpen ?? false);
+    setBreakpoint(isBreakpoint ?? false);
+  });
+  return null;
+};

--- a/components/layout/layoutFooter/sidebarTransition/__test__/sidebarTransition.test.tsx
+++ b/components/layout/layoutFooter/sidebarTransition/__test__/sidebarTransition.test.tsx
@@ -1,33 +1,15 @@
-import { atomLayoutNavigationOpen } from '@layout/layout.states';
-import { TypesLayout } from '@layout/layout.types';
 import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
 import { screen, waitFor } from '@testing-library/react';
-import { useEffect } from 'react';
-import { useSetRecoilState } from 'recoil';
 import { SidebarTransition } from '..';
-import { atomEffectMediaQuery } from '@states/atomEffects/misc';
-import { BREAKPOINT } from '@constAssertions/ui';
-
-type Props = Pick<TypesLayout, 'path'> & { isSidebarOpen?: boolean; isBreakpoint?: boolean };
-
-const SidebarEffect = ({ isSidebarOpen, isBreakpoint, path }: Props) => {
-  const setSidebarOpen = useSetRecoilState(atomLayoutNavigationOpen(path));
-  const setBreakpoint = useSetRecoilState(atomEffectMediaQuery(BREAKPOINT['md']));
-
-  useEffect(() => {
-    setSidebarOpen(isSidebarOpen ?? false);
-    setBreakpoint(isBreakpoint ?? false);
-  });
-  return null;
-};
+import { PropsSidebarTransition, MockSidebarTransition } from './__mock__/mockSidebarTransition';
 
 describe('SidebarTransition', () => {
-  const renderWithSidebarTransition = ({ isBreakpoint, isSidebarOpen, path }: Props) => {
+  const renderWithSidebarTransition = ({ isBreakpoint, isSidebarOpen, path }: PropsSidebarTransition) => {
     const options = { session: null };
     return renderWithRecoilRootAndSession(
       <>
         <SidebarTransition path={path}>transition-text</SidebarTransition>
-        <SidebarEffect
+        <MockSidebarTransition
           path={path}
           isSidebarOpen={isSidebarOpen}
           isBreakpoint={isBreakpoint}


### PR DESCRIPTION
Implement a directory specific to mocks to enhance readability and organization of test suites.

Rename MockStateEffect to MockLayoutAppLazyEffect for more descriptive naming.