### PR TITLE
test: Add unit tests for TodosCount component

### DIFF
--- a/components/layout/app/todosCount/__test__/todosCount.test.tsx
+++ b/components/layout/app/todosCount/__test__/todosCount.test.tsx
@@ -1,0 +1,61 @@
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { TodosCount } from '..';
+import { UserSessionEffect } from '@user/userSessionGroupEffect/userSessionEffect';
+import { screen, waitFor } from '@testing-library/react';
+import { Suspense } from 'react';
+import { DATA_DEMO } from '@collections/demo';
+import { DATA_DEMO_LABELS } from '@label/label.data';
+import { PropsTodosCount } from '@layout/layout.types';
+import { Labels } from '@label/label.types';
+
+describe('TodosCount', () => {
+  const renderWithTodosCount = ({ pathname, label }: PropsTodosCount) => {
+    const options = { session: null };
+    return renderWithRecoilRootAndSession(
+      <>
+        <Suspense>
+          <TodosCount
+            pathname={pathname}
+            label={label}
+          />
+        </Suspense>
+        <UserSessionEffect />
+      </>,
+      options,
+    );
+  };
+
+  const urgentPriority = 1;
+  const todosCountOnAppRoute = DATA_DEMO.filter((item) => item.priorityLevel === urgentPriority).length;
+  const labelPersonalName = 'Personal';
+  const labelPersonal = DATA_DEMO_LABELS.find((label) => label.name === labelPersonalName) ?? ({} as Labels);
+  const todosCountLabelPersonal = labelPersonal.title_id?.length ?? 0;
+
+  it('should render the correct todosCount based on the the appropriate pathname when userSession is null', async () => {
+    const { container } = renderWithTodosCount({ pathname: '/app/urgent' });
+
+    expect(container).toBeInTheDocument();
+    await waitFor(() => {
+      const todosCount = screen.queryByText(todosCountOnAppRoute);
+      expect(todosCount).toBeInTheDocument();
+    });
+  });
+
+  it('should not render any todosCount if pathname is not under the /app such as root path', async () => {
+    renderWithTodosCount({ pathname: '/' });
+
+    await waitFor(() => {
+      const todosCount = screen.queryByText(todosCountOnAppRoute);
+      expect(todosCount).toBeNull();
+    });
+  });
+
+  it('should render correct number of todoCount on the matched label', async () => {
+    renderWithTodosCount({ pathname: '/app/label', label: labelPersonal });
+
+    await waitFor(() => {
+      const todosCount = screen.queryByText(todosCountLabelPersonal);
+      expect(todosCount).toBeInTheDocument();
+    });
+  });
+});

--- a/components/layout/app/todosCount/index.tsx
+++ b/components/layout/app/todosCount/index.tsx
@@ -1,12 +1,9 @@
-import { TypesLabel } from '@label/label.types';
-import { Types } from '@lib/types';
+import { PropsTodosCount } from '@layout/layout.types';
 import { selectorTodosCount } from '@states/todos';
 import { Fragment } from 'react';
 import { useRecoilValue } from 'recoil';
 
-type Props = Partial<Pick<Types, 'pathname'> & Pick<TypesLabel, 'label'>>;
-
-export const TodosCount = ({ pathname, label }: Props) => {
+export const TodosCount = ({ pathname, label }: PropsTodosCount) => {
   const todosCount = useRecoilValue(selectorTodosCount({ pathname: pathname, labelId: label?._id }));
 
   return <Fragment>{todosCount > 0 ? todosCount : undefined}</Fragment>;

--- a/components/layout/layout.types.ts
+++ b/components/layout/layout.types.ts
@@ -1,3 +1,8 @@
+import { TypesLabel } from '@label/label.types';
+import { Types } from '@lib/types';
+
 export interface TypesLayout {
   path: 'app' | 'home';
 }
+
+export type PropsTodosCount = Partial<Pick<Types, 'pathname'> & Pick<TypesLabel, 'label'>>;


### PR DESCRIPTION
Conduct unit tests to ascertain whether TodosCount renders the number of todos accurately according to specified conditions. To enhance type usability, the Props of TodosCount component are renamed to PropsTodosCount and relocated to `layoutTypes`.