### PR TITLE
test: Add unit test for LoadingSpinner component

### DIFF
--- a/components/loadable/loadingSpinner/__test__/__mock__/mockSpinnerState.tsx
+++ b/components/loadable/loadingSpinner/__test__/__mock__/mockSpinnerState.tsx
@@ -1,0 +1,14 @@
+import { SPINNER } from '@constAssertions/ui';
+import { atomLoadingSpinner } from '@states/misc';
+import { useEffect } from 'react';
+import { useSetRecoilState } from 'recoil';
+
+export const MockSpinnerState = ({ spinnerId }: { spinnerId: SPINNER }) => {
+  const setSpinner = useSetRecoilState(atomLoadingSpinner(spinnerId));
+
+  useEffect(() => {
+    setSpinner(!!spinnerId);
+  }, [setSpinner, spinnerId]);
+
+  return null;
+};

--- a/components/loadable/loadingSpinner/__test__/loadingSpinner.test.tsx
+++ b/components/loadable/loadingSpinner/__test__/loadingSpinner.test.tsx
@@ -1,0 +1,28 @@
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { LoadingSpinner } from '..';
+import { SPINNER } from '@constAssertions/ui';
+import { screen } from '@testing-library/react';
+import { MockSpinnerState } from './__mock__/mockSpinnerState';
+
+describe('LoadingSpinner', () => {
+  const renderWithLoadingSpinner = (spinnerId: SPINNER) => {
+    return renderWithRecoilRootAndSession(
+      <>
+        <LoadingSpinner spinnerId={spinnerId} />
+        <MockSpinnerState spinnerId={spinnerId} />
+      </>,
+    );
+  };
+
+  it('should render the loadingSpinner when spinnerId is provided', async () => {
+    const SPINNER_VALUES = Object.values(SPINNER) as SPINNER[];
+
+    SPINNER_VALUES.forEach((spinner, index) => {
+      const { container } = renderWithLoadingSpinner(SPINNER[spinner]);
+      const spinnerTestId = screen.queryAllByTestId('loadingSpinner-testid')[index];
+
+      expect(container).toBeInTheDocument();
+      expect(spinnerTestId).toBeInTheDocument();
+    });
+  });
+});

--- a/components/loadable/loadingSpinner/index.tsx
+++ b/components/loadable/loadingSpinner/index.tsx
@@ -13,7 +13,9 @@ export const LoadingSpinner = ({ spinnerId }: { spinnerId: SPINNER }) => {
           className='w-r h-4 animate-spin fill-white text-blue-500'
           viewBox='0 0 100 101'
           fill='none'
-          xmlns='http://www.w3.org/2000/svg'>
+          xmlns='http://www.w3.org/2000/svg'
+          data-testid='loadingSpinner-testid'
+        >
           <path
             d='M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z'
             fill='currentColor'


### PR DESCRIPTION
Add a unit test to verify the rendering of the LoadingSpinner component when the prop is provided. Also, include the data-testid attribute for improved testing execution.