### PR TITLE
test: Add unit test for ErrorState component

### DIFF
--- a/components/loadable/errorState/__test__/errorState.test.tsx
+++ b/components/loadable/errorState/__test__/errorState.test.tsx
@@ -1,0 +1,18 @@
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { ErrorState } from '..';
+import { screen } from '@testing-library/react';
+import { errorStateMessage } from '@components/loadable/loadable.consts';
+
+describe('ErrorState', () => {
+  const renderWithErrorState = () => {
+    return renderWithRecoilRootAndSession(<ErrorState />);
+  };
+
+  it('should render the correct errorStateMessage when the component mounts', () => {
+    const { container } = renderWithErrorState();
+    const errorStateMessageText = screen.getByText(errorStateMessage);
+
+    expect(container).toBeInTheDocument();
+    expect(errorStateMessageText).toBeInTheDocument();
+  });
+});

--- a/components/loadable/errorState/index.tsx
+++ b/components/loadable/errorState/index.tsx
@@ -1,3 +1,5 @@
+import { errorStateMessage } from '../loadable.consts';
+
 export const ErrorState = () => {
-  return <span className='text-2xl'>Failed to load!</span>;
+  return <span className='text-2xl'>{errorStateMessage}</span>;
 };

--- a/components/loadable/loadable.consts.ts
+++ b/components/loadable/loadable.consts.ts
@@ -3,3 +3,5 @@ export const SPINNER = {
   authForm: 'authForm',
   verificationConfirm: 'verificationConfirm',
 } as const;
+
+export const errorStateMessage = 'Something went wrong! Please try again.';


### PR DESCRIPTION
Introduce a unit test for the ErrorState component to verify the error message. To enhance flexibility, the error message employs a constant variable instead of hardcoded text.