### PR TITLE
test: Add unit test for LoadingState component

### DIFF
--- a/components/loadable/loadable.types.ts
+++ b/components/loadable/loadable.types.ts
@@ -3,9 +3,7 @@ import { Types } from '@lib/types';
 export interface TypesLoadings {
   loadingSkeleton: Types['children'];
   repeatingCount: number;
-  delay: number;
 }
 
-export type TypesOptionsLoadingState = Partial<Pick<TypesLoadings, 'delay'>> &
-  Pick<TypesLoadings, 'loadingSkeleton' | 'repeatingCount'> &
+export type TypesOptionsLoadingState = Pick<TypesLoadings, 'loadingSkeleton' | 'repeatingCount'> &
   Pick<Types, 'margin' | 'space'>;

--- a/components/loadable/loadingStates/__test__/__mock__/mockLoadingSkeleton.tsx
+++ b/components/loadable/loadingStates/__test__/__mock__/mockLoadingSkeleton.tsx
@@ -1,0 +1,3 @@
+export const MockLoadingSkeleton = () => {
+  return <div data-testid='mockLoadingSkeleton-testid' />;
+};

--- a/components/loadable/loadingStates/__test__/loadingState.test.tsx
+++ b/components/loadable/loadingStates/__test__/loadingState.test.tsx
@@ -1,0 +1,29 @@
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { LoadingState } from '..';
+import { TypesOptionsLoadingState } from '@components/loadable/loadable.types';
+import { MockLoadingSkeleton } from './__mock__/mockLoadingSkeleton';
+import { screen } from '@testing-library/react';
+
+describe('LoadingState', () => {
+  const renderWithLoadingState = ({ options }: { options: TypesOptionsLoadingState }) => {
+    return renderWithRecoilRootAndSession(<LoadingState options={options} />);
+  };
+
+  it('should render the options props with component', () => {
+    const numberOfRepeatingCount = 2;
+    const mockOptions: TypesOptionsLoadingState = {
+      margin: 'm-1',
+      space: 'space-y-1',
+      repeatingCount: numberOfRepeatingCount,
+      loadingSkeleton: <MockLoadingSkeleton />,
+    };
+    const { container } = renderWithLoadingState({ options: mockOptions });
+    const loadingStateComponent = screen.getByTestId('loadingState-testid');
+    const loadingSkeletons = screen.getAllByTestId('mockLoadingSkeleton-testid');
+
+    expect(container).toBeInTheDocument();
+    expect(loadingStateComponent).toBeInTheDocument();
+    expect(loadingStateComponent).toHaveClass('m-1 space-y-1');
+    expect(loadingSkeletons).toHaveLength(numberOfRepeatingCount);
+  });
+});

--- a/components/loadable/loadingStates/index.tsx
+++ b/components/loadable/loadingStates/index.tsx
@@ -5,7 +5,10 @@ import { TypesOptionsLoadingState } from '../loadable.types';
 export const LoadingState = ({ options }: { options: TypesOptionsLoadingState }) => {
   return (
     <Fragment>
-      <div className={classNames(options.margin, options.space)}>
+      <div
+        className={classNames(options.margin, options.space)}
+        data-testid='loadingState-testid'
+      >
         {/* It is reasonable to use index as unique key as this component is static once prop is set */}
         {[...Array(options.repeatingCount)].map((_, index) => (
           <ul key={index}>{options.loadingSkeleton}</ul>


### PR DESCRIPTION
Add a unit test to verify that the LoadingState component renders loadingSkeleton based on the provided props or condition. To facilitate testing, `data-testid` attributes have been added to the LoadingState component and MockLoadingSkeleton. Additionally, the redundant `delay` type has been removed.