### PR TITLE
refactor: Enhance image sizes and switch formats

### DIFF
--- a/components/sections/homeContent/index.tsx
+++ b/components/sections/homeContent/index.tsx
@@ -42,8 +42,8 @@ export const HomeContent = () => {
               <div className={classNames(styleImageWrapper, 'opacity-100')}>
                 <Image
                   loader={cloudflareLoader}
-                  width={1850}
-                  height={2529}
+                  width={504}
+                  height={689}
                   className={styleImage}
                   src={PATH_IMAGE_HOME['contentFocus']}
                   sizes='(max-width: 748px) 70vw, 33vw'
@@ -64,8 +64,8 @@ export const HomeContent = () => {
               <div className={classNames(styleImageWrapper, 'opacity-100')}>
                 <Image
                   loader={cloudflareLoader}
-                  width={456}
-                  height={600}
+                  width={494}
+                  height={650}
                   className={styleImage}
                   src={PATH_IMAGE_HOME['contentOrganize']}
                   sizes='(max-width: 748px) 70vw, 33vw'

--- a/components/sections/homeHero.tsx
+++ b/components/sections/homeHero.tsx
@@ -90,11 +90,11 @@ export const HomeHero = () => {
                       <div className='mx-auto flex w-full max-w-[60rem] flex-row items-center justify-center rounded-xl border-none ring-0 lg:rounded-2xl'>
                         <Image
                           loader={cloudflareLoader}
-                          width={1000}
-                          height={1000}
+                          width={961}
+                          height={754}
                           className='h-auto w-auto rounded-2xl ring-2 ring-slate-300/20 drop-shadow-2xl will-change-transform'
                           src={PATH_IMAGE_HOME['demo']}
-                          sizes='80vw'
+                          sizes='90vw'
                           alt='demo application image'
                           priority={true}
                         />

--- a/components/sections/underConstruction/index.tsx
+++ b/components/sections/underConstruction/index.tsx
@@ -34,8 +34,8 @@ export const UnderConstruction = () => {
         <div className='relative flex h-[30rem] w-full max-w-lg flex-row items-center justify-center rounded-xl'>
           <Image
             loader={cloudflareLoader}
-            width={1000}
-            height={1000}
+            width={512}
+            height={512}
             className='h-auto w-full rounded-xl bg-transparent drop-shadow-2xl'
             src={PATH_IMAGE_HOME['underConstruction']}
             sizes='80vw'

--- a/lib/data/constAssertions/data.tsx
+++ b/lib/data/constAssertions/data.tsx
@@ -43,21 +43,21 @@ export const PATH_HOME = {
 
 export type PATH_IMAGE_APP = (typeof PATH_IMAGE_APP)[keyof typeof PATH_IMAGE_APP];
 export const PATH_IMAGE_APP = {
-  focus: 'app-focus.webp',
-  urgent: 'app-urgent.webp',
-  important: 'app-important.webp',
-  showAll: 'app-showall.webp',
-  completed: 'app-completed.webp',
-  label: 'app-label.webp',
-  avatar: 'app-user-avatar.webp',
+  focus: 'app-focus.png',
+  urgent: 'app-urgent.png',
+  important: 'app-important.png',
+  showAll: 'app-showall.png',
+  completed: 'app-completed.png',
+  label: 'app-label.png',
+  avatar: 'app-user-avatar.png',
 } as const;
 
 export type PATH_IMAGE_HOME = (typeof PATH_IMAGE_HOME)[keyof typeof PATH_IMAGE_HOME];
 export const PATH_IMAGE_HOME = {
-  demo: 'home-demo-image-desk.webp',
-  contentFocus: 'home-content-focus.webp',
-  contentOrganize: 'home-content-organize.webp',
-  underConstruction: 'home-under-construction.webp',
+  demo: 'home-demo-image-desk.png',
+  contentFocus: 'home-content-focus.png',
+  contentOrganize: 'home-content-organize.png',
+  underConstruction: 'home-under-construction.png',
 } as const;
 
 export type RETENTION = (typeof RETENTION)[keyof typeof RETENTION];


### PR DESCRIPTION
Resize images and change formats from webp to png for augmented compatibility and versatility. Establish hotlink protection through external infrastructure, as opposed to direct implementation within the repository, allowing exclusive display for authorized connections.