### PR TITLE
feat: Update the dependabot configs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,6 @@ updates:
       interval: 'daily'
     target-branch: 'develop'
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'


### PR DESCRIPTION
Add the prefix to `chore` instead of default of `build`.