### PR TITLE
test: Extend Footer component integration tests

### DIFF
--- a/components/section/footer/__test__/footer.test.tsx
+++ b/components/section/footer/__test__/footer.test.tsx
@@ -1,0 +1,60 @@
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { Footer } from '..';
+import { fireEvent, screen } from '@testing-library/react';
+import { copyRightText } from '@components/section/section.consts';
+import { DATA_FOOTER_NAVIGATION, DATA_FOOTER_SOCIAL } from '@collections/footer';
+import mockRouter from 'next-router-mock';
+
+describe('Footer', () => {
+  const renderWithFooter = () => {
+    return renderWithRecoilRootAndSession(<Footer />);
+  };
+
+  it('should render the copyRight text when component mounts', () => {
+    const { container } = renderWithFooter();
+    const copyRightTextElement = screen.getByText(copyRightText);
+
+    expect(container).toBeInTheDocument();
+    expect(copyRightTextElement).toBeInTheDocument();
+  });
+
+  it('should render the child components correctly', () => {
+    renderWithFooter();
+    const dividerXComponentTestId = screen.getByTestId('dividerX-testid');
+    const logoComponentTestId = screen.getByTestId('MainWhite-testid');
+
+    expect(dividerXComponentTestId).toBeInTheDocument();
+    expect(logoComponentTestId).toBeInTheDocument();
+  });
+
+  it('should correctly render the navigation name and route', async () => {
+    mockRouter.push('/');
+    renderWithFooter();
+
+    expect(mockRouter).toMatchObject({ pathname: '/' });
+
+    await Promise.all(
+      DATA_FOOTER_NAVIGATION.map((item) => {
+        const itemText = screen.getByText(item.name);
+
+        expect(itemText).toBeInTheDocument();
+
+        fireEvent.click(itemText);
+
+        expect(mockRouter).toMatchObject({ pathname: item.path });
+      }),
+    );
+  });
+
+  it('should correctly render the social testId', async () => {
+    renderWithFooter();
+
+    await Promise.all(
+      DATA_FOOTER_SOCIAL.map((item) => {
+        const itemTestId = screen.getByTestId(item.testId);
+
+        expect(itemTestId).toBeInTheDocument();
+      }),
+    );
+  });
+});

--- a/components/section/footer/index.tsx
+++ b/components/section/footer/index.tsx
@@ -6,6 +6,7 @@ import { classNames } from '@stateLogics/utils';
 import { DividerX } from '@ui/dividers/dividerX';
 import Link from 'next/link';
 import { optionsSocialPaths } from '../section.utils';
+import { copyRightText } from '../section.consts';
 
 export const Footer = () => {
   return (
@@ -51,9 +52,7 @@ export const Footer = () => {
                 </Link>
               ))}
             </div>
-            <p className='text-center text-xs leading-5 text-gray-500'>
-              &copy; 2023 tpatalas. Repository code under MIT License.
-            </p>
+            <p className='text-center text-xs leading-5 text-gray-500'>{copyRightText}</p>
           </div>
         </div>
       </footer>

--- a/components/section/section.consts.ts
+++ b/components/section/section.consts.ts
@@ -1,0 +1,1 @@
+export const copyRightText = '\u00A9 2023 tpatalas. Repository code under MIT License.';

--- a/components/section/section.utils.ts
+++ b/components/section/section.utils.ts
@@ -3,4 +3,5 @@ import { TypesFooterSocial } from '@collections/footer';
 export const optionsSocialPaths = (social: TypesFooterSocial) => ({
   path: social.path,
   className: 'w-6 h-6 fill-gray-400 group-hover:fill-gray-700',
+  testId: social.testId,
 });

--- a/components/ui/dividers/dividerX.tsx
+++ b/components/ui/dividers/dividerX.tsx
@@ -2,18 +2,20 @@ import { Types } from '@lib/types';
 import { classNames } from '@stateLogics/utils';
 
 type optionTypeDivider = 'margin' | 'hidden' | 'width';
-type Props = { options?: Partial<Record<optionTypeDivider, string>> } & Partial<
-  Pick<Types, 'children'>
->;
+type Props = { options?: Partial<Record<optionTypeDivider, string>> } & Partial<Pick<Types, 'children'>>;
 
 export const DividerX = ({ children, options }: Props) => {
   const { margin, hidden, width = 'w-full' } = options || {};
 
   return (
-    <div className={classNames('relative', margin, hidden)}>
+    <div
+      className={classNames('relative', margin, hidden)}
+      data-testid='dividerX-testid'
+    >
       <div
         className='absolute inset-0 flex items-center justify-center'
-        aria-hidden='true'>
+        aria-hidden='true'
+      >
         <div className={classNames('border-t border-gray-300', width)} />
       </div>
       {children && (

--- a/lib/data/collections/footer.tsx
+++ b/lib/data/collections/footer.tsx
@@ -18,7 +18,7 @@ interface TypesFooterNavigation {
   path: PATH_HOME;
 }
 
-type social = 'name' | 'link' | 'path';
+type social = 'name' | 'link' | 'path' | 'testId';
 export type TypesFooterSocial = Record<social, string>;
 
 export const DATA_FOOTER_NAVIGATION: TypesFooterNavigation[] = [
@@ -35,6 +35,7 @@ export const DATA_FOOTER_SOCIAL: TypesFooterSocial[] = [
     name: 'GitHub',
     link: process.env.NEXT_PUBLIC_SOCIAL_GITHUB as string,
     path: 'M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z',
+    testId: 'socialGithub-testid',
   },
 ];
 


### PR DESCRIPTION
Extend integration testing for Footer components to ensure correct rendering of child components and routing functionality.

As part of the testing improvements, relocate copyright text to `section.consts` for optimal testability. Furthermore, add `data-testid` attribute to DividerX component and DATA_FOOTER_SOCIAL for enhanced component identification during test runs.