### PR TITLE
test: Add tests for UnderConstruction component

### DIFF
--- a/components/section/section.consts.ts
+++ b/components/section/section.consts.ts
@@ -34,3 +34,8 @@ export const homeStartTodayText = {
   content:
     'Elevate your efficiency and unlock the key to accomplishing more with our productivity-boosting app.',
 };
+
+export const underConstructionText = {
+  content:
+    'The page is currently under construction for improvements to better serve you. We appreciate your patience. Please check back soon for an upgraded and user-friendly experience. Thank you!',
+};

--- a/components/section/underConstruction/__test__/underConstruction.test.tsx
+++ b/components/section/underConstruction/__test__/underConstruction.test.tsx
@@ -1,0 +1,23 @@
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { UnderConstruction } from '..';
+import { screen } from '@testing-library/react';
+import { underConstructionText } from '@components/section/section.consts';
+
+describe('UnderConstruction', () => {
+  const renderWithUnderConstruction = () => renderWithRecoilRootAndSession(<UnderConstruction />);
+
+  it('should render the context text proper', () => {
+    const { container } = renderWithUnderConstruction();
+    const contentText = screen.getByText(underConstructionText.content);
+
+    expect(container).toBeInTheDocument();
+    expect(contentText).toBeInTheDocument();
+  });
+
+  it('should render the Link button', async () => {
+    renderWithUnderConstruction();
+    const backToHomepageLinkButton = await screen.findByText(/Back to homepage/i);
+
+    expect(backToHomepageLinkButton).toBeInTheDocument();
+  });
+});

--- a/components/section/underConstruction/index.tsx
+++ b/components/section/underConstruction/index.tsx
@@ -3,6 +3,7 @@ import { STYLE_BUTTON_FULL_BLUE } from '@data/stylePreset';
 import { classNames, cloudflareLoader } from '@stateLogics/utils';
 import Image from 'next/image';
 import Link from 'next/link';
+import { underConstructionText } from '../section.consts';
 
 export const UnderConstruction = () => {
   const styleParagraph = 'text-3xl font-bold uppercase tracking-wide ml:text-4xl';
@@ -16,10 +17,7 @@ export const UnderConstruction = () => {
             <h1 className={classNames(styleParagraph)}>Construction</h1>
           </div>
           <div>
-            <p className='text-slate-800/80'>
-              The page is currently under construction for improvements to better serve you. We appreciate
-              your patience. Please check back soon for an upgraded and user-friendly experience. Thank you!
-            </p>
+            <p className='text-slate-800/80'>{underConstructionText.content}</p>
           </div>
           <Link
             href='/'


### PR DESCRIPTION
Create unit tests for UnderConstruction, verifying the accurate rendering of content text and link button. For testing efficiency, content text has been relocated to section.consts from UnderConstruction component.