### PR TITLE
feat: Implement ServiceWorkerRegister unit test

### DIFF
--- a/components/serviceWorker/serviceWorker.consts.ts
+++ b/components/serviceWorker/serviceWorker.consts.ts
@@ -1,0 +1,1 @@
+export const serviceWorkerPath = '/service-worker.js';

--- a/components/serviceWorker/serviceWorkerRegister/__test__/__mock__/mockServiceWorkerRegister.tsx
+++ b/components/serviceWorker/serviceWorkerRegister/__test__/__mock__/mockServiceWorkerRegister.tsx
@@ -1,0 +1,13 @@
+export const mockServiceWorkerRegister = () => {
+  // should be called before render function
+  const mockRegister = jest.fn();
+
+  Object.defineProperty(navigator, 'serviceWorker', {
+    value: {
+      register: mockRegister,
+    },
+    configurable: true,
+  });
+
+  return mockRegister;
+};

--- a/components/serviceWorker/serviceWorkerRegister/__test__/serviceWorkerRegister.test.tsx
+++ b/components/serviceWorker/serviceWorkerRegister/__test__/serviceWorkerRegister.test.tsx
@@ -1,0 +1,16 @@
+import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { ServiceWorkerRegister } from '..';
+import { mockServiceWorkerRegister } from './__mock__/mockServiceWorkerRegister';
+import { serviceWorkerPath } from '@serviceWorker/serviceWorker.consts';
+
+describe('ServiceWorkerRegister', () => {
+  const renderWithServiceWorkerRegister = () => renderWithRecoilRootAndSession(<ServiceWorkerRegister />);
+
+  it('should register the service worker on mount', () => {
+    const mockServiceWorker = mockServiceWorkerRegister();
+    const { container } = renderWithServiceWorkerRegister();
+
+    expect(container).toBeInTheDocument();
+    expect(mockServiceWorker).toHaveBeenCalledWith(serviceWorkerPath);
+  });
+});

--- a/components/serviceWorker/serviceWorkerRegister/index.tsx
+++ b/components/serviceWorker/serviceWorkerRegister/index.tsx
@@ -1,3 +1,4 @@
+import { serviceWorkerPath } from '@serviceWorker/serviceWorker.consts';
 import { useEffect } from 'react';
 
 export const ServiceWorkerRegister = () => {
@@ -5,7 +6,7 @@ export const ServiceWorkerRegister = () => {
     const registerServiceWorker = async () => {
       if ('serviceWorker' in navigator) {
         try {
-          await navigator.serviceWorker.register('/service-worker.js');
+          await navigator.serviceWorker.register(serviceWorkerPath);
         } catch (error) {
           console.error('Service Worker registration failed:', error);
         }


### PR DESCRIPTION
Implemented unit testing for the ServiceWorkerRegister component, focusing on serviceWorker registration upon component mounting. To improve testing utility, created mockServiceWorkerRegister for mimicking the registration process. Furthermore, relocated the path to service-worker.js to serviceWorker.consts, enabling precise reuse within both component and test environments.