### PR TITLE
refactor: Move Todo types to todos.types

### DIFF
--- a/components/editor/editor.hooks.ts
+++ b/components/editor/editor.hooks.ts
@@ -1,6 +1,6 @@
+import { TypesTodos, TypesTodosEditors } from '@components/todos/todos.types';
 import { TypesEditor } from '@editor/editor.types';
 import { useTodoAdd, useTodoUpdateItem } from '@hooks/todos';
-import { Todos, TodosEditors } from '@lib/types';
 import { CustomEditor } from '@lib/types/misc/slate';
 import { atomSelectorTodoItem } from '@states/atomEffects/todos';
 import { atomEditorDeserialize, atomEditorSerialize } from '@states/editors';
@@ -9,7 +9,7 @@ import { isMobile } from 'react-device-detect';
 import { RecoilValue, useRecoilCallback } from 'recoil';
 import { Descendant, Transforms } from 'slate';
 
-export const useEditorTodoUpdate = (_id: Todos['_id'], titleName: TypesEditor['titleName']) => {
+export const useEditorTodoUpdate = (_id: TypesTodos['_id'], titleName: TypesEditor['titleName']) => {
   return useRecoilCallback(
     ({ set, snapshot }) =>
       (content: string) => {
@@ -29,7 +29,7 @@ export const useEditorTodoUpdate = (_id: Todos['_id'], titleName: TypesEditor['t
   );
 };
 
-export const useEditorInitialValue = (_id: Todos['_id'], titleName: TypesEditor['titleName']) => {
+export const useEditorInitialValue = (_id: TypesTodos['_id'], titleName: TypesEditor['titleName']) => {
   return useRecoilCallback(
     ({ snapshot }) =>
       () => {
@@ -37,8 +37,8 @@ export const useEditorInitialValue = (_id: Todos['_id'], titleName: TypesEditor[
 
         return (get(atomEditorDeserialize)(
           _id === undefined
-            ? get(atomTodoNew)[titleName as keyof TodosEditors]
-            : get(atomSelectorTodoItem(_id))[titleName as keyof TodosEditors],
+            ? get(atomTodoNew)[titleName as keyof TypesTodosEditors]
+            : get(atomSelectorTodoItem(_id))[titleName as keyof TypesTodosEditors],
         ) || [
           {
             type: 'paragraph',
@@ -50,7 +50,7 @@ export const useEditorInitialValue = (_id: Todos['_id'], titleName: TypesEditor[
   );
 };
 
-export const useEditorChangeHandler = (_id: Todos['_id'], titleName: TypesEditor['titleName']) => {
+export const useEditorChangeHandler = (_id: TypesTodos['_id'], titleName: TypesEditor['titleName']) => {
   const createEditor = useEditorTodoUpdate(undefined, titleName);
   const updateEditor = useEditorTodoUpdate(_id, titleName);
   const editorState = useRecoilCallback(
@@ -69,7 +69,7 @@ export const useEditorChangeHandler = (_id: Todos['_id'], titleName: TypesEditor
 
 export const useKeyWithEditor = (
   titleName: TypesEditor['titleName'],
-  _id: Todos['_id'],
+  _id: TypesTodos['_id'],
   editor: CustomEditor,
 ) => {
   const addTodo = useTodoAdd();

--- a/components/editor/editor.renders.tsx
+++ b/components/editor/editor.renders.tsx
@@ -1,3 +1,4 @@
+import { TypesTodos } from '@components/todos/todos.types';
 import { TypesEditor } from '@editor/editor.types';
 import { classNames } from '@stateLogics/utils';
 import { Types } from 'lib/types';
@@ -57,7 +58,7 @@ export const renderPlaceholder = ({
 
 export const renderCustomElement = ({
   ...props
-}: RenderElementProps & Partial<Pick<TypesEditor, 'titleName'> & Pick<Types, 'completed'>>) => {
+}: RenderElementProps & Partial<Pick<TypesEditor, 'titleName'> & Pick<TypesTodos, 'completed'>>) => {
   switch (props.element.type) {
     case 'code':
       return <CodeElement {...props} />;

--- a/components/editor/editor.types.ts
+++ b/components/editor/editor.types.ts
@@ -1,10 +1,10 @@
-import { Types } from '@lib/types';
 import { Descendant } from 'slate';
 import { ReactEditor } from 'slate-react';
 import { CustomEditor } from '@lib/types/misc/slate';
+import { TypesTodo } from '@components/todos/todos.types';
 
 export type TypesPropsEditorComposer = Pick<TypesEditor, 'titleName' | 'placeholder'> &
-  Partial<Pick<TypesEditor, 'isAutoFocus'> & Pick<Types, 'todo'>>;
+  Partial<Pick<TypesEditor, 'isAutoFocus'> & Pick<TypesTodo, 'todo'>>;
 
 export type TypesPropsAuthFocusEffect = Pick<TypesEditor, 'isAutoFocus'> & { editor: CustomEditor };
 

--- a/components/editor/todoEditor/index.tsx
+++ b/components/editor/todoEditor/index.tsx
@@ -1,4 +1,4 @@
-import { Types } from '@lib/types';
+import { TypesTodo } from '@components/todos/todos.types';
 import { classNames } from '@stateLogics/utils';
 import { selectorSessionTodoItem } from '@states/atomEffects/todos';
 import dynamic from 'next/dynamic';
@@ -6,7 +6,7 @@ import { useRecoilCallback } from 'recoil';
 
 const EditorComposer = dynamic(() => import('@editor/editorComposer').then((mod) => mod.EditorComposer));
 
-export const TodoEditors = ({ todo }: Partial<Pick<Types, 'todo'>>) => {
+export const TodoEditors = ({ todo }: Partial<Pick<TypesTodo, 'todo'>>) => {
   const isTodoCompleted = useRecoilCallback(
     ({ snapshot }) =>
       () => {

--- a/components/label/label.hooks.ts
+++ b/components/label/label.hooks.ts
@@ -1,3 +1,4 @@
+import { TypesTodos } from '@components/todos/todos.types';
 import { CATCH } from '@constAssertions/misc';
 import { NOTIFICATION } from '@constAssertions/ui';
 import { ICON_FILTER_LIST, ICON_FILTER_LIST_OFF } from '@data/materialSymbols';
@@ -18,7 +19,6 @@ import {
   updateDataLabelItem,
   updateDataLabels,
 } from '@lib/queries/queryLabels';
-import { Todos } from '@lib/types';
 import { TypesOptionsButton } from '@lib/types/options';
 import { atomSelectorTodoItem } from '@states/atomEffects/todos';
 import { atomFilterSelected } from '@states/comboBoxes';
@@ -108,7 +108,7 @@ export const useLabelRemoveItem = (_id: Labels['_id']) => {
   });
 };
 
-export const useLabelRemoveItemTitleId = (_id: Todos['_id']) => {
+export const useLabelRemoveItemTitleId = (_id: TypesTodos['_id']) => {
   const updateLabels = useLabelUpdateDataItem();
   const get = useGetWithRecoilCallback();
 
@@ -160,7 +160,7 @@ export const useLabelUpdateDataItem = () => {
   });
 };
 
-export const useLabelChangeHandler = (_id: Todos['_id']) => {
+export const useLabelChangeHandler = (_id: TypesTodos['_id']) => {
   const compareLabelsToQueryLabel = useCompareToQueryLabels();
   return useRecoilCallback(({ set, snapshot }) => (selected: Labels[]) => {
     const get = <T>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
@@ -204,7 +204,7 @@ export const useLabelChangeHandler = (_id: Todos['_id']) => {
   });
 };
 
-export const useDataButtonComboboxFilterLabel = (_id: Todos['_id']): TypesOptionsButton => {
+export const useDataButtonComboboxFilterLabel = (_id: TypesTodos['_id']): TypesOptionsButton => {
   const isFilterOn = useRecoilValue(atomFilterSelected(_id));
   const resetFilter = useResetRecoilState(atomFilterSelected(_id));
   const selectedLabels = useRecoilValue(selectorSelectedLabels(_id));

--- a/components/label/label.states.ts
+++ b/components/label/label.states.ts
@@ -1,13 +1,13 @@
 import { IDB_KEY, IDB_STORE } from '@constAssertions/storage';
 import { getDataLabels } from '@lib/queries/queryLabels';
 import { queryEffect } from '@lib/stateLogics/effects/atomEffects/queryEffects';
-import { Todos } from '@lib/types';
 import { atomComboBoxQuery, atomFilterSelected } from '@states/comboBoxes';
 import { atomTodoNew } from '@states/todos';
 import { atomUserSession } from '@user/user.states';
 import { atom, atomFamily, selector, selectorFamily } from 'recoil';
 import { Labels } from './label.types';
 import { DATA_DEMO_LABELS } from './label.data';
+import { TypesTodos } from '@components/todos/todos.types';
 
 /**
  * Atom Queries
@@ -86,7 +86,7 @@ export const atomLabelQuerySlug = atom<Labels['_id']>({
 /**
  * Selectors
  **/
-export const selectorSelectedLabels = selectorFamily<Labels[], Todos['_id']>({
+export const selectorSelectedLabels = selectorFamily<Labels[], TypesTodos['_id']>({
   key: 'selectorSelectedLabels',
   get:
     (_id) =>
@@ -99,7 +99,7 @@ export const selectorSelectedLabels = selectorFamily<Labels[], Todos['_id']>({
   },
 });
 
-export const selectorSelectedQueryLabels = selectorFamily<Labels[], Todos['_id']>({
+export const selectorSelectedQueryLabels = selectorFamily<Labels[], TypesTodos['_id']>({
   key: 'selectorSelectedLabels',
   get:
     (_id) =>
@@ -112,7 +112,7 @@ export const selectorSelectedQueryLabels = selectorFamily<Labels[], Todos['_id']
   },
 });
 
-export const selectorComboBoxFilteredLabels = selectorFamily<Labels[], Todos['_id']>({
+export const selectorComboBoxFilteredLabels = selectorFamily<Labels[], TypesTodos['_id']>({
   key: 'selectorComboBoxFilteredLabels',
   get:
     (todoId) =>

--- a/components/layout/app/layoutAppLazy/__test__/__mock__/mockStateEffect.tsx
+++ b/components/layout/app/layoutAppLazy/__test__/__mock__/mockStateEffect.tsx
@@ -1,6 +1,7 @@
+import { TypesTodos } from '@components/todos/todos.types';
 import { BREAKPOINT } from '@constAssertions/ui';
 import { atomLayoutType, atomLayoutNavigationOpen } from '@layout/layout.states';
-import { Todos, TypesNotification } from '@lib/types';
+import { TypesNotification } from '@lib/types';
 import { atomEffectMediaQuery } from '@states/atomEffects/misc';
 import { atomHtmlTitleTag } from '@states/misc';
 import { atomLabelModalOpen, atomTodoModalMini, atomTodoModalOpen } from '@states/modals';
@@ -42,7 +43,7 @@ export const MockLayoutAppLazyEffect = <T,>({
     !!notificationId && setNotificationOpen(true);
     setTodoModalOpen(isTodoModalOpen ?? false);
     setMinimizedTodoModalOpen(isMinimizedTodoModalOpen ?? false);
-    !!isMinimizedTodoModalOpen && setTodoNew({ title: 'test-title' } as Todos);
+    !!isMinimizedTodoModalOpen && setTodoNew({ title: 'test-title' } as TypesTodos);
     setLabelModalOpen(isLabelModalOpen ?? false);
   }, [
     isLabelModalOpen,

--- a/components/todos/todoList/todo/index.tsx
+++ b/components/todos/todoList/todo/index.tsx
@@ -1,7 +1,6 @@
 import { ICON_EDIT_NOTE } from '@data/materialSymbols';
 import { DropdownMenuItem } from '@dropdowns/v1/dropdown/dropdownMenuItem';
 import { TodoItemDropdown } from '@dropdowns/v1/todoItemDropdown';
-import { TypesTodo } from 'lib/types';
 import { Fragment as ModalActionsFragment } from 'react';
 import { TodoItemFocuser } from './todoItemFocuser';
 import { useTodoModalStateOpen } from '@hooks/modals';
@@ -11,6 +10,7 @@ import {
   ItemTodoModal,
   MinimizedModal,
 } from '@components/todos/todos.dynamicImports';
+import { TypesTodo } from '@components/todos/todos.types';
 
 type Props = Pick<TypesTodo, 'todo'> & Partial<Pick<TypesTodo, 'index'>>;
 

--- a/components/todos/todoList/todo/todoItem/index.tsx
+++ b/components/todos/todoList/todo/todoItem/index.tsx
@@ -1,3 +1,4 @@
+import { TypesTodo } from '@components/todos/todos.types';
 import { PRIORITY_LEVEL, CATCH } from '@constAssertions/misc';
 import { LabelComboBoxDropdown } from '@dropdowns/v1/labelComboBoxDropdown';
 import { useTodoModalStateOpen } from '@hooks/modals';
@@ -5,7 +6,6 @@ import { useTodoCompleteItem } from '@hooks/todos';
 import { SvgIcon } from '@icon/svgIcon';
 import { CheckBox } from '@inputs/checkbox';
 import { selectorSelectedQueryLabels } from '@label/label.states';
-import { TypesTodo } from '@lib/types';
 import {
   optionsSvgPriorityUrgent,
   optionsSvgPriorityImportant,

--- a/components/todos/todoList/todo/todoItemFocuser/index.tsx
+++ b/components/todos/todoList/todo/todoItemFocuser/index.tsx
@@ -1,8 +1,9 @@
+import { TypesTodo } from '@components/todos/todos.types';
 import { KeysWithNavigationEffect } from '@effects/KeysWithNavigateEffect';
 import { useFocusOnClick } from '@hooks/focus';
 import { useKeyWithFocus } from '@hooks/keybindings';
 import { classNames } from '@stateLogics/utils';
-import { Types, TypesTodo } from 'lib/types';
+import { Types } from 'lib/types';
 import { Fragment as FocuserFragment, useRef } from 'react';
 import { isMobile } from 'react-device-detect';
 
@@ -24,7 +25,8 @@ export const TodoItemFocuser = ({ todo, index, children }: Props) => {
         )}
         ref={divFocus}
         onKeyDown={focusKeyHandler}
-        onClick={() => focusOnClick()}>
+        onClick={() => focusOnClick()}
+      >
         <KeysWithNavigationEffect
           index={index}
           divFocus={divFocus}

--- a/components/todos/todos.types.ts
+++ b/components/todos/todos.types.ts
@@ -1,0 +1,34 @@
+import { OBJECT_ID } from '@constAssertions/data';
+import { PRIORITY_LEVEL } from '@constAssertions/misc';
+import { Labels } from '@label/label.types';
+import { TypesMongoDB } from '@lib/types';
+
+export interface TypesTodo {
+  todoItem: TypesTodos;
+  todo: TypesTodoIds;
+  index: number;
+}
+
+export interface TypesTodosEditors {
+  title: string;
+  note: string;
+}
+
+export interface TypesTodoIds {
+  _id?: OBJECT_ID;
+  completed?: boolean;
+  priorityLevel?: PRIORITY_LEVEL | null;
+  priorityRankScore?: number;
+  completedDate?: Date | null;
+  deleted?: boolean | TypesMongoDB['notEqual'];
+  update?: number | TypesMongoDB['greaterThan'];
+}
+
+export interface TypesTodos extends TypesTodosEditors, TypesTodoIds {
+  createdDate: Date;
+  dueDate: Date | null;
+  completedDate: Date | null;
+  labelItem: Labels[];
+  title_id?: OBJECT_ID;
+  user_id?: OBJECT_ID;
+}

--- a/components/ui/buttons/iconButton/priorityButton.tsx
+++ b/components/ui/buttons/iconButton/priorityButton.tsx
@@ -1,4 +1,5 @@
 import { IconButton } from '@buttons/iconButton';
+import { TypesTodo } from '@components/todos/todos.types';
 import { PRIORITY_LEVEL } from '@constAssertions/misc';
 import {
   ICON_FLAG,
@@ -15,7 +16,7 @@ import { atomTodoNew } from '@states/todos';
 import { Fragment, Fragment as TodoPriorityFragment } from 'react';
 import { useRecoilCallback, useRecoilValue } from 'recoil';
 
-type Props = { options: TypesOptionsPriority } & Partial<Pick<Types, 'todo'>> & Pick<Types, 'onClick'>;
+type Props = { options: TypesOptionsPriority } & Partial<Pick<TypesTodo, 'todo'>> & Pick<Types, 'onClick'>;
 
 export const PriorityButton = ({ todo, options, onClick }: Props) => {
   const atomTodo = typeof todo === 'undefined' ? atomTodoNew : atomSelectorTodoItem(todo._id);

--- a/components/ui/calendars/calendar/index.tsx
+++ b/components/ui/calendars/calendar/index.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@buttons/button';
 import { IconButton } from '@buttons/iconButton';
+import { TypesTodo } from '@components/todos/todos.types';
 import { CALENDAR } from '@constAssertions/misc';
 import { ICON_TODAY } from '@data/materialSymbols';
 import { STYLE_CALENDAR_COL_START } from '@data/stylePreset';
@@ -12,7 +13,7 @@ import { atomDayPickerUpdater, atomCurrentMonth } from '@states/calendars';
 import { format, getDay, isEqual, isPast, isSameMonth, isThisMonth, isToday, parse } from 'date-fns';
 import { useRecoilValue } from 'recoil';
 
-type Props = Partial<Pick<Types, 'todo' | 'headerButtons'>>;
+type Props = Partial<Pick<Types, 'headerButtons'> & Pick<TypesTodo, 'todo'>>;
 
 export const Calendar = ({ todo, headerButtons }: Props) => {
   const itemDay = useRecoilValue(atomDayPickerUpdater(todo?._id)) as Date;

--- a/components/ui/comboBoxes/labelComboBox.tsx
+++ b/components/ui/comboBoxes/labelComboBox.tsx
@@ -5,7 +5,6 @@ import { ComboBoxSelectedLabelsEffect } from '@effects/comboBoxSelectedLabelsEff
 import { Combobox } from '@headlessui/react';
 import { useSetFilterLabels } from '@hooks/comboBoxes';
 import { useLabelModalStateOpen } from '@hooks/modals';
-import { Types } from '@lib/types';
 import { atomComboBoxQuery } from '@states/comboBoxes';
 import { useRecoilValue } from 'recoil';
 import { ComboBox } from './comboBox';
@@ -16,8 +15,9 @@ import { SvgIcon } from '@icon/svgIcon';
 import { selectorSelectedLabels, selectorComboBoxFilteredLabels } from '@label/label.states';
 import { Labels, TypesLabel } from '@label/label.types';
 import { useLabelChangeHandler, useDataButtonComboboxFilterLabel } from '@label/label.hooks';
+import { TypesTodo } from '@components/todos/todos.types';
 
-type Props = Partial<Pick<Types, 'todo'> & Pick<TypesLabel, 'selectedQueryLabels'>>;
+type Props = Partial<Pick<TypesTodo, 'todo'> & Pick<TypesLabel, 'selectedQueryLabels'>>;
 
 export const LabelComboBox = ({ todo }: Props) => {
   const onChangeLabelHandler = useLabelChangeHandler(todo?._id);

--- a/components/ui/dropdowns/v1/calendarDropdown.tsx
+++ b/components/ui/dropdowns/v1/calendarDropdown.tsx
@@ -19,8 +19,10 @@ import { Calendar } from '@ui/calendars/calendar';
 import { classNames } from '@stateLogics/utils';
 import { TypesOptionsDropdown } from '@lib/types/options';
 import { SvgIcon } from '@icon/svgIcon';
+import { TypesTodo } from '@components/todos/todos.types';
 
-type Props = { options: TypesOptionsDropdown } & Partial<Pick<Types, 'todo'>> & Pick<Types, 'onClickConfirm'>;
+type Props = { options: TypesOptionsDropdown } & Partial<Pick<TypesTodo, 'todo'>> &
+  Pick<Types, 'onClickConfirm'>;
 
 export const CalendarDropdown = ({ todo, onClickConfirm, options }: Props) => {
   const resetCalendar = useCalResetDayUpdater(todo?._id);

--- a/components/ui/dropdowns/v1/labelComboBoxDropdown.tsx
+++ b/components/ui/dropdowns/v1/labelComboBoxDropdown.tsx
@@ -1,6 +1,5 @@
 import { PrefetchRouterButton } from '@buttons/button/prefetchRouterButton';
 import { IconButton } from '@buttons/iconButton';
-import { Types } from '@lib/types';
 import { LabelComboBox } from '@ui/comboBoxes/labelComboBox';
 import { LabelsHorizontalGradients } from '@ui/gradients/labelsHorizontalGradients';
 import { Fragment as LabelComboBoxDropdownFragment, useRef } from 'react';
@@ -18,8 +17,12 @@ import { classNames, paths } from '@stateLogics/utils';
 import { selectorSelectedLabels } from '@label/label.states';
 import { TypesLabel } from '@label/label.types';
 import { useLabelRemoveItemTitleId } from '@label/label.hooks';
+import { TypesTodo } from '@components/todos/todos.types';
+import { Types } from '@lib/types';
 
-type Props = Partial<Pick<Types, 'container' | 'todo'> & Pick<TypesLabel, 'selectedQueryLabels'>>;
+type Props = Partial<
+  Pick<TypesTodo, 'todo'> & Pick<Types, 'container'> & Pick<TypesLabel, 'selectedQueryLabels'>
+>;
 
 export const LabelComboBoxDropdown = ({ todo, selectedQueryLabels, container }: Props) => {
   const removeTitleId = useLabelRemoveItemTitleId(todo?._id);

--- a/components/ui/dropdowns/v1/todoItemDropdown.tsx
+++ b/components/ui/dropdowns/v1/todoItemDropdown.tsx
@@ -14,8 +14,9 @@ import { usePriorityUpdate, usePriorityUpdateData } from '@hooks/priorities';
 import { useTodoRemoveItem } from '@hooks/todos';
 import { selectorSessionTodoItem } from '@states/atomEffects/todos';
 import { TypesOptionsDropdown } from '@lib/types/options';
+import { TypesTodo } from '@components/todos/todos.types';
 
-type Props = { options: TypesOptionsDropdown } & Partial<Pick<Types, 'todo' | 'children'>>;
+type Props = { options: TypesOptionsDropdown } & Partial<Pick<TypesTodo, 'todo'> & Pick<Types, 'children'>>;
 
 export const TodoItemDropdown = ({ todo, children, options }: Props) => {
   const removeTodo = useTodoRemoveItem(todo?._id);

--- a/components/ui/inputs/checkbox.tsx
+++ b/components/ui/inputs/checkbox.tsx
@@ -1,8 +1,9 @@
-import { Types, TypesTodo } from 'lib/types';
+import { Types } from 'lib/types';
 import { Input } from './input';
 import { MODIFIER_KBD } from '@constAssertions/misc';
 import { useConditionCompareTodoItemsEqual } from '@hooks/misc';
 import { classNames } from '@stateLogics/utils';
+import { TypesTodo } from '@components/todos/todos.types';
 
 type Props = Partial<Pick<Types, 'isChecked' | 'onChange' | 'className' | 'checkBoxColor' | 'checkedColor'>> &
   Pick<TypesTodo, 'todoItem'>;

--- a/components/ui/modals/confirmModal/deleteConfirmModal/deleteTodoConfirmModal.tsx
+++ b/components/ui/modals/confirmModal/deleteConfirmModal/deleteTodoConfirmModal.tsx
@@ -1,14 +1,16 @@
+import { TypesTodo } from '@components/todos/todos.types';
 import { useTodoModalConfirmStateDelete } from '@hooks/modals';
-import { Types } from '@lib/types';
 import { selectorSessionTodoItem } from '@states/atomEffects/todos';
 import { atomConfirmModalDelete } from '@states/modals';
 import dynamic from 'next/dynamic';
 import { Fragment } from 'react';
 import { useRecoilValue } from 'recoil';
 
-const DeleteConfirmModal = dynamic(() => import('../deleteConfirmModal').then((mod) => mod.DeleteConfirmModal));
+const DeleteConfirmModal = dynamic(() =>
+  import('../deleteConfirmModal').then((mod) => mod.DeleteConfirmModal),
+);
 
-type Props = Pick<Types, 'todo'>;
+type Props = Pick<TypesTodo, 'todo'>;
 
 export const DeleteTodoConfirmModal = ({ todo }: Props) => {
   const deleteConfirmModal = useTodoModalConfirmStateDelete(todo?._id);

--- a/components/ui/modals/confirmModal/discardConfirmModal.tsx
+++ b/components/ui/modals/confirmModal/discardConfirmModal.tsx
@@ -1,6 +1,6 @@
 import { Button as ConfirmButton } from '@buttons/button';
+import { TypesTodo } from '@components/todos/todos.types';
 import { useTodoModalConfirmStateDiscard } from '@hooks/modals';
-import { Types } from '@lib/types';
 import { HeaderDescription } from '@modals/modal/modalHeaders/headerDescription';
 import { HeaderTitle } from '@modals/modal/modalHeaders/headerTitle';
 import { optionsButtonConfirmModalDiscard } from '@options/button';
@@ -12,7 +12,7 @@ import { useRecoilValue } from 'recoil';
 const ConfirmModal = dynamic(() => import('.').then((mod) => mod.ConfirmModal));
 const SvgIcon = dynamic(() => import('@icon/svgIcon').then((mod) => mod.SvgIcon));
 
-export const DiscardConfirmModal = ({ todo }: Partial<Pick<Types, 'todo'>>) => {
+export const DiscardConfirmModal = ({ todo }: Partial<Pick<TypesTodo, 'todo'>>) => {
   const discardConfirmModal = useTodoModalConfirmStateDiscard(todo?._id);
   const isConfirmModalOpen = useRecoilValue(atomConfirmModalDiscard(todo?._id));
   const initialFocusButton = useRef<HTMLButtonElement>(null);

--- a/components/ui/modals/minimizedModal.tsx
+++ b/components/ui/modals/minimizedModal.tsx
@@ -5,7 +5,6 @@ import {
 } from '@buttons/iconButton';
 import { atomTodoModalMini } from '@states/modals';
 import { atomTodoNew } from '@states/todos';
-import { TypesTodo } from 'lib/types';
 import { Fragment } from 'react';
 import { useRecoilValue } from 'recoil';
 import { MinimizeModalTransition } from './modal/modalTransition/minimizeModalTransition';
@@ -23,6 +22,7 @@ import {
   useTodoModalStateExitMinimize,
 } from '@hooks/modals';
 import { atomEffectMediaQuery } from '@states/atomEffects/misc';
+import { TypesTodo } from '@components/todos/todos.types';
 
 type Props = Partial<Pick<TypesTodo, 'todo'>>;
 
@@ -39,7 +39,8 @@ export const MinimizedModal = ({ todo }: Props) => {
       {isMediaQuerySmall && (
         <MinimizeModalTransition
           show={isTodoModalMiniOpen}
-          options={optionsMinimizedModal}>
+          options={optionsMinimizedModal}
+        >
           <div className=' flex flex-shrink-0 flex-row items-center justify-between'>
             <div className='flex flex-1 flex-col justify-center'>
               <p className='line-clamp-1 w-44 break-words text-sm font-medium text-gray-500'>

--- a/components/ui/modals/todoModals/itemTodoModal.tsx
+++ b/components/ui/modals/todoModals/itemTodoModal.tsx
@@ -1,11 +1,11 @@
 import { DisableButton } from '@buttons/disableButton';
+import { TypesTodo } from '@components/todos/todos.types';
 import { PRIORITY_LEVEL } from '@constAssertions/misc';
 import { KeysWithItemModalEffect } from '@effects/KeysWithItemModalEffect';
 import { KeysWithTodoModalEffect } from '@effects/keysWithTodoModalEffect';
 import { useConditionCompareTodoItemsEqual } from '@hooks/misc';
 import { useTodoUpdateItem, useTodoCompleteItem } from '@hooks/todos';
 import { CheckBox as CompleteTodoCheckBox } from '@inputs/checkbox';
-import { Types } from '@lib/types';
 import { optionsButtonItemModalUpdate } from '@options/button';
 import { classNames } from '@stateLogics/utils';
 import { selectorSessionTodoItem } from '@states/atomEffects/todos';
@@ -15,7 +15,7 @@ import { Fragment as FooterButtonsFragment, Fragment as HeaderContentFragment } 
 import { useRecoilValue } from 'recoil';
 const TodoModal = dynamic(() => import('@modals/todoModals/todoModal').then((mod) => mod.TodoModal));
 
-export const ItemTodoModal = ({ todo }: Pick<Types, 'todo'>) => {
+export const ItemTodoModal = ({ todo }: Pick<TypesTodo, 'todo'>) => {
   const updateTodo = useTodoUpdateItem(todo._id);
   const completeTodo = useTodoCompleteItem(todo._id);
   const todoItem = useRecoilValue(selectorSessionTodoItem(todo._id));
@@ -46,11 +46,13 @@ export const ItemTodoModal = ({ todo }: Pick<Types, 'todo'>) => {
           <DisableButton
             options={optionsButtonItemModalUpdate}
             isConditionalRendering={condition}
-            onClick={() => updateTodo()}>
+            onClick={() => updateTodo()}
+          >
             Update
           </DisableButton>
         </FooterButtonsFragment>
-      }>
+      }
+    >
       <KeysWithTodoModalEffect todo={todo} />
       <KeysWithItemModalEffect todo={todo} />
     </TodoModal>

--- a/components/ui/modals/todoModals/todoModal/index.tsx
+++ b/components/ui/modals/todoModals/todoModal/index.tsx
@@ -23,9 +23,10 @@ import { selectorSessionTodoItem } from '@states/atomEffects/todos';
 import { KeysWithTodoModalEffect } from '@effects/keysWithTodoModalEffect';
 import { classNames } from '@stateLogics/utils';
 import { DividerX } from '@ui/dividers/dividerX';
+import { TypesTodo } from '@components/todos/todos.types';
 
 type Props = Partial<
-  Pick<Types, 'todo' | 'children' | 'menuButtonContent' | 'footerButtons' | 'headerButtons'>
+  Pick<Types, 'children' | 'menuButtonContent' | 'footerButtons' | 'headerButtons'> & Pick<TypesTodo, 'todo'>
 >;
 
 export const TodoModal = ({ todo, menuButtonContent, headerButtons, footerButtons, children }: Props) => {

--- a/components/ui/modals/todoModals/todoModal/todoModalHeaderButtons.tsx
+++ b/components/ui/modals/todoModals/todoModal/todoModalHeaderButtons.tsx
@@ -3,16 +3,12 @@ import {
   IconButton as ExpandReversibleIconButton,
   IconButton as MinimizeIconButton,
 } from '@buttons/iconButton';
+import { TypesTodo } from '@components/todos/todos.types';
 import { MODIFIER_KBD } from '@constAssertions/misc';
 import { BREAKPOINT } from '@constAssertions/ui';
 import { ICON_CLOSE_FULL_SCREEN, ICON_OPEN_IN_FULL } from '@data/materialSymbols';
 import { TodoItemDropdown } from '@dropdowns/v1/todoItemDropdown';
-import {
-  useTodoModalStateMinimize,
-  useTodoModalStateExpand,
-  useTodoModalStateClose,
-} from '@hooks/modals';
-import { Types } from '@lib/types';
+import { useTodoModalStateMinimize, useTodoModalStateExpand, useTodoModalStateClose } from '@hooks/modals';
 import { optionsButtonTodoModalMinimize, optionsButtonTodoModalClose } from '@options/button';
 import { atomEffectMediaQuery } from '@states/atomEffects/misc';
 import { atomTodoModalMax } from '@states/modals';
@@ -23,7 +19,7 @@ import {
 } from 'react';
 import { useRecoilValue } from 'recoil';
 
-type Props = Partial<Pick<Types, 'todo'>>;
+type Props = Partial<Pick<TypesTodo, 'todo'>>;
 
 export const TodoModalHeaderButtons = ({ todo }: Props) => {
   const minimizeModal = useTodoModalStateMinimize(todo?._id);

--- a/components/ui/modals/todoModals/todoModal/todoModalHeaderContents.tsx
+++ b/components/ui/modals/todoModals/todoModal/todoModalHeaderContents.tsx
@@ -1,4 +1,5 @@
 import { PriorityButton } from '@buttons/iconButton/priorityButton';
+import { TypesTodo } from '@components/todos/todos.types';
 import { PRIORITY_LEVEL } from '@constAssertions/misc';
 import { usePriorityUpdate } from '@hooks/priorities';
 import { Types } from '@lib/types';
@@ -7,12 +8,15 @@ import { optionsPriorityTodoModalImportant, optionsPriorityTodoModalUrgent } fro
 import { selectorSessionTodoItem } from '@states/atomEffects/todos';
 import { useRecoilCallback } from 'recoil';
 
-type Props = Pick<Types, 'children'> & Partial<Pick<Types, 'todo'>>;
+type Props = Pick<Types, 'children'> & Partial<Pick<TypesTodo, 'todo'>>;
 
 export const TodoModalHeaderContents = ({ todo, children }: Props) => {
   const setPriority = usePriorityUpdate(todo?._id);
   const isTodoCompleted = useRecoilCallback(({ snapshot }) => () => {
-    return typeof todo !== 'undefined' && snapshot.getLoadable(selectorSessionTodoItem(todo._id)).getValue().completed;
+    return (
+      typeof todo !== 'undefined' &&
+      snapshot.getLoadable(selectorSessionTodoItem(todo._id)).getValue().completed
+    );
   });
   const disabledStyle = isTodoCompleted() ? 'cursor-not-allowed opacity-50 select-none' : '';
   const conditionalHeaderDescription = isTodoCompleted() ? 'Completed todo' : 'Update todo';

--- a/lib/data/collections/demo.tsx
+++ b/lib/data/collections/demo.tsx
@@ -1,7 +1,7 @@
-import { TodoIds, Todos } from '@lib/types';
+import { TypesTodoIds, TypesTodos } from '@components/todos/todos.types';
 import { addDays, subDays } from 'date-fns';
 
-export const DATA_DEMO: Todos[] = [
+export const DATA_DEMO: TypesTodos[] = [
   {
     _id: '1',
     title: 'Buy groceries',
@@ -111,4 +111,4 @@ export const DATA_DEMO: Todos[] = [
   },
 ];
 
-export const DATA_DEMO_TODOIDS: TodoIds[] = DATA_DEMO.filter((todo) => todo._id);
+export const DATA_DEMO_TODOIDS: TypesTodoIds[] = DATA_DEMO.filter((todo) => todo._id);

--- a/lib/dataConnections/aggregationPipeline.ts
+++ b/lib/dataConnections/aggregationPipeline.ts
@@ -1,12 +1,12 @@
-import { Todos } from '@lib/types';
+import { TypesTodos } from '@components/todos/todos.types';
 import mongoose, { PipelineStage } from 'mongoose';
 
 export const aggregatedTodoItem = ({
   todoId,
   userId,
 }: {
-  todoId: Todos['_id'];
-  userId: Todos['user_id'];
+  todoId: TypesTodos['_id'];
+  userId: TypesTodos['user_id'];
 }): PipelineStage[] => {
   //   * Example:
   //   const getItem = await TodoItem.aggregate(

--- a/lib/queries/queryTodos.ts
+++ b/lib/queries/queryTodos.ts
@@ -1,12 +1,13 @@
 import { DATA_DEMO } from '@collections/demo';
+import { TypesTodos } from '@components/todos/todos.types';
 import { STORAGE_KEY } from '@constAssertions/storage';
-import { Todos, Types } from '@lib/types';
+import { Types } from '@lib/types';
 import { fetchWithRetry, queries } from '@stateLogics/utils';
 
 const apiTodos = process.env.NEXT_PUBLIC_API_ENDPOINT_TODOS as string;
 
 export const getDemoTodoItem = ({ _id }: Pick<Types, '_id'>) => {
-  const data = DATA_DEMO.find((todo) => todo._id === _id) || ({} as Todos);
+  const data = DATA_DEMO.find((todo) => todo._id === _id) || ({} as TypesTodos);
   return data;
 };
 
@@ -26,7 +27,7 @@ export const getDataTodoItem = async ({ _id }: Pick<Types, '_id'>) => {
   return await response.json();
 };
 
-export const createDataNewTodo = async (data: Todos) => {
+export const createDataNewTodo = async (data: TypesTodos) => {
   const response = await fetchWithRetry(apiTodos, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -36,7 +37,7 @@ export const createDataNewTodo = async (data: Todos) => {
   return await response.json();
 };
 
-export const deleteDataTodo = async (_id: Todos['_id']) => {
+export const deleteDataTodo = async (_id: TypesTodos['_id']) => {
   const response = await fetchWithRetry(apiTodos + `/${_id}`, {
     method: 'DELETE',
   });
@@ -44,7 +45,7 @@ export const deleteDataTodo = async (_id: Todos['_id']) => {
   return await response.json();
 };
 
-export const updateDataTodo = async (_id: Todos['_id'], data: Todos) => {
+export const updateDataTodo = async (_id: TypesTodos['_id'], data: TypesTodos) => {
   const response = await fetchWithRetry(apiTodos + `/${_id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
@@ -55,9 +56,9 @@ export const updateDataTodo = async (_id: Todos['_id'], data: Todos) => {
 };
 
 export const completeDataTodo = async (
-  _id: Todos['_id'],
-  completed: Todos['completed'],
-  completedDate: Todos['completedDate'],
+  _id: TypesTodos['_id'],
+  completed: TypesTodos['completed'],
+  completedDate: TypesTodos['completedDate'],
 ) => {
   const response = await fetchWithRetry(apiTodos + `/${_id}`, {
     method: 'PATCH',
@@ -72,9 +73,9 @@ export const completeDataTodo = async (
 };
 
 export const updateDataCalendarTodo = async (
-  _id: Todos['_id'],
-  dueDate: Todos['dueDate'],
-  priorityRankScore: Todos['priorityRankScore'],
+  _id: TypesTodos['_id'],
+  dueDate: TypesTodos['dueDate'],
+  priorityRankScore: TypesTodos['priorityRankScore'],
 ) => {
   const response = await fetchWithRetry(apiTodos + `/${_id}`, {
     method: 'PATCH',
@@ -89,9 +90,9 @@ export const updateDataCalendarTodo = async (
 };
 
 export const updateDataPriorityTodo = async (
-  _id: Todos['_id'],
-  priority: Todos['priorityLevel'],
-  priorityRankScore: Todos['priorityRankScore'],
+  _id: TypesTodos['_id'],
+  priority: TypesTodos['priorityLevel'],
+  priorityRankScore: TypesTodos['priorityRankScore'],
 ) => {
   const response = await fetchWithRetry(apiTodos + `/${_id}`, {
     method: 'PATCH',

--- a/lib/sanitizers/sanitizedSchemas.tsx
+++ b/lib/sanitizers/sanitizedSchemas.tsx
@@ -1,9 +1,9 @@
+import { TypesTodos } from '@components/todos/todos.types';
 import { OBJECT_ID } from '@constAssertions/data';
 import { Labels } from '@label/label.types';
-import { Todos } from '@lib/types';
 import { sanitize, sanitizeObject } from '@stateLogics/utils';
 
-export const sanitizedUserTodoItem = (data: Todos) => {
+export const sanitizedUserTodoItem = (data: TypesTodos) => {
   return {
     title: sanitize(data.title),
     completed: data.completed,
@@ -16,14 +16,14 @@ export const sanitizedUserTodoItem = (data: Todos) => {
   };
 };
 
-export const sanitizedUserTodoNote = (data: Todos) => {
+export const sanitizedUserTodoNote = (data: TypesTodos) => {
   return {
     note: sanitize(data.note),
     update: Date.now(),
   };
 };
 
-export const sanitizedUserLabels = (data: Todos['labelItem'] | Labels[]) => {
+export const sanitizedUserLabels = (data: TypesTodos['labelItem'] | Labels[]) => {
   return (
     data &&
     (data.map((labelItem) => {

--- a/lib/stateLogics/effects/KeysWithItemModalEffect.tsx
+++ b/lib/stateLogics/effects/KeysWithItemModalEffect.tsx
@@ -1,5 +1,5 @@
+import { TypesTodo } from '@components/todos/todos.types';
 import { useItemModalWithKey } from '@hooks/keybindings';
-import { TypesTodo } from '@lib/types';
 import { useEffect } from 'react';
 
 type Props = Pick<TypesTodo, 'todo'>;

--- a/lib/stateLogics/effects/KeysWithNavigateEffect.tsx
+++ b/lib/stateLogics/effects/KeysWithNavigateEffect.tsx
@@ -1,3 +1,4 @@
+import { TypesTodo } from '@components/todos/todos.types';
 import { CATCH, FOCUS } from '@constAssertions/misc';
 import { useFocusState } from '@hooks/focus';
 import { useKeyWithNavigate } from '@hooks/keybindings';
@@ -9,7 +10,7 @@ import { atomTodoModalOpen } from '@states/modals';
 import { useEffect } from 'react';
 import { RecoilValue, useRecoilCallback, useRecoilValue } from 'recoil';
 
-type Props = Pick<Types, 'index' | 'divFocus' | 'todo'>;
+type Props = Pick<Types, 'divFocus'> & Pick<TypesTodo, 'index' | 'todo'>;
 
 export const KeysWithNavigationEffect = ({ index, divFocus, todo }: Props) => {
   const setFocus = useFocusState(todo._id);

--- a/lib/stateLogics/effects/comboBoxSelectedLabelsEffect.tsx
+++ b/lib/stateLogics/effects/comboBoxSelectedLabelsEffect.tsx
@@ -1,12 +1,12 @@
-import { Types } from '@lib/types';
 import { useEffect } from 'react';
 import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
 import { atomFilterSelected } from '@states/comboBoxes';
 import { CATCH } from '@constAssertions/misc';
 import { atomCatch } from '@states/misc';
 import { useLabelUpdateDataItem } from '@label/label.hooks';
+import { TypesTodo } from '@components/todos/todos.types';
 
-type Props = Partial<Pick<Types, 'todo'>>;
+type Props = Partial<Pick<TypesTodo, 'todo'>>;
 
 export const ComboBoxSelectedLabelsEffect = ({ todo }: Props) => {
   const resetFilter = useResetRecoilState(atomFilterSelected(todo?._id));

--- a/lib/stateLogics/effects/keysWithTodoModalEffect.tsx
+++ b/lib/stateLogics/effects/keysWithTodoModalEffect.tsx
@@ -1,5 +1,5 @@
+import { TypesTodo } from '@components/todos/todos.types';
 import { useKeyWithTodoModal } from '@hooks/keybindings';
-import { TypesTodo } from '@lib/types';
 import { useEffect } from 'react';
 
 type Props = Partial<Pick<TypesTodo, 'todo'>>;

--- a/lib/stateLogics/hooks/calendar.tsx
+++ b/lib/stateLogics/hooks/calendar.tsx
@@ -1,5 +1,4 @@
 import { updateDataCalendarTodo } from '@lib/queries/queryTodos';
-import { Todos } from '@lib/types';
 import { atomTodoNew } from '@states/todos';
 import {
   parse,
@@ -23,12 +22,13 @@ import { useGetWithRecoilCallback } from './misc';
 import { useNotificationState } from './notifications';
 import { usePriorityRankScore } from './priorities';
 import { atomCurrentMonth, atomDayPickerUpdater, atomDayPicker } from '@states/calendars';
+import { TypesTodos } from '@components/todos/todos.types';
 
 /**
  * Hooks
  * */
 
-export const useCalState = (todoId: Todos['_id']) => {
+export const useCalState = (todoId: TypesTodos['_id']) => {
   return useRecoilCallback(({ set, reset, snapshot }) => (state: CALENDAR) => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
     const currentMonth = get(atomCurrentMonth(todoId));
@@ -64,7 +64,7 @@ export const useCalState = (todoId: Todos['_id']) => {
   });
 };
 
-export const useCalResetDateItemOnly = (todoId: Todos['_id']) => {
+export const useCalResetDateItemOnly = (todoId: TypesTodos['_id']) => {
   return useRecoilCallback(({ reset }) => () => {
     reset(atomCurrentMonth(todoId));
     reset(atomSelectorTodoItem(todoId));
@@ -73,7 +73,7 @@ export const useCalResetDateItemOnly = (todoId: Todos['_id']) => {
     // set(atomDayPickerUpdater(todoId), null); //derived state does not reset to default value as null if reset
   });
 };
-export const useCalResetDateAll = (todoId: Todos['_id']) => {
+export const useCalResetDateAll = (todoId: TypesTodos['_id']) => {
   return useRecoilCallback(({ reset, set, snapshot }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
     reset(atomCurrentMonth(todoId));
@@ -92,13 +92,13 @@ export const useCalResetDateAll = (todoId: Todos['_id']) => {
   });
 };
 
-export const useCalSelectDay = (todoId: Todos['_id']) => {
+export const useCalSelectDay = (todoId: TypesTodos['_id']) => {
   return useRecoilCallback(({ set }) => (newValue: Date) => {
     set(atomDayPickerUpdater(todoId), newValue);
   });
 };
 
-export const useCalUpdateDay = (todoId: Todos['_id']) => {
+export const useCalUpdateDay = (todoId: TypesTodos['_id']) => {
   return useRecoilCallback(({ set, snapshot }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
 
@@ -106,7 +106,7 @@ export const useCalUpdateDay = (todoId: Todos['_id']) => {
   });
 };
 
-export const useCalUpdate = (todoId: Todos['_id']) => {
+export const useCalUpdate = (todoId: TypesTodos['_id']) => {
   return useRecoilCallback(({ set, snapshot }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
 
@@ -124,7 +124,7 @@ export const useCalUpdate = (todoId: Todos['_id']) => {
   });
 };
 
-export const useCalUpdateItem = (todoId: Todos['_id']) => {
+export const useCalUpdateItem = (todoId: TypesTodos['_id']) => {
   const updateCalendarDay = useCalUpdateDay(todoId);
   const updateCalendarTodoItem = useCalUpdate(todoId);
 
@@ -134,7 +134,7 @@ export const useCalUpdateItem = (todoId: Todos['_id']) => {
   };
 };
 
-export const useCalUpdateDataItem = (todoId: Todos['_id']) => {
+export const useCalUpdateDataItem = (todoId: TypesTodos['_id']) => {
   const { status } = useSession();
   const get = useGetWithRecoilCallback();
   const updateCalItem = useCalUpdateItem(todoId);
@@ -156,7 +156,8 @@ export const useCalUpdateDataItem = (todoId: Todos['_id']) => {
   return () => {
     updateCalItem();
     updatePriorityRankScore();
-    if (equal(get(selectorSessionTodoItem(todoId)).dueDate, get(atomSelectorTodoItem(todoId)).dueDate)) return;
+    if (equal(get(selectorSessionTodoItem(todoId)).dueDate, get(atomSelectorTodoItem(todoId)).dueDate))
+      return;
     get(atomSelectorTodoItem(todoId)).dueDate
       ? setNotification(NOTIFICATION['updatedDueDate'])
       : setNotification(NOTIFICATION['removedDueDate']);
@@ -164,7 +165,7 @@ export const useCalUpdateDataItem = (todoId: Todos['_id']) => {
   };
 };
 
-export const useCalResetDayUpdater = (todoId: Todos['_id']) => {
+export const useCalResetDayUpdater = (todoId: TypesTodos['_id']) => {
   return useRecoilCallback(({ reset }) => () => {
     reset(atomDayPickerUpdater(todoId));
   });

--- a/lib/stateLogics/hooks/comboBoxes.tsx
+++ b/lib/stateLogics/hooks/comboBoxes.tsx
@@ -1,9 +1,9 @@
+import { TypesTodos } from '@components/todos/todos.types';
 import { selectorSelectedLabels } from '@label/label.states';
-import { Todos } from '@lib/types';
 import { atomFilterSelected, atomComboBoxQuery } from '@states/comboBoxes';
 import { RecoilValue, useRecoilCallback } from 'recoil';
 
-export const useSetFilterLabels = (_id: Todos['_id']) => {
+export const useSetFilterLabels = (_id: TypesTodos['_id']) => {
   return useRecoilCallback(({ set, reset, snapshot }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
     const selectedLabels = get(selectorSelectedLabels(_id));

--- a/lib/stateLogics/hooks/focus.tsx
+++ b/lib/stateLogics/hooks/focus.tsx
@@ -1,15 +1,15 @@
-import { Todos, Types } from '@lib/types';
 import { atomTodoModalMini } from '@states/modals';
 import { useRecoilCallback, RecoilValue } from 'recoil';
 import { FOCUS } from '@constAssertions/misc';
 import { selectorSessionTodoItem } from '@states/atomEffects/todos';
 import { atomOnFocus, atomCurrentFocus } from '@states/focus';
 import { useTodoModalStateOpen } from './modals';
+import { TypesTodo, TypesTodos } from '@components/todos/todos.types';
 
 /*
  * Hooks
  **/
-export const useFocusState = (_id: Todos['_id']) => {
+export const useFocusState = (_id: TypesTodos['_id']) => {
   const openModal = useTodoModalStateOpen(_id);
   const focusState = useRecoilCallback(({ reset, snapshot }) => (state: FOCUS) => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
@@ -33,7 +33,7 @@ export const useFocusState = (_id: Todos['_id']) => {
   return focusState;
 };
 
-export const useFocusOnClick = (index: Types['index']) => {
+export const useFocusOnClick = (index: TypesTodo['index']) => {
   return useRecoilCallback(({ set }) => () => {
     set(atomCurrentFocus, index);
     set(atomOnFocus, true);

--- a/lib/stateLogics/hooks/keybindings.tsx
+++ b/lib/stateLogics/hooks/keybindings.tsx
@@ -1,6 +1,5 @@
 import { CATCH } from '@constAssertions/misc';
 import { BREAKPOINT } from '@constAssertions/ui';
-import { Todos } from '@lib/types';
 import { atomEffectMediaQuery } from '@states/atomEffects/misc';
 import { selectorSessionTodoItem } from '@states/atomEffects/todos';
 import { atomCurrentFocus, atomOnBlur, atomOnFocus } from '@states/focus';
@@ -24,8 +23,9 @@ import {
 import { useTodoCompleteItem, useTodoRemoveItem } from './todos';
 import { Labels } from '@label/label.types';
 import { useLabelAdd, useLabelUpdateItem, useLabelUpdateDataItem } from '@label/label.hooks';
+import { TypesTodos } from '@components/todos/todos.types';
 
-export const useItemModalWithKey = (_id: Todos['_id']) => {
+export const useItemModalWithKey = (_id: TypesTodos['_id']) => {
   const completeTodo = useTodoCompleteItem(_id);
   const removeTodo = useTodoRemoveItem(_id);
 
@@ -49,7 +49,7 @@ export const useItemModalWithKey = (_id: Todos['_id']) => {
   return itemModalKeyHandler;
 };
 
-export const useKeyWithFocus = (_id: Todos['_id']) => {
+export const useKeyWithFocus = (_id: TypesTodos['_id']) => {
   const completeTodo = useTodoCompleteItem(_id);
   const openModal = useTodoModalStateOpen(_id);
   const removeTodo = useTodoRemoveItem(_id);
@@ -168,7 +168,7 @@ export const useKeyWithNavigate = () => {
   return keyDownNavigate;
 };
 
-export const useKeyWithTodoModal = (_id: Todos['_id']) => {
+export const useKeyWithTodoModal = (_id: TypesTodos['_id']) => {
   const openModal = useTodoModalStateOpen(_id);
   const expandModal = useTodoModalStateExpand(_id);
   const exitMinimizeModal = useTodoModalStateExitMinimize(_id);

--- a/lib/stateLogics/hooks/misc.tsx
+++ b/lib/stateLogics/hooks/misc.tsx
@@ -1,7 +1,7 @@
+import { TypesTodos } from '@components/todos/todos.types';
 import { PATH_APP } from '@constAssertions/data';
 import { atomLabelNew, atomSelectorLabelItem, selectorSessionLabels } from '@label/label.states';
 import { Labels } from '@label/label.types';
-import { Todos } from '@lib/types';
 import { atomSelectorTodoItem, selectorSessionTodoItem } from '@states/atomEffects/todos';
 import { atomTodoModalMini, atomTodoModalOpen } from '@states/modals';
 import { atomTodoNew, selectorFilterTodoIdsByPathname } from '@states/todos';
@@ -61,7 +61,7 @@ export const useConditionCheckLabelTitleEmpty = () => {
   return typeof newTodo.name === 'undefined' || newTodo.name.trim() === '';
 };
 
-export const useConditionCompareTodoItemsEqual = (_id: Todos['_id']) => {
+export const useConditionCompareTodoItemsEqual = (_id: TypesTodos['_id']) => {
   const todoItem = useRecoilValueLoadable(selectorSessionTodoItem(_id)).valueMaybe();
   const selectorTodoItem = useRecoilValueLoadable(atomSelectorTodoItem(_id)).valueMaybe();
   if (typeof _id === 'undefined') return;

--- a/lib/stateLogics/hooks/modals.tsx
+++ b/lib/stateLogics/hooks/modals.tsx
@@ -1,4 +1,3 @@
-import { Todos } from '@lib/types';
 import { atomTodoNew } from '@states/todos';
 import ObjectID from 'bson-objectid';
 import { RecoilValue, useRecoilCallback, useResetRecoilState } from 'recoil';
@@ -19,12 +18,13 @@ import { atomCatch } from '@states/misc';
 import { atomLabelNew, atomSelectorLabelItem, atomSelectorLabels } from '@label/label.states';
 import { Labels } from '@label/label.types';
 import { useLabelRemoveItem } from '@label/label.hooks';
+import { TypesTodos } from '@components/todos/todos.types';
 
 /**
  * Hooks
  * */
 // Confirm Modal
-export const useModalConfirmStateCancel = (_id: Todos['_id']) => {
+export const useModalConfirmStateCancel = (_id: TypesTodos['_id']) => {
   return useRecoilCallback(({ reset, snapshot }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
 
@@ -35,7 +35,7 @@ export const useModalConfirmStateCancel = (_id: Todos['_id']) => {
 };
 
 // Todo Confirm Modal
-export const useTodoModalConfirmStateDiscard = (_id: Todos['_id']) => {
+export const useTodoModalConfirmStateDiscard = (_id: TypesTodos['_id']) => {
   return useRecoilCallback(({ reset, snapshot }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
 
@@ -51,7 +51,7 @@ export const useTodoModalConfirmStateDiscard = (_id: Todos['_id']) => {
   });
 };
 
-export const useTodoModalConfirmStateDelete = (_id: Todos['_id']) => {
+export const useTodoModalConfirmStateDelete = (_id: TypesTodos['_id']) => {
   const removeTodo = useTodoRemoveItem(_id);
 
   return useRecoilCallback(({ reset, snapshot }) => () => {
@@ -79,7 +79,7 @@ export const useLabelModalConfirmStateDelete = (_id: Labels['_id']) => {
 };
 
 //Todo Modal
-export const useTodoModalCloseState = (_id: Todos['_id']) => {
+export const useTodoModalCloseState = (_id: TypesTodos['_id']) => {
   const resetLabelsDrafted = useResetRecoilState(atomSelectorLabels);
   const compareTodoItemsEqual = useConditionCompareTodoItemsEqual(_id);
   const checkTodoTitleEmpty = useConditionCheckTodoTitleEmpty();
@@ -113,7 +113,7 @@ export const useTodoModalCloseState = (_id: Todos['_id']) => {
   return modalCloseState;
 };
 
-export const useTodoModalStateExpand = (_id: Todos['_id']) => {
+export const useTodoModalStateExpand = (_id: TypesTodos['_id']) => {
   return useRecoilCallback(({ set, snapshot }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
 
@@ -121,7 +121,7 @@ export const useTodoModalStateExpand = (_id: Todos['_id']) => {
   });
 };
 
-export const useTodoModalStateMaximize = (_id: Todos['_id']) => {
+export const useTodoModalStateMaximize = (_id: TypesTodos['_id']) => {
   return useRecoilCallback(({ set, reset, snapshot }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
 
@@ -133,7 +133,7 @@ export const useTodoModalStateMaximize = (_id: Todos['_id']) => {
   });
 };
 
-export const useTodoModalStateMinimize = (_id: Todos['_id']) => {
+export const useTodoModalStateMinimize = (_id: TypesTodos['_id']) => {
   return useRecoilCallback(({ set, reset, snapshot }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
 
@@ -144,7 +144,7 @@ export const useTodoModalStateMinimize = (_id: Todos['_id']) => {
   });
 };
 
-export const useTodoModalStateExitMinimize = (_id: Todos['_id']) => {
+export const useTodoModalStateExitMinimize = (_id: TypesTodos['_id']) => {
   return useRecoilCallback(({ set, reset, snapshot }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
 
@@ -156,7 +156,7 @@ export const useTodoModalStateExitMinimize = (_id: Todos['_id']) => {
   });
 };
 
-export const useTodoModalStateOpen = (_id: Todos['_id']) => {
+export const useTodoModalStateOpen = (_id: TypesTodos['_id']) => {
   const resetDateItemOnly = useCalResetDateItemOnly(_id);
   return useRecoilCallback(({ set, reset, snapshot }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
@@ -169,7 +169,7 @@ export const useTodoModalStateOpen = (_id: Todos['_id']) => {
   });
 };
 
-export const useTodoModalStateClose = (_id: Todos['_id']) => {
+export const useTodoModalStateClose = (_id: TypesTodos['_id']) => {
   const setModalClose = useTodoModalCloseState(_id);
   return useRecoilCallback(({ reset, snapshot }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
@@ -180,7 +180,7 @@ export const useTodoModalStateClose = (_id: Todos['_id']) => {
   });
 };
 
-export const useTodoModalStateReset = (_id: Todos['_id']) => {
+export const useTodoModalStateReset = (_id: TypesTodos['_id']) => {
   return useRecoilCallback(({ reset }) => () => {
     reset(atomTodoModalOpen(_id));
     reset(atomCatch(CATCH.todoModal));

--- a/lib/stateLogics/hooks/priorities.tsx
+++ b/lib/stateLogics/hooks/priorities.tsx
@@ -1,18 +1,22 @@
 import { updateDataPriorityTodo } from '@lib/queries/queryTodos';
-import { Todos } from '@lib/types';
 import { atomTodoNew } from '@states/todos';
 import { useSession } from 'next-auth/react';
 import { RecoilValue, useRecoilCallback } from 'recoil';
 import { PRIORITY_LEVEL } from '@constAssertions/misc';
-import { atomSelectorTodoItem, selectorSessionTodoItem, selectorSessionTodoIds } from '@states/atomEffects/todos';
+import {
+  atomSelectorTodoItem,
+  selectorSessionTodoItem,
+  selectorSessionTodoIds,
+} from '@states/atomEffects/todos';
 import { atomPriority, selectorPriorityRankScore } from '@states/priorities';
+import { TypesTodos } from '@components/todos/todos.types';
 
 /**
  * Hooks
  * */
 
 // Priority
-export const usePriorityUpdateTodoItem = (todoId: Todos['_id']) => {
+export const usePriorityUpdateTodoItem = (todoId: TypesTodos['_id']) => {
   return useRecoilCallback(({ set, snapshot }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
 
@@ -28,7 +32,7 @@ export const usePriorityUpdateTodoItem = (todoId: Todos['_id']) => {
   });
 };
 
-export const usePriorityUpdate = (todoId: Todos['_id']) => {
+export const usePriorityUpdate = (todoId: TypesTodos['_id']) => {
   const updatePriorityTodoItem = usePriorityUpdateTodoItem(todoId);
   const updatePriority = useRecoilCallback(({ set, reset, snapshot }) => (state: PRIORITY_LEVEL) => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
@@ -60,7 +64,7 @@ export const usePriorityUpdate = (todoId: Todos['_id']) => {
   };
 };
 
-export const usePriorityUpdateData = (todoId: Todos['_id']) => {
+export const usePriorityUpdateData = (todoId: TypesTodos['_id']) => {
   const { status } = useSession();
   const updatePriorityItem = usePriorityUpdate(todoId);
   const updatePriorityRankScore = usePriorityRankScore(todoId);
@@ -78,7 +82,8 @@ export const usePriorityUpdateData = (todoId: Todos['_id']) => {
       get(selectorSessionTodoIds).map((todo) => {
         return {
           ...todo,
-          priorityLevel: todo._id === todoId ? get(selectorSessionTodoItem(todoId)).priorityLevel : todo.priorityLevel,
+          priorityLevel:
+            todo._id === todoId ? get(selectorSessionTodoItem(todoId)).priorityLevel : todo.priorityLevel,
         };
       }),
     );
@@ -101,7 +106,7 @@ export const usePriorityUpdateData = (todoId: Todos['_id']) => {
 
 // PRS = Priority Rank Score
 
-export const usePriorityRankScore = (todoId: Todos['_id']) => {
+export const usePriorityRankScore = (todoId: TypesTodos['_id']) => {
   return useRecoilCallback(({ set, snapshot }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
 

--- a/lib/stateLogics/hooks/todos.tsx
+++ b/lib/stateLogics/hooks/todos.tsx
@@ -1,5 +1,4 @@
 import { completeDataTodo, createDataNewTodo, deleteDataTodo, updateDataTodo } from '@lib/queries/queryTodos';
-import { Todos } from '@lib/types';
 import { atomConfirmModalDelete } from '@states/modals';
 import { useSession } from 'next-auth/react';
 import { RecoilValue, useRecoilCallback, useResetRecoilState } from 'recoil';
@@ -22,6 +21,7 @@ import {
 import { atomEffectNetworkStatus } from '@states/atomEffects/misc';
 import { atomCatch } from '@states/misc';
 import { selectorSessionLabels, atomSelectorLabels } from '@label/label.states';
+import { TypesTodos } from '@components/todos/todos.types';
 
 /**
  * Hooks
@@ -57,7 +57,7 @@ export const useTodoAdd = () => {
   };
 };
 
-export const useTodoUpdateItem = (todoId: Todos['_id']) => {
+export const useTodoUpdateItem = (todoId: TypesTodos['_id']) => {
   const { status } = useSession();
   const setNotification = useNotificationState();
   const resetModal = useTodoModalStateReset(todoId);
@@ -100,7 +100,7 @@ export const useTodoUpdateItem = (todoId: Todos['_id']) => {
   };
 };
 
-export const useTodoRemoveItem = (todoId: Todos['_id']) => {
+export const useTodoRemoveItem = (todoId: TypesTodos['_id']) => {
   const { status } = useSession();
   const setNotification = useNotificationState();
   const get = useGetWithRecoilCallback();
@@ -132,7 +132,7 @@ export const useTodoRemoveItem = (todoId: Todos['_id']) => {
   };
 };
 
-export const useTodoCompleteDate = (todoId: Todos['_id']) => {
+export const useTodoCompleteDate = (todoId: TypesTodos['_id']) => {
   return useRecoilCallback(({ set, snapshot }) => () => {
     const get = <T,>(p: RecoilValue<T>) => snapshot.getLoadable(p).getValue();
 
@@ -143,7 +143,7 @@ export const useTodoCompleteDate = (todoId: Todos['_id']) => {
   });
 };
 
-export const useTodoCompleteItem = (todoId: Todos['_id']) => {
+export const useTodoCompleteItem = (todoId: TypesTodos['_id']) => {
   const { status } = useSession();
   const updateCompletedDate = useTodoCompleteDate(todoId);
   const setNotification = useNotificationState();

--- a/lib/stateLogics/states/atomEffects/todos.tsx
+++ b/lib/stateLogics/states/atomEffects/todos.tsx
@@ -1,8 +1,8 @@
 import { DATA_DEMO_TODOIDS } from '@collections/demo';
+import { TypesTodoIds, TypesTodos } from '@components/todos/todos.types';
 import { IDB_KEY, IDB_STORE } from '@constAssertions/storage';
 import { getDataTodoIds, getDataTodoItem, getDemoTodoItem } from '@lib/queries/queryTodos';
 import { queryEffect } from '@lib/stateLogics/effects/atomEffects/queryEffects';
-import { TodoIds, Todos } from '@lib/types';
 import { atomUserSession } from '@user/user.states';
 import { atom, atomFamily, selector, selectorFamily } from 'recoil';
 
@@ -11,7 +11,7 @@ import { atom, atomFamily, selector, selectorFamily } from 'recoil';
  * Defining `storeName` will automatically apply the predefined IndexedDB name.
  */
 
-export const atomQueryTodoIds = atom<TodoIds[]>({
+export const atomQueryTodoIds = atom<TypesTodoIds[]>({
   key: 'atomQueryTodoIds',
   default: [],
   effects: [
@@ -25,12 +25,12 @@ export const atomQueryTodoIds = atom<TodoIds[]>({
   ],
 });
 
-export const atomDemoTodoIds = atom<TodoIds[]>({
+export const atomDemoTodoIds = atom<TypesTodoIds[]>({
   key: 'atomDemoTodoIds',
   default: DATA_DEMO_TODOIDS,
 });
 
-export const selectorSessionTodoIds = selector<TodoIds[]>({
+export const selectorSessionTodoIds = selector<TypesTodoIds[]>({
   key: 'selectorSessionTodoIds',
   get: ({ get }) => {
     const session = get(atomUserSession);
@@ -42,9 +42,9 @@ export const selectorSessionTodoIds = selector<TodoIds[]>({
   },
 });
 
-export const atomQueryTodoItem = atomFamily<Todos, Todos['_id']>({
+export const atomQueryTodoItem = atomFamily<TypesTodos, TypesTodos['_id']>({
   key: 'atomQueryTodoItem',
-  default: {} as Todos,
+  default: {} as TypesTodos,
   //! Default value must be set to trigger the reset (reset removes the data from indexedDB)
   effects: (todoId) => [
     queryEffect({
@@ -58,9 +58,9 @@ export const atomQueryTodoItem = atomFamily<Todos, Todos['_id']>({
   ],
 });
 
-export const atomDemoTodoItem = atomFamily<Todos, Todos['_id']>({
+export const atomDemoTodoItem = atomFamily<TypesTodos, TypesTodos['_id']>({
   key: 'atomDemoTodoItem',
-  default: {} as Todos,
+  default: {} as TypesTodos,
   effects: (todoId) => [
     ({ setSelf }) => {
       const demoFunction = () => getDemoTodoItem({ _id: todoId });
@@ -69,7 +69,7 @@ export const atomDemoTodoItem = atomFamily<Todos, Todos['_id']>({
   ],
 });
 
-export const selectorSessionTodoItem = selectorFamily<Todos, Todos['_id']>({
+export const selectorSessionTodoItem = selectorFamily<TypesTodos, TypesTodos['_id']>({
   key: 'selectorSessionTodoItem',
   get:
     (todoId) =>
@@ -88,7 +88,7 @@ export const selectorSessionTodoItem = selectorFamily<Todos, Todos['_id']>({
 /**
  * Derived Query Todos
  **/
-export const atomSelectorTodoItem = atomFamily<Todos, Todos['_id']>({
+export const atomSelectorTodoItem = atomFamily<TypesTodos, TypesTodos['_id']>({
   key: 'atomSelectorTodoItem',
   default: selectorFamily({
     key: 'selectorAtomTodoItem',

--- a/lib/stateLogics/states/calendars.tsx
+++ b/lib/stateLogics/states/calendars.tsx
@@ -1,16 +1,16 @@
-import { Todos } from '@lib/types';
+import { TypesTodos } from '@components/todos/todos.types';
 import { format, startOfToday } from 'date-fns';
 import { atomFamily, selectorFamily } from 'recoil';
 
 /**
  * atoms
  */
-export const atomDayPicker = atomFamily<Todos['dueDate'], Todos['_id']>({
+export const atomDayPicker = atomFamily<TypesTodos['dueDate'], TypesTodos['_id']>({
   key: 'atomDayPicker',
   default: null,
 });
 
-export const atomDayPickerUpdater = atomFamily<Todos['dueDate'], Todos['_id']>({
+export const atomDayPickerUpdater = atomFamily<TypesTodos['dueDate'], TypesTodos['_id']>({
   key: 'atomDayPickerUpdater',
   default: selectorFamily({
     key: 'selectorAtomDayPickerUpdater',
@@ -25,7 +25,7 @@ export const atomDayPickerUpdater = atomFamily<Todos['dueDate'], Todos['_id']>({
   }),
 });
 
-export const atomCurrentMonth = atomFamily<string, Todos['_id']>({
+export const atomCurrentMonth = atomFamily<string, TypesTodos['_id']>({
   key: 'atomCurrentMonth',
   default: format(startOfToday(), 'MMM-yyyy'),
 });

--- a/lib/stateLogics/states/comboBoxes.tsx
+++ b/lib/stateLogics/states/comboBoxes.tsx
@@ -1,4 +1,4 @@
-import { Todos } from '@lib/types';
+import { TypesTodos } from '@components/todos/todos.types';
 import { atom, atomFamily } from 'recoil';
 
 /**
@@ -11,7 +11,7 @@ export const atomComboBoxQuery = atom<string>({
   default: '',
 });
 
-export const atomFilterSelected = atomFamily<boolean, Todos['_id']>({
+export const atomFilterSelected = atomFamily<boolean, TypesTodos['_id']>({
   key: 'atomFilterSelected',
   default: false,
 });

--- a/lib/stateLogics/states/priorities.tsx
+++ b/lib/stateLogics/states/priorities.tsx
@@ -1,16 +1,16 @@
 import { PRIORITY_LEVEL } from '@constAssertions/misc';
-import { Todos } from '@lib/types';
 import { selectorDynamicTodoItem } from '@states/todos';
 import { subDays, differenceInDays } from 'date-fns';
 import { atomFamily, selectorFamily, selector } from 'recoil';
 import { selectorSessionTodoIds } from './atomEffects/todos';
+import { TypesTodos } from '@components/todos/todos.types';
 
 /**
  * atoms
  */
 
 // priority
-export const atomPriority = atomFamily<PRIORITY_LEVEL | null, Todos['_id']>({
+export const atomPriority = atomFamily<PRIORITY_LEVEL | null, TypesTodos['_id']>({
   key: 'atomPriority',
   default: null,
 });
@@ -20,7 +20,7 @@ export const atomPriority = atomFamily<PRIORITY_LEVEL | null, Todos['_id']>({
  * */
 // priority rank score
 
-export const selectorDynamicPriority = selectorFamily<Todos['priorityLevel'], Todos['_id']>({
+export const selectorDynamicPriority = selectorFamily<TypesTodos['priorityLevel'], TypesTodos['_id']>({
   key: 'selectorPriority',
   get:
     (todoId) =>
@@ -102,7 +102,7 @@ export const selectorTaskCompleteCapacity = selector({
   },
 });
 
-export const selectorPrsDueDate = selectorFamily<number, Todos['_id']>({
+export const selectorPrsDueDate = selectorFamily<number, TypesTodos['_id']>({
   key: 'selectorPrsDueDate',
   get:
     (todoId) =>
@@ -132,7 +132,7 @@ export const selectorPrsDueDate = selectorFamily<number, Todos['_id']>({
   },
 });
 
-export const selectorPrsCreateDate = selectorFamily<number, Todos['_id']>({
+export const selectorPrsCreateDate = selectorFamily<number, TypesTodos['_id']>({
   key: 'selectorPrsCreateDate',
   get:
     (todoId) =>
@@ -150,7 +150,7 @@ export const selectorPrsCreateDate = selectorFamily<number, Todos['_id']>({
   },
 });
 
-export const selectorPrsTaskCapacity = selectorFamily<number, Todos['_id']>({
+export const selectorPrsTaskCapacity = selectorFamily<number, TypesTodos['_id']>({
   key: 'selectorPrsTaskCapacity',
   get:
     (todoId) =>
@@ -166,7 +166,7 @@ export const selectorPrsTaskCapacity = selectorFamily<number, Todos['_id']>({
   },
 });
 
-export const selectorPriorityRankScore = selectorFamily<number, Todos['_id']>({
+export const selectorPriorityRankScore = selectorFamily<number, TypesTodos['_id']>({
   key: 'selectorPriorityRankScore',
   get:
     (todoId) =>

--- a/lib/stateLogics/states/todos.tsx
+++ b/lib/stateLogics/states/todos.tsx
@@ -1,4 +1,4 @@
-import { TodoIds, Todos, Types } from '@lib/types';
+import { Types } from '@lib/types';
 import { selectorFilterPriorityRankScore } from '@states/priorities';
 import { atom, selector, selectorFamily } from 'recoil';
 import { PATH_APP, OBJECT_ID } from '@constAssertions/data';
@@ -7,11 +7,12 @@ import { atomSelectorTodoItem, selectorSessionTodoIds } from './atomEffects/todo
 import { atomFilterEffect } from './misc';
 import { atomLabelQuerySlug, selectorSessionLabels } from '@label/label.states';
 import { Labels } from '@label/label.types';
+import { TypesTodoIds, TypesTodos } from '@components/todos/todos.types';
 
 /**
  * atoms
  * */
-export const atomTodoNew = atom<Todos>({
+export const atomTodoNew = atom<TypesTodos>({
   key: 'atomTodoNew',
   default: {
     _id: undefined,
@@ -20,10 +21,10 @@ export const atomTodoNew = atom<Todos>({
     completed: false,
     createdDate: new Date(),
     labelItem: [] as Labels[],
-  } as Todos,
+  } as TypesTodos,
 });
 
-export const selectorDynamicTodoItem = selectorFamily<Todos, Todos['_id']>({
+export const selectorDynamicTodoItem = selectorFamily<TypesTodos, TypesTodos['_id']>({
   key: 'selectorDynamicTodoItem',
   get:
     (todoId) =>
@@ -63,7 +64,7 @@ export const selectorFilterTodoIds = selector({
   },
 });
 
-export const selectorFilterTodoIdsByPathname = selectorFamily<TodoIds[], PATH_APP>({
+export const selectorFilterTodoIdsByPathname = selectorFamily<TypesTodoIds[], PATH_APP>({
   key: 'selectorFilterTodoIdsByPathname',
   get:
     (pathname) =>
@@ -98,7 +99,7 @@ export const selectorFilterTodoIdsByPathname = selectorFamily<TodoIds[], PATH_AP
   },
 });
 
-export const selectorFilterTodoIdsByLabelQueryId = selectorFamily<TodoIds[], Labels['_id']>({
+export const selectorFilterTodoIdsByLabelQueryId = selectorFamily<TypesTodoIds[], Labels['_id']>({
   key: 'selectorFilterTodoIdsByQueryId',
   get:
     (labelId) =>

--- a/lib/types/bases/arrayOfObjects.ts
+++ b/lib/types/bases/arrayOfObjects.ts
@@ -1,12 +1,12 @@
+import { TypesTodoIds } from '@components/todos/todos.types';
 import { OBJECT_ID } from '@constAssertions/data';
-import { PRIORITY_LEVEL } from '@constAssertions/misc';
-import { LabelIds, Labels } from '@label/label.types';
+import { LabelIds } from '@label/label.types';
 
-export type CollectTypesArrayObject = Todos & TypesTodo & Settings & TypesGlobals & TypesMongoDB;
+export type CollectTypesArrayObject = Settings & TypesGlobals & TypesMongoDB;
 
 // GlobalTypes
 export interface TypesGlobals {
-  itemIds: TodoIds | LabelIds;
+  itemIds: TypesTodoIds | LabelIds;
   data: unknown;
   matchingId: OBJECT_ID;
 }
@@ -14,37 +14,6 @@ export interface TypesGlobals {
 export interface TypesMongoDB {
   notEqual: { $ne: boolean };
   greaterThan: { $gt: number };
-}
-
-// Todos
-export interface Todos extends TodosEditors, TodoIds {
-  createdDate: Date;
-  dueDate: Date | null;
-  completedDate: Date | null;
-  labelItem: Labels[];
-  title_id?: OBJECT_ID;
-  user_id?: OBJECT_ID;
-}
-
-export interface TodoIds {
-  _id?: OBJECT_ID;
-  completed?: boolean;
-  priorityLevel?: PRIORITY_LEVEL | null;
-  priorityRankScore?: number;
-  completedDate?: Date | null;
-  deleted?: boolean | TypesMongoDB['notEqual'];
-  update?: number | TypesMongoDB['greaterThan'];
-}
-
-export interface TodosEditors {
-  title: string;
-  note: string;
-}
-
-export interface TypesTodo {
-  todoItem: Todos;
-  todo: TodoIds;
-  index: number;
 }
 
 //* Users Settings

--- a/lib/types/options/index.ts
+++ b/lib/types/options/index.ts
@@ -1,3 +1,4 @@
+import { TypesTodos } from '@components/todos/todos.types';
 import { Types } from '..';
 import { TypesElement, TypesStyleAttributes } from '../bases/ui';
 
@@ -37,7 +38,7 @@ export type TypesOptionsPriority = Partial<
       'margin' | 'display' | 'width' | 'container' | 'padding' | 'size' | 'color' | 'borderRadius' | 'hoverBg'
     >
 > &
-  Pick<Types, 'priorityLevel'>;
+  Pick<TypesTodos, 'priorityLevel'>;
 
 export type TypesOptionsBackdrop = Partial<
   Pick<Types, 'isPortal' | 'enterDuration' | 'leaveDuration'> & Pick<TypesStyleAttributes, 'color' | 'zIndex'>

--- a/pages/api/v1/todos/index.tsx
+++ b/pages/api/v1/todos/index.tsx
@@ -2,12 +2,12 @@ import { databaseConnect } from '@lib/dataConnections/databaseConnection';
 import Label from '@lib/models/Label';
 import TodoItem from '@lib/models/Todo/TodoItems';
 import TodoNote from '@lib/models/Todo/TodoNotes';
-import { Todos } from '@lib/types';
 import mongoose from 'mongoose';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '../auth/[...nextauth]';
 import { Labels } from '@label/label.types';
+import { TypesTodos } from '@components/todos/todos.types';
 
 const Todos = async (req: NextApiRequest, res: NextApiResponse) => {
   await databaseConnect();
@@ -20,8 +20,8 @@ const Todos = async (req: NextApiRequest, res: NextApiResponse) => {
     query: { update: lastUpdate },
   } = req;
 
-  const data: Todos = body;
-  const filter: Partial<Todos> = {
+  const data: TypesTodos = body;
+  const filter: Partial<TypesTodos> = {
     user_id: userId,
   };
 


### PR DESCRIPTION
Reposition the Todo-related types into todos.types to improve maintainability and organization.