### PR TITLE
refactor: Abstract Prop types of Todos component

### DIFF
--- a/components/todos/todoList/todo/index.tsx
+++ b/components/todos/todoList/todo/index.tsx
@@ -10,11 +10,9 @@ import {
   ItemTodoModal,
   MinimizedModal,
 } from '@components/todos/todos.dynamicImports';
-import { TypesTodo } from '@components/todos/todos.types';
+import { PropsTodo } from '@components/todos/todos.types';
 
-type Props = Pick<TypesTodo, 'todo'> & Partial<Pick<TypesTodo, 'index'>>;
-
-export const Todo = ({ todo, index }: Props) => {
+export const Todo = ({ todo, index }: PropsTodo) => {
   const openModal = useTodoModalStateOpen(todo?._id);
 
   return (

--- a/components/todos/todoList/todo/todoItem/index.tsx
+++ b/components/todos/todoList/todo/todoItem/index.tsx
@@ -18,9 +18,7 @@ import { format } from 'date-fns';
 import { Fragment as CheckBoxFragment, Fragment as TodoItemFragment } from 'react';
 import { useRecoilValue } from 'recoil';
 
-type Props = Pick<TypesTodo, 'todo'>;
-
-export const TodoItem = ({ todo }: Props) => {
+export const TodoItem = ({ todo }: Pick<TypesTodo, 'todo'>) => {
   const openModal = useTodoModalStateOpen(todo._id);
   const completeTodo = useTodoCompleteItem(todo._id);
   const todoItem = useRecoilValue(selectorSessionTodoItem(todo._id));

--- a/components/todos/todoList/todo/todoItemFocuser/index.tsx
+++ b/components/todos/todoList/todo/todoItemFocuser/index.tsx
@@ -1,15 +1,12 @@
-import { TypesTodo } from '@components/todos/todos.types';
+import { PropsTodoItemFocuser } from '@components/todos/todos.types';
 import { KeysWithNavigationEffect } from '@effects/KeysWithNavigateEffect';
 import { useFocusOnClick } from '@hooks/focus';
 import { useKeyWithFocus } from '@hooks/keybindings';
 import { classNames } from '@stateLogics/utils';
-import { Types } from 'lib/types';
 import { Fragment as FocuserFragment, useRef } from 'react';
 import { isMobile } from 'react-device-detect';
 
-type Props = Pick<TypesTodo, 'todo' | 'index'> & Pick<Types, 'children'>;
-
-export const TodoItemFocuser = ({ todo, index, children }: Props) => {
+export const TodoItemFocuser = ({ todo, index, children }: PropsTodoItemFocuser) => {
   const divFocus = useRef<HTMLDivElement>(null);
   const focusKeyHandler = useKeyWithFocus(todo._id);
   const focusOnClick = useFocusOnClick(index);

--- a/components/todos/todos.types.ts
+++ b/components/todos/todos.types.ts
@@ -2,6 +2,7 @@ import { OBJECT_ID } from '@constAssertions/data';
 import { PRIORITY_LEVEL } from '@constAssertions/misc';
 import { Labels } from '@label/label.types';
 import { TypesMongoDB } from '@lib/types';
+import { ReactNode } from 'react';
 
 export interface TypesTodo {
   todoItem: TypesTodos;
@@ -32,3 +33,7 @@ export interface TypesTodos extends TypesTodosEditors, TypesTodoIds {
   title_id?: OBJECT_ID;
   user_id?: OBJECT_ID;
 }
+
+export type PropsTodo = Pick<TypesTodo, 'todo'> & Partial<Pick<TypesTodo, 'index'>>;
+
+export type PropsTodoItemFocuser = Pick<TypesTodo, 'todo' | 'index'> & { children: ReactNode };


### PR DESCRIPTION
Relocate the Todos related props type from the components into todos.types for better maintainability and reusability.