### PR TITLE
refactor: Relocate Todos-related states

### DIFF
--- a/components/editor/editor.hooks.ts
+++ b/components/editor/editor.hooks.ts
@@ -1,10 +1,10 @@
+import { atomTodoNew } from '@components/todos/todos.states';
 import { TypesTodos, TypesTodosEditors } from '@components/todos/todos.types';
 import { TypesEditor } from '@editor/editor.types';
 import { useTodoAdd, useTodoUpdateItem } from '@hooks/todos';
 import { CustomEditor } from '@lib/types/misc/slate';
 import { atomSelectorTodoItem } from '@states/atomEffects/todos';
 import { atomEditorDeserialize, atomEditorSerialize } from '@states/editors';
-import { atomTodoNew } from '@states/todos';
 import { isMobile } from 'react-device-detect';
 import { RecoilValue, useRecoilCallback } from 'recoil';
 import { Descendant, Transforms } from 'slate';

--- a/components/label/label.hooks.ts
+++ b/components/label/label.hooks.ts
@@ -1,3 +1,4 @@
+import { atomTodoNew } from '@components/todos/todos.states';
 import { TypesTodos } from '@components/todos/todos.types';
 import { CATCH } from '@constAssertions/misc';
 import { NOTIFICATION } from '@constAssertions/ui';
@@ -24,7 +25,6 @@ import { atomSelectorTodoItem } from '@states/atomEffects/todos';
 import { atomFilterSelected } from '@states/comboBoxes';
 import { atomCatch } from '@states/misc';
 import { atomConfirmModalDelete, atomLabelModalOpen } from '@states/modals';
-import { atomTodoNew } from '@states/todos';
 import ObjectID from 'bson-objectid';
 import { useSession } from 'next-auth/react';
 import { useEffect } from 'react';

--- a/components/label/label.states.ts
+++ b/components/label/label.states.ts
@@ -2,12 +2,12 @@ import { IDB_KEY, IDB_STORE } from '@constAssertions/storage';
 import { getDataLabels } from '@lib/queries/queryLabels';
 import { queryEffect } from '@lib/stateLogics/effects/atomEffects/queryEffects';
 import { atomComboBoxQuery, atomFilterSelected } from '@states/comboBoxes';
-import { atomTodoNew } from '@states/todos';
 import { atomUserSession } from '@user/user.states';
 import { atom, atomFamily, selector, selectorFamily } from 'recoil';
 import { Labels } from './label.types';
 import { DATA_DEMO_LABELS } from './label.data';
 import { TypesTodos } from '@components/todos/todos.types';
+import { atomTodoNew } from '@components/todos/todos.states';
 
 /**
  * Atom Queries

--- a/components/layout/app/layoutAppLazy/__test__/__mock__/mockStateEffect.tsx
+++ b/components/layout/app/layoutAppLazy/__test__/__mock__/mockStateEffect.tsx
@@ -1,3 +1,4 @@
+import { atomTodoNew } from '@components/todos/todos.states';
 import { TypesTodos } from '@components/todos/todos.types';
 import { BREAKPOINT } from '@constAssertions/ui';
 import { atomLayoutType, atomLayoutNavigationOpen } from '@layout/layout.states';
@@ -6,7 +7,6 @@ import { atomEffectMediaQuery } from '@states/atomEffects/misc';
 import { atomHtmlTitleTag } from '@states/misc';
 import { atomLabelModalOpen, atomTodoModalMini, atomTodoModalOpen } from '@states/modals';
 import { atomNotificationID, atomNotificationOpen } from '@states/notifications';
-import { atomTodoNew } from '@states/todos';
 import { useEffect } from 'react';
 import { RecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 

--- a/components/layout/app/todosCount/index.tsx
+++ b/components/layout/app/todosCount/index.tsx
@@ -1,5 +1,5 @@
+import { selectorTodosCount } from '@components/todos/todos.states';
 import { PropsTodosCount } from '@layout/layout.types';
-import { selectorTodosCount } from '@states/todos';
 import { Fragment } from 'react';
 import { useRecoilValue } from 'recoil';
 

--- a/components/todos/todoList/index.tsx
+++ b/components/todos/todoList/index.tsx
@@ -2,12 +2,12 @@ import { DATA_PATHNAME_IMAGE } from '@collections/pathnameImage';
 import { TypesPathnameImage } from '@lib/types';
 import { cloudflareLoader } from '@stateLogics/utils';
 import { atomPathnameImage } from '@states/misc';
-import { selectorFilterTodoIds } from '@states/todos';
 import { SmoothTransition } from '@ui/transitions/smoothTransition';
 import Image from 'next/image';
 import { Fragment as TodosFragment } from 'react';
 import { useRecoilValue } from 'recoil';
 import { Todo } from './todo';
+import { selectorFilterTodoIds } from '../todos.states';
 
 export const TodoList = () => {
   const todoIds = useRecoilValue(selectorFilterTodoIds);

--- a/components/todos/todos.states.ts
+++ b/components/todos/todos.states.ts
@@ -3,11 +3,11 @@ import { selectorFilterPriorityRankScore } from '@states/priorities';
 import { atom, selector, selectorFamily } from 'recoil';
 import { PATH_APP, OBJECT_ID } from '@constAssertions/data';
 import { PRIORITY_LEVEL } from '@constAssertions/misc';
-import { atomSelectorTodoItem, selectorSessionTodoIds } from './atomEffects/todos';
-import { atomFilterEffect } from './misc';
 import { atomLabelQuerySlug, selectorSessionLabels } from '@label/label.states';
 import { Labels } from '@label/label.types';
 import { TypesTodoIds, TypesTodos } from '@components/todos/todos.types';
+import { atomSelectorTodoItem, selectorSessionTodoIds } from '@states/atomEffects/todos';
+import { atomFilterEffect } from '@states/misc';
 
 /**
  * atoms

--- a/components/ui/buttons/iconButton/priorityButton.tsx
+++ b/components/ui/buttons/iconButton/priorityButton.tsx
@@ -1,4 +1,5 @@
 import { IconButton } from '@buttons/iconButton';
+import { atomTodoNew } from '@components/todos/todos.states';
 import { TypesTodo } from '@components/todos/todos.types';
 import { PRIORITY_LEVEL } from '@constAssertions/misc';
 import {
@@ -12,7 +13,6 @@ import { Types } from '@lib/types';
 import { TypesOptionsPriority } from '@lib/types/options';
 import { classNames } from '@stateLogics/utils';
 import { atomSelectorTodoItem, selectorSessionTodoItem } from '@states/atomEffects/todos';
-import { atomTodoNew } from '@states/todos';
 import { Fragment, Fragment as TodoPriorityFragment } from 'react';
 import { useRecoilCallback, useRecoilValue } from 'recoil';
 

--- a/components/ui/dropdowns/v1/calendarDropdown.tsx
+++ b/components/ui/dropdowns/v1/calendarDropdown.tsx
@@ -2,7 +2,6 @@ import { Button } from '@buttons/button';
 import { IconButton } from '@buttons/iconButton';
 import { ICON_EVENT_AVAILABLE, ICON_EVENT_AVAILABLE_FILL } from '@data/materialSymbols';
 import { Menu } from '@headlessui/react';
-import { atomTodoNew } from '@states/todos';
 import { format } from 'date-fns';
 import { Types } from 'lib/types';
 import { Fragment, Fragment as HeaderContentsFragment } from 'react';
@@ -20,6 +19,7 @@ import { classNames } from '@stateLogics/utils';
 import { TypesOptionsDropdown } from '@lib/types/options';
 import { SvgIcon } from '@icon/svgIcon';
 import { TypesTodo } from '@components/todos/todos.types';
+import { atomTodoNew } from '@components/todos/todos.states';
 
 type Props = { options: TypesOptionsDropdown } & Partial<Pick<TypesTodo, 'todo'>> &
   Pick<Types, 'onClickConfirm'>;

--- a/components/ui/dropdowns/v1/labelComboBoxDropdown.tsx
+++ b/components/ui/dropdowns/v1/labelComboBoxDropdown.tsx
@@ -12,13 +12,13 @@ import { optionsButtonLabelRemove } from '@options/button';
 import { optionsDropdownComboBox } from '@options/misc';
 import { useTodoModalStateClose } from '@hooks/modals';
 import { selectorSessionTodoItem } from '@states/atomEffects/todos';
-import { atomTodoNew } from '@states/todos';
 import { classNames, paths } from '@stateLogics/utils';
 import { selectorSelectedLabels } from '@label/label.states';
 import { TypesLabel } from '@label/label.types';
 import { useLabelRemoveItemTitleId } from '@label/label.hooks';
 import { TypesTodo } from '@components/todos/todos.types';
 import { Types } from '@lib/types';
+import { atomTodoNew } from '@components/todos/todos.states';
 
 type Props = Partial<
   Pick<TypesTodo, 'todo'> & Pick<Types, 'container'> & Pick<TypesLabel, 'selectedQueryLabels'>

--- a/components/ui/modals/minimizedModal.tsx
+++ b/components/ui/modals/minimizedModal.tsx
@@ -4,7 +4,6 @@ import {
   IconButton as OpenFullIconButton,
 } from '@buttons/iconButton';
 import { atomTodoModalMini } from '@states/modals';
-import { atomTodoNew } from '@states/todos';
 import { Fragment } from 'react';
 import { useRecoilValue } from 'recoil';
 import { MinimizeModalTransition } from './modal/modalTransition/minimizeModalTransition';
@@ -23,6 +22,7 @@ import {
 } from '@hooks/modals';
 import { atomEffectMediaQuery } from '@states/atomEffects/misc';
 import { TypesTodo } from '@components/todos/todos.types';
+import { atomTodoNew } from '@components/todos/todos.states';
 
 type Props = Partial<Pick<TypesTodo, 'todo'>>;
 

--- a/lib/stateLogics/hooks/calendar.tsx
+++ b/lib/stateLogics/hooks/calendar.tsx
@@ -1,5 +1,4 @@
 import { updateDataCalendarTodo } from '@lib/queries/queryTodos';
-import { atomTodoNew } from '@states/todos';
 import {
   parse,
   eachDayOfInterval,
@@ -23,6 +22,7 @@ import { useNotificationState } from './notifications';
 import { usePriorityRankScore } from './priorities';
 import { atomCurrentMonth, atomDayPickerUpdater, atomDayPicker } from '@states/calendars';
 import { TypesTodos } from '@components/todos/todos.types';
+import { atomTodoNew } from '@components/todos/todos.states';
 
 /**
  * Hooks

--- a/lib/stateLogics/hooks/misc.tsx
+++ b/lib/stateLogics/hooks/misc.tsx
@@ -1,10 +1,10 @@
+import { selectorFilterTodoIdsByPathname, atomTodoNew } from '@components/todos/todos.states';
 import { TypesTodos } from '@components/todos/todos.types';
 import { PATH_APP } from '@constAssertions/data';
 import { atomLabelNew, atomSelectorLabelItem, selectorSessionLabels } from '@label/label.states';
 import { Labels } from '@label/label.types';
 import { atomSelectorTodoItem, selectorSessionTodoItem } from '@states/atomEffects/todos';
 import { atomTodoModalMini, atomTodoModalOpen } from '@states/modals';
-import { atomTodoNew, selectorFilterTodoIdsByPathname } from '@states/todos';
 import equal from 'fast-deep-equal/react';
 import { useRouter } from 'next/router';
 import { useMemo } from 'react';

--- a/lib/stateLogics/hooks/modals.tsx
+++ b/lib/stateLogics/hooks/modals.tsx
@@ -1,4 +1,3 @@
-import { atomTodoNew } from '@states/todos';
 import ObjectID from 'bson-objectid';
 import { RecoilValue, useRecoilCallback, useResetRecoilState } from 'recoil';
 import { CATCH } from '@constAssertions/misc';
@@ -19,6 +18,7 @@ import { atomLabelNew, atomSelectorLabelItem, atomSelectorLabels } from '@label/
 import { Labels } from '@label/label.types';
 import { useLabelRemoveItem } from '@label/label.hooks';
 import { TypesTodos } from '@components/todos/todos.types';
+import { atomTodoNew } from '@components/todos/todos.states';
 
 /**
  * Hooks

--- a/lib/stateLogics/hooks/priorities.tsx
+++ b/lib/stateLogics/hooks/priorities.tsx
@@ -1,5 +1,4 @@
 import { updateDataPriorityTodo } from '@lib/queries/queryTodos';
-import { atomTodoNew } from '@states/todos';
 import { useSession } from 'next-auth/react';
 import { RecoilValue, useRecoilCallback } from 'recoil';
 import { PRIORITY_LEVEL } from '@constAssertions/misc';
@@ -10,6 +9,7 @@ import {
 } from '@states/atomEffects/todos';
 import { atomPriority, selectorPriorityRankScore } from '@states/priorities';
 import { TypesTodos } from '@components/todos/todos.types';
+import { atomTodoNew } from '@components/todos/todos.states';
 
 /**
  * Hooks

--- a/lib/stateLogics/hooks/todos.tsx
+++ b/lib/stateLogics/hooks/todos.tsx
@@ -12,7 +12,6 @@ import {
   selectorSessionTodoIds,
   atomSelectorTodoItem,
 } from '@states/atomEffects/todos';
-import { atomTodoNew } from '@states/todos';
 import {
   useConditionCheckTodoTitleEmpty,
   useGetWithRecoilCallback,
@@ -22,6 +21,7 @@ import { atomEffectNetworkStatus } from '@states/atomEffects/misc';
 import { atomCatch } from '@states/misc';
 import { selectorSessionLabels, atomSelectorLabels } from '@label/label.states';
 import { TypesTodos } from '@components/todos/todos.types';
+import { atomTodoNew } from '@components/todos/todos.states';
 
 /**
  * Hooks

--- a/lib/stateLogics/states/priorities.tsx
+++ b/lib/stateLogics/states/priorities.tsx
@@ -1,9 +1,9 @@
 import { PRIORITY_LEVEL } from '@constAssertions/misc';
-import { selectorDynamicTodoItem } from '@states/todos';
 import { subDays, differenceInDays } from 'date-fns';
 import { atomFamily, selectorFamily, selector } from 'recoil';
 import { selectorSessionTodoIds } from './atomEffects/todos';
 import { TypesTodos } from '@components/todos/todos.types';
+import { selectorDynamicTodoItem } from '@components/todos/todos.states';
 
 /**
  * atoms


### PR DESCRIPTION
Transitioned states pertinent to Todos into todos.states to enhance maintainability. Colocation structure now followed more closely.