### PR TITLE
chore: Install Jotai for Recoil substitution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "date-fns": "^2.30.0",
         "fast-deep-equal": "^3.1.3",
         "idb": "^7.1.1",
+        "jotai": "^2.2.2",
         "mongoose": "^7.3.4",
         "next": "^13.4.9",
         "next-auth": "^4.22.1",
@@ -6637,6 +6638,22 @@
       "integrity": "sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/jotai": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.2.2.tgz",
+      "integrity": "sha512-Cn8hnBg1sc5ppFwEgVGTfMR5WSM0hbAasd/bdAwIwTaum0j3OUPqBSC4tyk3jtB95vicML+RRWgKFOn6gtfN0A==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "date-fns": "^2.30.0",
     "fast-deep-equal": "^3.1.3",
     "idb": "^7.1.1",
+    "jotai": "^2.2.2",
     "mongoose": "^7.3.4",
     "next": "^13.4.9",
     "next-auth": "^4.22.1",


### PR DESCRIPTION
Installed Jotai library to substitute Recoil, initiating migration to Next.js' appRouter.