### PR TITLE
chore: Update the cleanup-cache workflow

### DIFF
--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -2,7 +2,7 @@ name: Cleanup Caches
 
 on:
   schedule:
-    - cron: '0 0 */5 * *' # every 5 days at midnight (UTC)
+    - cron: '0 0 */2 * *' # every 2 days at midnight (UTC)
 
 jobs:
   cleanup:


### PR DESCRIPTION
Now Github Actions will run to cleanup cache every 2 days instead of 5 days.