### PR TITLE
feat: Add SmoothTransition component to appRouter

### DIFF
--- a/app/components/transition/smoothTransition/__test__/smoothTransition.test.tsx
+++ b/app/components/transition/smoothTransition/__test__/smoothTransition.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import { SmoothTransition } from '..';
+import { ReactNode } from 'react';
+
+jest.mock('..', () => ({
+  SmoothTransition: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+describe('SmoothTransition', () => {
+  const renderWithSmoothTransition = (children: ReactNode) => {
+    return render(<SmoothTransition>{children}</SmoothTransition>);
+  };
+
+  it('should render the children props', () => {
+    renderWithSmoothTransition(<div>test</div>);
+    const testText = screen.getByText('test');
+    expect(testText).toBeInTheDocument();
+  });
+});

--- a/app/components/transition/smoothTransition/index.tsx
+++ b/app/components/transition/smoothTransition/index.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { DURATION } from '@constAssertions/ui';
+import { Transition } from '@headlessui/react';
+import { useVerticalScrollPositionTrigger } from '@hooks/ui';
+import { classNames } from '@stateLogics/utils';
+import { DATA_SMOOTH_TRANSITION } from './smoothTransition.data';
+import { TypesDataTransition, PropsSmoothTransition } from './smoothTransition.types';
+import { useEffect, useState } from 'react';
+
+export const SmoothTransition = ({ children, scrollRef, options }: PropsSmoothTransition) => {
+  const [hasShown, setHasShown] = useState(false);
+  const {
+    appear = true,
+    enterDuration = DURATION['500'],
+    leaveDuration = DURATION['500'],
+    type = 'fadeIn',
+    delay,
+  } = options || {};
+  const data = DATA_SMOOTH_TRANSITION.find((data) => data.type === type) || ({} as TypesDataTransition);
+  const triggerRate = !!scrollRef ? options?.rate : undefined;
+  const isTriggered = useVerticalScrollPositionTrigger(scrollRef, triggerRate);
+  const isShowing = !!scrollRef ? isTriggered : hasShown;
+
+  useEffect(() => {
+    !!scrollRef ? false : setHasShown(true);
+  }, [hasShown, scrollRef]);
+
+  return (
+    <Transition
+      appear={appear}
+      show={isShowing}
+      enter={classNames(data.enter, enterDuration, delay)}
+      enterFrom={classNames(data.enterFrom)}
+      enterTo={classNames(data.enterTo)}
+      leave={classNames(data.leave, leaveDuration, delay)}
+      leaveFrom={classNames(data.leaveFrom)}
+      leaveTo={classNames(data.leaveTo)}
+    >
+      {children}
+    </Transition>
+  );
+};

--- a/app/components/transition/smoothTransition/smoothTransition.data.ts
+++ b/app/components/transition/smoothTransition/smoothTransition.data.ts
@@ -1,0 +1,58 @@
+import { TypesDataTransition } from './smoothTransition.types';
+
+export const DATA_SMOOTH_TRANSITION: TypesDataTransition[] = [
+  {
+    type: 'fadeIn',
+    enter: 'transition-opacity ease-in-out',
+    enterFrom: 'opacity-0',
+    enterTo: 'opacity-100',
+    leave: 'transition-opacity ease-in-out',
+    leaveFrom: 'opacity-100',
+    leaveTo: 'opacity-0',
+  },
+  {
+    type: 'scaleY',
+    enter: 'transition transform-gpu ease-in-out origin-top',
+    enterFrom: 'scale-y-[0] opacity-0',
+    enterTo: 'scale-y-[1] opacity-100',
+    leave: 'transition ease-in-out origin-bottom',
+    leaveFrom: 'scale-y-[1] opacity-100',
+    leaveTo: 'scale-y-[0] opacity-0',
+  },
+  {
+    type: 'scaleX',
+    enter: 'transition transform-gpu ease-in-out origin-left',
+    enterFrom: 'scale-x-[0] opacity-0',
+    enterTo: 'scale-x-[1] opacity-100',
+    leave: 'transition ease-in-out origin-right',
+    leaveFrom: 'scale-x-[1] opacity-100',
+    leaveTo: 'scale-X-[0] opacity-0',
+  },
+  {
+    type: 'scaleCenterFull',
+    enter: 'transition transform-gpu ease-in-out',
+    enterFrom: 'scale-[0] opacity-0',
+    enterTo: 'scale-[1] opacity-100',
+    leave: 'transition ease-in-out',
+    leaveFrom: 'scale-[1] opacity-100',
+    leaveTo: 'scale-[0] opacity-0',
+  },
+  {
+    type: 'scaleCenterSm',
+    enter: 'transition transform-gpu ease-in-out',
+    enterFrom: 'scale-[0.9] opacity-0',
+    enterTo: 'scale-[1] opacity-100',
+    leave: 'transition ease-in-out',
+    leaveFrom: 'scale-[0.9] opacity-100',
+    leaveTo: 'scale-[0] opacity-0',
+  },
+  {
+    type: 'translateDown',
+    enter: 'transition ease-in-out transform-gpu',
+    enterFrom: 'opacity-0 -translate-y-5',
+    enterTo: 'opacity-100 translate-y-0',
+    leave: 'transition ease-in-out transform-gpu',
+    leaveFrom: 'opacity-100 translate-y-0',
+    leaveTo: 'opacity-0 -translate-y-5',
+  },
+];

--- a/app/components/transition/smoothTransition/smoothTransition.types.ts
+++ b/app/components/transition/smoothTransition/smoothTransition.types.ts
@@ -1,0 +1,25 @@
+import { ReactNode, RefObject } from 'react';
+import {
+  TypesTransitionShow,
+  TypesTransitionDuration,
+  TypesTransitionTypes,
+  TypesTransitionProperties,
+  TypesTransitionDelay,
+} from '../transition.types';
+
+export type PropsSmoothTransition = {
+  children: ReactNode;
+  options?: Partial<
+    Record<TypesTransitionShow, boolean> & {
+      enterDuration: TypesTransitionDuration;
+      leaveDuration: TypesTransitionDuration;
+      rate: number;
+      type: TypesTransitionTypes;
+      delay: TypesTransitionDelay;
+    }
+  >;
+} & Partial<{ scrollRef: RefObject<HTMLElement> }>;
+
+export type TypesDataTransition = Record<TypesTransitionProperties, string> & {
+  type: TypesTransitionTypes;
+};

--- a/app/components/transition/transition.types.ts
+++ b/app/components/transition/transition.types.ts
@@ -1,0 +1,32 @@
+export type TypesTransitionTypes =
+  | 'fadeIn'
+  | 'scaleX'
+  | 'scaleY'
+  | 'scaleCenterFull'
+  | 'scaleCenterSm'
+  | 'translateDown'
+  | 'translateUp';
+
+export type TypesTransitionShow = 'show' | 'appear';
+
+export type TypesTransitionProperties = 'enter' | 'enterFrom' | 'enterTo' | 'leave' | 'leaveFrom' | 'leaveTo';
+
+export type TypesTransitionDuration =
+  | 'duration-75'
+  | 'duration-100'
+  | 'duration-150'
+  | 'duration-200'
+  | 'duration-300'
+  | 'duration-500'
+  | 'duration-700'
+  | 'duration-1000';
+
+export type TypesTransitionDelay =
+  | 'delay-75'
+  | 'delay-100'
+  | 'delay-150'
+  | 'delay-200'
+  | 'delay-300'
+  | 'delay-500'
+  | 'delay-700'
+  | 'delay-1000';

--- a/jest.config.js
+++ b/jest.config.js
@@ -20,6 +20,11 @@ const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'], // remove if jest.setup.js is deleted
   testEnvironment: 'jest-environment-jsdom',
   moduleNameMapper: {
+    //app router
+    '^@/transition/(.*)$': ['<rootDir>/app/components/transition/$1'],
+    '^@/components/(.*)$': ['<rootDir>/app/components/$1'],
+    '^@/(.*)$': ['<rootDir>/app/$1'],
+    //page router
     '^@collections/(.*)$': ['<rootDir>/lib/data/collections/$1'],
     '^@constAssertions/(.*)$': ['<rootDir>/lib/data/constAssertions/$1'],
     '^@options/(.*)$': ['<rootDir>/lib/data/options/$1'],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,11 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
+      //app Router
+      "@/transition/*": ["app/components/transition/*"],
+      "@/components/*": ["app/components/*"],
+      "@/*": ["app/*"],
+      //page Router
       "@collections/*": ["lib/data/collections/*"],
       "@constAssertions/*": ["lib/data/constAssertions/*"],
       "@options/*": ["lib/data/options/*"],


### PR DESCRIPTION
Transition initiation is now facilitated via the inclusion of SmoothTransition in appRouter using the 'use client' directive. While relocating the component, types have been simplified for improved maintainability.

A corresponding unit test is provided, employing a mock of SmoothTransition. Note that the actual transition behavior is not covered, as it falls under the scope of end-to-end, not unit, testing.