### PR TITLE
feat: Implement Tooltip in appRouter

### DIFF
--- a/app/components/tooltip/__test__/tooltip.test.tsx
+++ b/app/components/tooltip/__test__/tooltip.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+import { Tooltip } from '..';
+import { ReactNode } from 'react';
+import { screen } from '@testing-library/react';
+
+jest.mock('..', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+describe('Tooltip', () => {
+  const renderWithTooltip = (children: ReactNode) => render(<Tooltip>{children}</Tooltip>);
+
+  it('should render the child element', () => {
+    const { container } = renderWithTooltip(<div>Test</div>);
+    const testText = screen.getByText('Test');
+
+    expect(container).toBeInTheDocument();
+    expect(testText).toBeInTheDocument();
+  });
+});

--- a/app/components/tooltip/index.tsx
+++ b/app/components/tooltip/index.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { Portal } from '@headlessui/react';
+import { classNames } from '@stateLogics/utils';
+import { memo } from 'react';
+import { isMobile } from 'react-device-detect';
+import { usePopperTooltip } from 'react-popper-tooltip';
+import { PropsTooltip } from './tooltip.types';
+
+export const Tooltip = memo(({ options = {}, children }: PropsTooltip) => {
+  const { getTooltipProps, setTooltipRef, setTriggerRef, visible } = usePopperTooltip({
+    trigger: options.trigger ?? 'hover',
+    delayShow: options.delayShow ?? 50,
+    offset: options.offset ?? [0, 25],
+    placement: options.placement ?? 'bottom',
+    visible: options.isVisible,
+    closeOnTriggerHidden: options.isCloseOnTriggerHidden,
+    delayHide: 50,
+    interactive: false,
+  });
+
+  return (
+    <>
+      <span
+        className={classNames(options.container)}
+        ref={setTriggerRef}
+      >
+        {children}
+      </span>
+      {visible && (
+        <>
+          {!isMobile && (
+            <Portal>
+              <div
+                ref={setTooltipRef}
+                {...getTooltipProps()}
+                className={classNames(
+                  options.tooltip &&
+                    'z-50 max-w-[15rem] truncate whitespace-nowrap rounded-lg bg-gray-700 p-2 text-xs text-white opacity-90',
+                )}
+              >
+                <span>{options.tooltip}</span>
+                <kbd
+                  className={classNames(
+                    options.kbd &&
+                      'ml-2 h-6 rounded border-x border-y py-px px-1.5 font-sans tracking-normal subpixel-antialiased',
+                  )}
+                >
+                  {options.kbd}
+                </kbd>
+              </div>
+            </Portal>
+          )}
+        </>
+      )}
+    </>
+  );
+});
+
+Tooltip.displayName = 'Tooltip';

--- a/app/components/tooltip/tooltip.types.ts
+++ b/app/components/tooltip/tooltip.types.ts
@@ -1,0 +1,19 @@
+import { ReactElement, ReactNode } from 'react';
+import { TriggerType } from 'react-popper-tooltip';
+import { Placement } from '@popperjs/core';
+
+export interface TypesTooltipAttributes {
+  tooltip: string | ReactElement | null;
+  kbd: string;
+  delayShow: number;
+  trigger: TriggerType | TriggerType[] | null;
+  offset: [number, number];
+  placement: Placement;
+  isVisible: boolean;
+  isCloseOnTriggerHidden: boolean;
+  container: string;
+}
+
+export type PropsTooltip = { options?: Partial<TypesTooltipAttributes> } & {
+  children: ReactNode;
+};


### PR DESCRIPTION
Tooltip implementation now resides in appRouter via the 'use client' directive. Given Tooltip's inherent requirement for client-side interaction, designation as a client component supersedes server component status.

A supplementary unit test is incorporated, validating child element rendering.