### PR TITLE
feat: Add the Button appRouter components

### DIFF
--- a/app/components/ui/button/__test__/button.test.tsx
+++ b/app/components/ui/button/__test__/button.test.tsx
@@ -1,0 +1,26 @@
+import { fireEvent, render } from '@testing-library/react';
+import { Button } from '..';
+import { screen } from '@testing-library/react';
+
+const mockOnClick = jest.fn();
+
+describe('Button', () => {
+  const renderWithButton = () => render(<Button onClick={mockOnClick}>Test button</Button>);
+
+  it('should render the child element', () => {
+    const { container } = renderWithButton();
+    const renderChildElement = screen.getByText('Test button');
+
+    expect(container).toBeInTheDocument();
+    expect(renderChildElement).toBeInTheDocument();
+  });
+
+  it('should call the mockOnClick function onClick', () => {
+    renderWithButton();
+    const renderButtonElement = screen.getByText('Test button');
+
+    fireEvent.click(renderButtonElement);
+
+    expect(mockOnClick).toHaveBeenCalled();
+  });
+});

--- a/app/components/ui/button/button.types.ts
+++ b/app/components/ui/button/button.types.ts
@@ -5,18 +5,22 @@ import { ReactNode } from 'react';
 export interface TypesButtons {
   isDisabled: boolean;
   name: string;
-  type: 'button' | 'submit' | 'reset';
+  type: 'button' | 'submit';
 }
 
-export type PropsButton = Partial<
+type TypesOptionsButton = TypesButtons & TypesClassNames & TypesAttributes;
+
+type TypesOptionsButtonWithTooltip = TypesOptionsButton &
+  Pick<TypesTooltips, 'tooltip' | 'kbd' | 'offset' | 'placement'>;
+
+type TypesButtonBase<T> = Partial<
   {
-    options: Partial<
-      TypesButtons &
-        TypesClassNames &
-        TypesAttributes &
-        Pick<TypesTooltips, 'tooltip' | 'kbd' | 'offset' | 'placement'>
-    >;
+    options: Partial<T>;
   } & TypesEvents & {
       children: ReactNode;
     }
 >;
+
+export type PropsButton = TypesButtonBase<TypesOptionsButton>;
+
+export type PropsButtonWithTooltip = TypesButtonBase<TypesOptionsButtonWithTooltip>;

--- a/app/components/ui/button/buttonWithTooltip/__test__/buttonWithTooltip.test.tsx
+++ b/app/components/ui/button/buttonWithTooltip/__test__/buttonWithTooltip.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render } from '@testing-library/react';
+import { ButtonWithTooltip } from '..';
+import { screen } from '@testing-library/react';
+
+const mockOnClick = jest.fn();
+const mockButtonElement = 'Test button element';
+
+describe('ButtonWithTooltip', () => {
+  const renderWithButtonWithTooltip = () =>
+    render(<ButtonWithTooltip onClick={mockOnClick}>{mockButtonElement}</ButtonWithTooltip>);
+
+  it('should render button element and tooltip element', () => {
+    const { container } = renderWithButtonWithTooltip();
+    const buttonElement = screen.getByText(mockButtonElement);
+
+    expect(container).toBeInTheDocument();
+    expect(buttonElement).toBeInTheDocument();
+  });
+
+  it('should call function when button is clicked', () => {
+    renderWithButtonWithTooltip();
+
+    const buttonElement = screen.getByText(mockButtonElement);
+
+    fireEvent.click(buttonElement);
+
+    expect(mockOnClick).toHaveBeenCalled();
+  });
+});

--- a/app/components/ui/button/buttonWithTooltip/index.tsx
+++ b/app/components/ui/button/buttonWithTooltip/index.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { forwardRef, useState } from 'react';
+import { PropsButtonWithTooltip } from '../button.types';
+import { Button } from '..';
+import { Tooltip } from '@tooltips/tooltips';
+
+export const ButtonWithTooltip = forwardRef<HTMLButtonElement, PropsButtonWithTooltip>(
+  ({ options = {}, onClick, onKeyDown, onDoubleClick, children }: PropsButtonWithTooltip, ref) => {
+    const [hasTooltip, setTooltip] = useState(false);
+    const { ariaLabel, type, className, isDisabled, container, placement, offset, tooltip, kbd } = options;
+    const optionsButton = { ariaLabel, type, className, isDisabled };
+    const optionsTooltip = {
+      tooltip: (hasTooltip || isDisabled) && !tooltip ? undefined : tooltip,
+      kbd: (hasTooltip || isDisabled) && !kbd ? undefined : kbd,
+      container,
+      placement,
+      offset,
+    };
+
+    return (
+      <Tooltip options={optionsTooltip}>
+        <Button
+          options={optionsButton}
+          onMouseDown={() => !isDisabled && setTooltip(true)}
+          onMouseEnter={() => !isDisabled && setTooltip(false)}
+          onMouseLeave={() => !isDisabled && setTooltip(true)}
+          onClick={onClick}
+          onKeyDown={onKeyDown}
+          onDoubleClick={onDoubleClick}
+          ref={ref}
+        >
+          {children}
+        </Button>
+      </Tooltip>
+    );
+  },
+);
+ButtonWithTooltip.displayName = 'ButtonWithTooltip';


### PR DESCRIPTION
Add the Button and ButtonWithTooltip components. These components are client components with the `use client` directive. Additionally simple unit tests are added for each component.