### PR TITLE
fix: Resolve console error in test environment

### DIFF
--- a/app/components/ui/button/buttonWithTooltip/__test__/buttonWithTooltip.test.tsx
+++ b/app/components/ui/button/buttonWithTooltip/__test__/buttonWithTooltip.test.tsx
@@ -35,9 +35,9 @@ describe('ButtonWithTooltip', () => {
     expect(mockOnClick).toHaveBeenCalled();
   });
 
-  it('should render the tooltip text', () => {
+  it('should render the tooltip text', async () => {
     renderWithButtonWithTooltip({ options: { isVisible: true, tooltip: 'button-tooltip-test' } });
-    const tooltipText = screen.getByText('button-tooltip-test');
+    const tooltipText = await screen.findByText('button-tooltip-test');
 
     expect(tooltipText).toBeInTheDocument();
   });

--- a/app/components/ui/button/signInButton/__test__/signInButton.test.tsx
+++ b/app/components/ui/button/signInButton/__test__/signInButton.test.tsx
@@ -18,7 +18,7 @@ describe('SignInButton', () => {
   it('should render the signInButtonName props', async () => {
     renderWithSignInButton({ options: { isVisible: true, signInButtonName: 'Get started' } });
     const signInText = screen.getByText('Get started');
-    const tooltipText = screen.queryByText('Sign in');
+    const tooltipText = await screen.findByText('Sign in');
 
     expect(signInText).toBeInTheDocument();
     expect(tooltipText).toBeInTheDocument();

--- a/app/components/ui/tooltip/__test__/tooltip.test.tsx
+++ b/app/components/ui/tooltip/__test__/tooltip.test.tsx
@@ -7,13 +7,13 @@ describe('Tooltip', () => {
   const renderWithTooltip = ({ options, children }: PropsTooltip) =>
     render(<Tooltip options={options}>{children}</Tooltip>);
 
-  it('should render the children props and tooltip text', () => {
+  it('should render the children props and tooltip text', async () => {
     const { container } = renderWithTooltip({
       options: { isVisible: true, tooltip: 'tooltip' },
       children: <div>Tooltip-test</div>,
     });
     const childrenElement = screen.getByText('Tooltip-test');
-    const tooltipText = screen.getByText('tooltip');
+    const tooltipText = await screen.findByText('tooltip');
 
     expect(container).toBeInTheDocument();
     expect(childrenElement).toBeInTheDocument();


### PR DESCRIPTION
Eliminate console error triggered by state update warning in the test environment. This anomaly stems from non-asynchronous state updates in testing. Employing `findByText` as a replacement for `getByText` mitigates the complications.