### PR TITLE
feat: Add SmoothTransitionWithDivRef component

### DIFF
--- a/app/components/ui/container/container.states.ts
+++ b/app/components/ui/container/container.states.ts
@@ -1,3 +1,4 @@
 import { atom } from 'jotai';
+import { RefObject } from 'react';
 
-export const atomDivRef = atom<HTMLDivElement | null>(null);
+export const atomDivRef = atom<RefObject<HTMLDivElement> | null>(null);

--- a/app/components/ui/container/divContainerWithRef/index.tsx
+++ b/app/components/ui/container/divContainerWithRef/index.tsx
@@ -10,7 +10,7 @@ export const DivContainerWithRef = ({ children, className }: PropsDivContainer) 
   const setDivRef = useSetAtom(atomDivRef);
 
   useEffect(() => {
-    setDivRef(divRef.current);
+    setDivRef(divRef);
   }, [setDivRef]);
 
   return (

--- a/app/components/ui/transition/smoothTransition/smoothTransition.types.ts
+++ b/app/components/ui/transition/smoothTransition/smoothTransition.types.ts
@@ -18,7 +18,9 @@ export type PropsSmoothTransition = {
       delay: TypesTransitionDelay;
     }
   >;
-} & Partial<{ scrollRef: RefObject<HTMLElement> }>;
+} & Partial<{ scrollRef: RefObject<HTMLElement> | null }>;
+
+export type PropsSmoothTransitionWithDivRef = Omit<PropsSmoothTransition, 'scrollRef'>;
 
 export type TypesDataTransition = Record<TypesTransitionProperties, string> & {
   type: TypesTransitionTypes;

--- a/app/components/ui/transition/smoothTransitionWithDivRef/__test__/smoothTransitionWithDivRef.test.tsx
+++ b/app/components/ui/transition/smoothTransitionWithDivRef/__test__/smoothTransitionWithDivRef.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import { SmoothTransitionWithDivRef } from '..';
+import { ReactNode } from 'react';
+
+describe('SmoothTransitionWithDivRef', () => {
+  const renderWithSmoothTransitionWithDivRef = (children: ReactNode) =>
+    render(<SmoothTransitionWithDivRef>{children}</SmoothTransitionWithDivRef>);
+
+  it('should render the child elements', () => {
+    const { container } = renderWithSmoothTransitionWithDivRef(<div>smoothTransition-test</div>);
+    const childElement = screen.getByText('smoothTransition-test');
+
+    expect(container).toBeInTheDocument();
+    expect(childElement).toBeInTheDocument();
+  });
+});

--- a/app/components/ui/transition/smoothTransitionWithDivRef/index.tsx
+++ b/app/components/ui/transition/smoothTransitionWithDivRef/index.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useAtomValue } from 'jotai';
+import { atomDivRef } from '@/container/container.states';
+import { SmoothTransition } from '../smoothTransition';
+import { PropsSmoothTransitionWithDivRef } from '../smoothTransition/smoothTransition.types';
+
+export const SmoothTransitionWithDivRef = ({ children, options }: PropsSmoothTransitionWithDivRef) => {
+  const divRef = useAtomValue(atomDivRef);
+
+  return (
+    <SmoothTransition
+      options={options}
+      scrollRef={divRef}
+    >
+      {children}
+    </SmoothTransition>
+  );
+};

--- a/app/components/ui/transition/transition.hooks.ts
+++ b/app/components/ui/transition/transition.hooks.ts
@@ -1,7 +1,7 @@
 import { RefObject, useState, useCallback, useEffect } from 'react';
 
 export const useVerticalScrollPositionTrigger = (
-  scrollRef?: RefObject<HTMLElement>,
+  scrollRef?: RefObject<HTMLElement> | null,
   triggerRate?: number,
 ) => {
   const [isShowing, setIsShowing] = useState(false);


### PR DESCRIPTION
Incorporated SmoothTransitionWithDivRef, a wrapper for the SmoothTransition component. Its role involves accepting divRef value via Jotai's atom. Accompanying unit tests have been included as well.

Moreover, relevant type definitions have been included in transition.types.