### PR TITLE
feat: Implement SectionHero in appRouter

### DIFF
--- a/__mock__/next/index.ts
+++ b/__mock__/next/index.ts
@@ -4,7 +4,7 @@ interface Props {
   quality?: number;
 }
 
-export const mockedImageUrl = ({ src, width, quality }: Props) => {
+export const mockImageUrl = ({ src, width, quality }: Props) => {
   if (!src) return;
   return `/_next/image?url=${encodeURIComponent(src)}&w=${width}&q=${quality ?? 75}`;
 };

--- a/app/components/section/section.consts.ts
+++ b/app/components/section/section.consts.ts
@@ -1,0 +1,6 @@
+export const sectionHeroContents = {
+  title: 'Simplify your life',
+  subTitle: 'Automate your tasks',
+  content:
+    'Focus on your work more and manage your to-dos less. Enhance your efficiency and improve your productivity.',
+};

--- a/app/components/section/sectionHero/__test__/sectionHero.test.tsx
+++ b/app/components/section/sectionHero/__test__/sectionHero.test.tsx
@@ -1,0 +1,47 @@
+import { sectionHeroContents } from '@/section/section.consts';
+import { render, screen } from '@testing-library/react';
+import { SectionHero } from '..';
+import { ReactNode } from 'react';
+
+jest.mock('@/transition/smoothTransitionWithDivRef', () => ({
+  SmoothTransitionWithDivRef: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: () => <div data-testid='mockImage-testid' />,
+}));
+
+describe('SectionHero', () => {
+  const renderWithSectionHero = () => render(<SectionHero />);
+
+  it('should render the text contents', async () => {
+    const { container } = renderWithSectionHero();
+    const titleText = await screen.findByText(sectionHeroContents.title);
+    const subTitleText = await screen.findByText(sectionHeroContents.subTitle);
+    const contentText = await screen.findByText(sectionHeroContents.content);
+
+    expect(container).toBeInTheDocument();
+    expect(titleText).toBeInTheDocument();
+    expect(subTitleText).toBeInTheDocument();
+    expect(contentText).toBeInTheDocument();
+  });
+
+  it('should render the signInButton and link button', async () => {
+    renderWithSectionHero();
+    const signInButton = await screen.findByText('Get started');
+    const linkButton = await screen.findByText('Learn more');
+
+    expect(signInButton).toBeInTheDocument();
+    expect(linkButton).toBeInTheDocument();
+  });
+
+  it('should render the gradient element and mockImage', async () => {
+    renderWithSectionHero();
+    const gradientElement = await screen.findByTestId('gradient-testid');
+    const mockImage = await screen.findByTestId('mockImage-testid');
+
+    expect(gradientElement).toBeInTheDocument();
+    expect(mockImage).toBeInTheDocument();
+  });
+});

--- a/app/components/section/sectionHero/index.tsx
+++ b/app/components/section/sectionHero/index.tsx
@@ -1,0 +1,105 @@
+import { DivContainerWithRef } from '@/container/divContainerWithRef';
+import { SmoothTransition } from '@/transition/smoothTransition';
+import { optionsTransition } from '@/transition/transition.utils';
+import { DELAY } from '@constAssertions/ui';
+import { sectionHeroContents } from '../section.consts';
+import Link from 'next/link';
+import { SignInButton } from '@/button/signInButton';
+import { STYLE_BUTTON_NORMAL_BLUE } from '@/button/button.consts';
+import { TypesOptionsButtonWithTooltip } from '@/button/button.types';
+import { SmoothTransitionWithDivRef } from '@/transition/smoothTransitionWithDivRef';
+import Image from 'next/image';
+import { PATH_HOME, PATH_IMAGE_HOME } from '@/lib/consts/assertion.consts';
+import { classNames } from '@/lib/lib.utils';
+import { STYLE_BLUR_GRADIENT_R_LG } from '@/lib/consts/style.consts';
+
+export const SectionHero = () => {
+  const signInButtonOptions: Partial<TypesOptionsButtonWithTooltip> = {
+    signInButtonName: 'Get started',
+    className: STYLE_BUTTON_NORMAL_BLUE,
+  };
+  const translateDownHandler = (delay?: keyof typeof DELAY) => {
+    return optionsTransition({ transition: 'translateDown', duration: 1000, delay: delay });
+  };
+
+  return (
+    <div>
+      <div className='relative isolate pt-10'>
+        <div className='py-24 sm:py-32 lg:pb-40'>
+          <DivContainerWithRef>
+            <SmoothTransition options={translateDownHandler()}>
+              <div className='mx-auto max-w-2xl text-center'>
+                <div className='mb-2 text-4xl font-bold text-slate-800 will-change-transform sm:text-6xl'>
+                  {sectionHeroContents.title}
+                </div>
+                <div className='text-4xl font-bold text-slate-800 will-change-transform sm:text-6xl'>
+                  {sectionHeroContents.subTitle}
+                </div>
+              </div>
+            </SmoothTransition>
+            <SmoothTransition options={translateDownHandler(300)}>
+              <div className='mx-auto max-w-2xl text-center'>
+                <p className='mt-6 text-xl leading-8 text-gray-600 will-change-transform'>
+                  {sectionHeroContents.content}
+                </p>
+              </div>
+            </SmoothTransition>
+            <SmoothTransition options={translateDownHandler(700)}>
+              <div className='mt-10 flex items-center justify-center gap-x-6'>
+                <SignInButton options={signInButtonOptions} />
+                <Link
+                  className='text-sm font-semibold leading-6 text-gray-900'
+                  href={PATH_HOME['features']}
+                >
+                  Learn more <span aria-hidden='true'>→</span>
+                </Link>
+              </div>
+            </SmoothTransition>
+            <SmoothTransition>
+              <div className='flex justify-center'>
+                <div className='relative mt-16 flow-root max-w-[60rem] sm:mt-24'>
+                  <SmoothTransitionWithDivRef
+                    options={optionsTransition({
+                      transition: 'fadeIn',
+                      duration: 1000,
+                      delay: 500,
+                      rate: 3,
+                    })}
+                  >
+                    <div
+                      className={classNames(
+                        'absolute h-full w-full rounded-xl will-change-transform',
+                        STYLE_BLUR_GRADIENT_R_LG,
+                      )}
+                      data-testid='gradient-testid'
+                    />
+                  </SmoothTransitionWithDivRef>
+                  <SmoothTransitionWithDivRef
+                    options={optionsTransition({
+                      transition: 'scaleCenterSm',
+                      duration: 700,
+                      delay: 300,
+                      rate: 3,
+                    })}
+                  >
+                    <div className='mx-auto flex w-full max-w-[60rem] flex-row items-center justify-center rounded-xl border-none ring-0 lg:rounded-2xl'>
+                      <Image
+                        width={961}
+                        height={754}
+                        className='h-auto w-auto rounded-2xl ring-2 ring-slate-300/20 drop-shadow-2xl will-change-transform'
+                        src={PATH_IMAGE_HOME['demo']}
+                        sizes='90vw'
+                        alt='demo application image'
+                        priority={true}
+                      />
+                    </div>
+                  </SmoothTransitionWithDivRef>
+                </div>
+              </div>
+            </SmoothTransition>
+          </DivContainerWithRef>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/app/components/ui/button/button.types.ts
+++ b/app/components/ui/button/button.types.ts
@@ -11,7 +11,7 @@ export interface TypesButtons {
 
 type TypesOptionsButton = TypesButtons & TypesClassNames & TypesAttributes;
 
-type TypesOptionsButtonWithTooltip = TypesOptionsButton &
+export type TypesOptionsButtonWithTooltip = TypesOptionsButton &
   Pick<TypesTooltips, 'tooltip' | 'kbd' | 'offset' | 'placement' | 'isVisible'>;
 
 type TypesButtonBase<T> = Partial<

--- a/app/components/ui/transition/smoothTransitionWithDivRef/__test__/smoothTransitionWithDivRef.test.tsx
+++ b/app/components/ui/transition/smoothTransitionWithDivRef/__test__/smoothTransitionWithDivRef.test.tsx
@@ -6,9 +6,9 @@ describe('SmoothTransitionWithDivRef', () => {
   const renderWithSmoothTransitionWithDivRef = (children: ReactNode) =>
     render(<SmoothTransitionWithDivRef>{children}</SmoothTransitionWithDivRef>);
 
-  it('should render the child elements', () => {
+  it('should render the child elements', async () => {
     const { container } = renderWithSmoothTransitionWithDivRef(<div>smoothTransition-test</div>);
-    const childElement = screen.getByText('smoothTransition-test');
+    const childElement = await screen.findByText('smoothTransition-test');
 
     expect(container).toBeInTheDocument();
     expect(childElement).toBeInTheDocument();

--- a/app/lib/consts/assertion.consts.ts
+++ b/app/lib/consts/assertion.consts.ts
@@ -8,3 +8,11 @@ export const PATH_HOME = {
   contact: '/contact',
   auth: '/auth',
 } as const;
+
+export type PATH_IMAGE_HOME = (typeof PATH_IMAGE_HOME)[keyof typeof PATH_IMAGE_HOME];
+export const PATH_IMAGE_HOME = {
+  demo: 'home-demo-image-desk.png',
+  contentFocus: 'home-content-focus.png',
+  contentOrganize: 'home-content-organize.png',
+  underConstruction: 'home-under-construction.png',
+} as const;

--- a/app/lib/imageLoader.ts
+++ b/app/lib/imageLoader.ts
@@ -1,0 +1,8 @@
+'use client';
+
+const cloudflareLoader = ({ src, width, quality }: { src: string; width: number; quality?: number }) => {
+  const params = [`width=${width}`, `quality=${quality || 75}`, `format=${'webp' || 'webp'}`];
+  return `${process.env.NEXT_PUBLIC_IMAGE_DOMAIN}/cdn-cgi/image/${params.join(',')}/${src}`;
+};
+
+export default cloudflareLoader;

--- a/app/lib/lib.utils.ts
+++ b/app/lib/lib.utils.ts
@@ -1,3 +1,1 @@
 export const classNames = (...classes: unknown[]) => classes.filter(Boolean).join(' ') || undefined;
-
-

--- a/components/user/userDropdown/__test__/userDropdown.test.tsx
+++ b/components/user/userDropdown/__test__/userDropdown.test.tsx
@@ -1,12 +1,12 @@
 import { PATH_IMAGE_APP } from '@constAssertions/data';
 import { cloudflareLoader } from '@stateLogics/utils';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { mockedImageUrl } from '__mock__/next';
 import { mockedUserSession } from '__mock__/next-auth';
 import { Session } from 'next-auth';
 import 'whatwg-fetch';
 import { UserDropdown } from '..';
 import { renderWithRecoilRootAndSession } from '@stateLogics/utils/testUtils';
+import { mockImageUrl } from '__mock__/next';
 
 describe('UserDropdown', () => {
   const renderWithSession = (session: Session | null) => {
@@ -20,7 +20,7 @@ describe('UserDropdown', () => {
     const userSession = session;
     const userAvatarImageAlt = screen.getByAltText('User avatar');
     const userAvatarImage = { src: mockedSession.user.image as string, width: 64, quality: 90 };
-    const optimizedUserImage = mockedImageUrl(userAvatarImage);
+    const optimizedUserImage = mockImageUrl(userAvatarImage);
     const dropdownButton = screen.getByRole('button', { name: /open user menu/i });
 
     return { userSession, container, dropdownButton, userAvatarImageAlt, optimizedUserImage };

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,6 +26,7 @@ const customJestConfig = {
     '^@/transition/(.*)$': ['<rootDir>/app/components/ui/transition/$1'],
     '^@/container/(.*)$': ['<rootDir>/app/components/ui/container/$1'],
     '^@/ui/(.*)$': ['<rootDir>/app/components/ui/$1'],
+    '^@/section/(.*)$': ['<rootDir>/app/components/section/$1'],
     '^@/components/(.*)$': ['<rootDir>/app/components/$1'],
     '^@/(.*)$': ['<rootDir>/app/$1'],
     //page router

--- a/next.config.js
+++ b/next.config.js
@@ -14,6 +14,8 @@ module.exports = withBundleAnalyzer({
     ignoreDuringBuilds: false,
   },
   images: {
+    loader: 'custom',
+    loaderFile: './app/lib/imageLoader.ts',
     domains: imageDomains,
   },
   output: 'standalone',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,6 +2,7 @@ import type { Config } from 'tailwindcss';
 
 export default {
   content: [
+    './app/**/*.{js,ts,jsx,tsx,mdx}',
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
     './lib/**/*.{js,ts,jsx,tsx}',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
       "@/tooltip/*": ["app/components/ui/tooltip/*"],
       "@/transition/*": ["app/components/ui/transition/*"],
       "@/container/*": ["app/components/ui/container/*"],
+      "@/section/*": ["app/components/section/*"],
       "@/ui/*": ["app/components/ui/*"],
       "@/components/*": ["app/components/*"],
       "@/*": ["app/*"],


### PR DESCRIPTION
SectionHero, inheriting primary functionality from HomeHero within pageRouter, has been integrated into appRouter with minor modifications. Comprehensive integration tests for SectionHero have been introduced, accounting for the interplay with child components.

Concurrently, appRouter Section path is now incorporated in tsconfig and jest.config. Resolved trivial defects, including console error witnessed during tests for SmoothTransitionWithDivRef. Appended absent appRouter path to tailwind.config to ensure appropriate forwarding of classNames to appRouter components.

Moreover, imageLoader for appRouter's lib/utils is established in a dedicated file. This utility, following 'use client' directive, serves client components. Registered imageLoader in next.js config as the default loader, subject to future revisions.