### PR TITLE
fix: Modify SectionHero component test

### DIFF
--- a/app/components/section/sectionHero/__test__/sectionHero.test.tsx
+++ b/app/components/section/sectionHero/__test__/sectionHero.test.tsx
@@ -13,6 +13,8 @@ jest.mock('next/image', () => ({
   default: () => <div data-testid='mockImage-testid' />,
 }));
 
+jest.mock('@/lib/utils/base64Converter.utils', () => jest.fn());
+
 describe('SectionHero', () => {
   const renderAsyncComponent = async () => {
     const ResolvedSectionHero = await getResolvedComponent(SectionHero);

--- a/app/components/section/sectionHero/index.tsx
+++ b/app/components/section/sectionHero/index.tsx
@@ -12,9 +12,10 @@ import Image from 'next/image';
 import { PATH_HOME, PATH_IMAGE } from '@/lib/consts/assertion.consts';
 import { STYLE_BLUR_GRADIENT_R_LG } from '@/lib/consts/style.consts';
 import { classNames } from '@/lib/utils/misc.utils';
+import getBase64FromImageURL from '@/lib/utils/base64Converter.utils';
 
 export const SectionHero = async () => {
-  // const placeholderDemo = await getBase64FromImageURL(PATH_IMAGE['demo']);
+  const placeholderDemo = await getBase64FromImageURL(PATH_IMAGE['demo']);
   const signInButtonOptions: Partial<TypesOptionsButtonWithTooltip> = {
     signInButtonName: 'Get started',
     className: STYLE_BUTTON_NORMAL_BLUE,
@@ -91,8 +92,8 @@ export const SectionHero = async () => {
                         src={PATH_IMAGE['demo']}
                         sizes='90vw'
                         alt='demo application image'
-                        // placeholder='blur'
-                        // blurDataURL={placeholderDemo}
+                        placeholder='blur'
+                        blurDataURL={placeholderDemo}
                         priority={true}
                       />
                     </div>


### PR DESCRIPTION
Embed base64Converter utility in SectionHero, fetching placeholder images as base64 encoded format. Function fetches original images at build time, scales down image size and quality via sharp library, minimizing final file size.

For integration testing, function is mocked ensuring seamless test transition.

Known limitation: Original images, once fetched, are cached permanently on server, only refetched during next build. Future modification of this functionality is plausible.