### PR TITLE
feat: Add ImageWithRemotePlaceholder component

### DIFF
--- a/app/components/next/imageWithRemotePlaceholder/__test__/imageWithRemotePlaceholder.test.tsx
+++ b/app/components/next/imageWithRemotePlaceholder/__test__/imageWithRemotePlaceholder.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import { ImageWithRemotePlaceholder } from '..';
+import { TypesImageWithRemotePlaceholder } from '../imageWithRemotePlaceholder.types';
+import { PATH_IMAGE } from '@/lib/consts/assertion.consts';
+
+type typesForTest = { options: Pick<TypesImageWithRemotePlaceholder, 'width' | 'height' | 'src' | 'alt'> };
+
+jest.mock('@/components/next/imageWithRemotePlaceholder', () => ({
+  ImageWithRemotePlaceholder: ({ options }: typesForTest) => (
+    <>
+      {Object.entries(options).map(([key, value]) => (
+        <div
+          key={key}
+          data-testid={`mockImage-${key}`}
+        >
+          {value}
+        </div>
+      ))}
+    </>
+  ),
+}));
+
+const mockImageOptions: TypesImageWithRemotePlaceholder = {
+  width: 1000,
+  height: 1000,
+  src: PATH_IMAGE['demo'],
+  alt: 'testing',
+};
+
+describe('ImageWithRemotePlaceholder', () => {
+  const renderWithImageWithRemotePlaceholder = ({ options }: typesForTest) =>
+    render(<ImageWithRemotePlaceholder options={options} />);
+
+  it('should properly passes the option props', async () => {
+    const { container } = renderWithImageWithRemotePlaceholder({ options: mockImageOptions });
+
+    expect(container).toBeInTheDocument();
+    Object.entries(mockImageOptions).forEach(([key, value]) => {
+      const imageOption = screen.getByTestId(`mockImage-${key}`);
+      expect(imageOption).toBeInTheDocument();
+      expect(imageOption.textContent).toBe(value.toString());
+    });
+  });
+});

--- a/app/components/next/imageWithRemotePlaceholder/imageWithRemotePlaceholder.types.ts
+++ b/app/components/next/imageWithRemotePlaceholder/imageWithRemotePlaceholder.types.ts
@@ -1,0 +1,6 @@
+import { TypesNextImage } from '../next.types';
+
+export type TypesImageWithRemotePlaceholder = Pick<TypesNextImage, 'src' | 'width' | 'height' | 'alt'> &
+  Partial<Omit<TypesNextImage, 'src' | 'width' | 'height' | 'alt'>>;
+
+export type PropsImageWithRemotePlaceholder = { options: TypesImageWithRemotePlaceholder };

--- a/app/components/next/imageWithRemotePlaceholder/index.tsx
+++ b/app/components/next/imageWithRemotePlaceholder/index.tsx
@@ -1,0 +1,41 @@
+import getBase64FromImageURL from '@/lib/utils/base64Converter.utils';
+import Image from 'next/image';
+import { PropsImageWithRemotePlaceholder } from './imageWithRemotePlaceholder.types';
+
+export const ImageWithRemotePlaceholder = async ({ options }: PropsImageWithRemotePlaceholder) => {
+  const {
+    src,
+    width,
+    height,
+    className,
+    alt,
+    quality,
+    fill,
+    style,
+    loading,
+    sizes = '100vw',
+    placeholder = 'blur',
+    priority = true,
+  } = options;
+  const remoteImageBlurDataURL = await getBase64FromImageURL(src);
+
+  return (
+    <>
+      <Image
+        width={width}
+        height={height}
+        className={className}
+        quality={quality}
+        src={src}
+        fill={fill}
+        sizes={sizes}
+        alt={alt}
+        placeholder={placeholder}
+        style={style}
+        loading={loading}
+        blurDataURL={remoteImageBlurDataURL}
+        priority={priority}
+      />
+    </>
+  );
+};

--- a/app/components/next/next.types.ts
+++ b/app/components/next/next.types.ts
@@ -1,0 +1,18 @@
+import { PATH_IMAGE } from '@/lib/consts/assertion.consts';
+import { CSSProperties } from 'react';
+
+export interface TypesNextImage {
+  width: number;
+  height: number;
+  className: string;
+  src: PATH_IMAGE;
+  alt: string;
+  sizes: string;
+  quality: number;
+  placeholder: 'blur' | 'empty';
+  blurDataURL: string;
+  priority: boolean;
+  fill: boolean;
+  style: CSSProperties;
+  loading: 'eager' | 'lazy';
+}

--- a/app/components/section/section.consts.ts
+++ b/app/components/section/section.consts.ts
@@ -1,3 +1,6 @@
+
+
+
 export const sectionHeroContents = {
   title: 'Simplify your life',
   subTitle: 'Automate your tasks',

--- a/app/components/section/sectionHero/__test__/sectionHero.test.tsx
+++ b/app/components/section/sectionHero/__test__/sectionHero.test.tsx
@@ -3,14 +3,15 @@ import { render, screen } from '@testing-library/react';
 import { SectionHero } from '..';
 import { ReactNode } from 'react';
 import { getResolvedComponent } from '@/lib/utils/test.utils';
+import { optionsSectionHeroWithSignInButton } from '../sectionHero.consts';
+import { TypesButtons } from '@/button/button.types';
 
 jest.mock('@/transition/smoothTransitionWithDivRef', () => ({
   SmoothTransitionWithDivRef: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: () => <div data-testid='mockImage-testid' />,
+jest.mock('@/components/next/imageWithRemotePlaceholder', () => ({
+  ImageWithRemotePlaceholder: () => <div data-testid='mockImage-testid' />,
 }));
 
 jest.mock('@/lib/utils/base64Converter.utils', () => jest.fn());
@@ -36,7 +37,9 @@ describe('SectionHero', () => {
   it('should render the signInButton and link button', async () => {
     await renderAsyncComponent();
 
-    const signInButton = await screen.findByText('Get started');
+    const signInButtonName =
+      optionsSectionHeroWithSignInButton.signInButtonName as TypesButtons['signInButtonName'];
+    const signInButton = await screen.findByText(signInButtonName);
     const linkButton = await screen.findByText('Learn more');
 
     expect(signInButton).toBeInTheDocument();

--- a/app/components/section/sectionHero/index.tsx
+++ b/app/components/section/sectionHero/index.tsx
@@ -5,21 +5,14 @@ import { DELAY } from '@constAssertions/ui';
 import { sectionHeroContents } from '../section.consts';
 import Link from 'next/link';
 import { SignInButton } from '@/button/signInButton';
-import { STYLE_BUTTON_NORMAL_BLUE } from '@/button/button.consts';
-import { TypesOptionsButtonWithTooltip } from '@/button/button.types';
 import { SmoothTransitionWithDivRef } from '@/transition/smoothTransitionWithDivRef';
-import Image from 'next/image';
-import { PATH_HOME, PATH_IMAGE } from '@/lib/consts/assertion.consts';
+import { PATH_HOME } from '@/lib/consts/assertion.consts';
 import { STYLE_BLUR_GRADIENT_R_LG } from '@/lib/consts/style.consts';
 import { classNames } from '@/lib/utils/misc.utils';
-import getBase64FromImageURL from '@/lib/utils/base64Converter.utils';
+import { ImageWithRemotePlaceholder } from '@/components/next/imageWithRemotePlaceholder';
+import { optionsSectionHeroWithSignInButton, optionsSectionHeroWithImage } from './sectionHero.consts';
 
 export const SectionHero = async () => {
-  const placeholderDemo = await getBase64FromImageURL(PATH_IMAGE['demo']);
-  const signInButtonOptions: Partial<TypesOptionsButtonWithTooltip> = {
-    signInButtonName: 'Get started',
-    className: STYLE_BUTTON_NORMAL_BLUE,
-  };
   const translateDownHandler = (delay?: keyof typeof DELAY) => {
     return optionsTransition({ transition: 'translateDown', duration: 1000, delay: delay });
   };
@@ -48,7 +41,7 @@ export const SectionHero = async () => {
             </SmoothTransition>
             <SmoothTransition options={translateDownHandler(700)}>
               <div className='mt-10 flex items-center justify-center gap-x-6'>
-                <SignInButton options={signInButtonOptions} />
+                <SignInButton options={optionsSectionHeroWithSignInButton} />
                 <Link
                   className='text-sm font-semibold leading-6 text-gray-900'
                   href={PATH_HOME['features']}
@@ -85,17 +78,7 @@ export const SectionHero = async () => {
                     })}
                   >
                     <div className='mx-auto flex w-full max-w-[60rem] flex-row items-center justify-center rounded-xl border-none ring-0 lg:rounded-2xl'>
-                      <Image
-                        width={961}
-                        height={754}
-                        className='h-auto w-auto rounded-2xl ring-2 ring-slate-300/20 drop-shadow-2xl will-change-transform'
-                        src={PATH_IMAGE['demo']}
-                        sizes='90vw'
-                        alt='demo application image'
-                        placeholder='blur'
-                        blurDataURL={placeholderDemo}
-                        priority={true}
-                      />
+                      <ImageWithRemotePlaceholder options={optionsSectionHeroWithImage} />
                     </div>
                   </SmoothTransitionWithDivRef>
                 </div>

--- a/app/components/section/sectionHero/sectionHero.consts.ts
+++ b/app/components/section/sectionHero/sectionHero.consts.ts
@@ -1,0 +1,20 @@
+import { TypesOptionsButtonWithTooltip } from '@/button/button.types';
+import { TypesImageWithRemotePlaceholder } from '@/components/next/imageWithRemotePlaceholder/imageWithRemotePlaceholder.types';
+import { PATH_IMAGE } from '@/lib/consts/assertion.consts';
+import { STYLE_BUTTON_NORMAL_BLUE } from '@data/stylePreset';
+
+export const optionsSectionHeroWithSignInButton: Partial<TypesOptionsButtonWithTooltip> = {
+  signInButtonName: 'Get started',
+  className: STYLE_BUTTON_NORMAL_BLUE,
+};
+
+export const optionsSectionHeroWithImage: TypesImageWithRemotePlaceholder = {
+  width: 961,
+  height: 754,
+  className: 'h-auto w-auto rounded-2xl ring-2 ring-slate-300/20 drop-shadow-2xl will-change-transform',
+  src: PATH_IMAGE['demo'],
+  sizes: '90vw',
+  alt: 'demo application image',
+  placeholder: 'blur',
+  priority: true,
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -27,6 +27,7 @@ const customJestConfig = {
     '^@/container/(.*)$': ['<rootDir>/app/components/ui/container/$1'],
     '^@/ui/(.*)$': ['<rootDir>/app/components/ui/$1'],
     '^@/section/(.*)$': ['<rootDir>/app/components/section/$1'],
+    '^@/next/(.*)$': ['<rootDir>/app/components/next/$1'],
     '^@/components/(.*)$': ['<rootDir>/app/components/$1'],
     '^@/(.*)$': ['<rootDir>/app/$1'],
     //page router

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
       "@/transition/*": ["app/components/ui/transition/*"],
       "@/container/*": ["app/components/ui/container/*"],
       "@/section/*": ["app/components/section/*"],
+      "@/next/*": ["app/components/next/*"],
       "@/ui/*": ["app/components/ui/*"],
       "@/components/*": ["app/components/*"],
       "@/*": ["app/*"],


### PR DESCRIPTION
Integrates ImageWithRemotePlaceholder, a simplified wrapper for Image component. Its function is to auto-fetch original images from remote URLs, and encode these as base64 using a utility function, reducing file size and quality significantly. Includes a unit test for ImageWithRemotePlaceholder. Addition of alias path for Next component has been made in tsconfig and jest.config.

Additionally, SectionHero's integration test is adjusted to accommodate ImageWithRemotePlaceholder component.