### PR TITLE
refactor: Enhance ImageWithRemotePlaceholder

### DIFF
--- a/app/components/next/imageWithRemotePlaceholder/index.tsx
+++ b/app/components/next/imageWithRemotePlaceholder/index.tsx
@@ -1,39 +1,31 @@
+import 'server-only';
 import getBase64FromImageURL from '@/lib/utils/base64Converter.utils';
 import Image from 'next/image';
 import { PropsImageWithRemotePlaceholder } from './imageWithRemotePlaceholder.types';
 
 export const ImageWithRemotePlaceholder = async ({ options }: PropsImageWithRemotePlaceholder) => {
-  const {
-    src,
-    width,
-    height,
-    className,
-    alt,
-    quality,
-    fill,
-    style,
-    loading,
-    sizes = '100vw',
-    placeholder = 'blur',
-    priority = true,
-  } = options;
-  const remoteImageBlurDataURL = await getBase64FromImageURL(src);
+  const { sizes = '100vw', priority = true } = options;
+  const remoteImageHandler = async () => {
+    if (options.placeholder === 'blur') return await getBase64FromImageURL(options.src);
+    return;
+  };
+  const remoteImageBlurDataURL = await remoteImageHandler();
 
   return (
     <>
       <Image
-        width={width}
-        height={height}
-        className={className}
-        quality={quality}
-        src={src}
-        fill={fill}
-        sizes={sizes}
-        alt={alt}
-        placeholder={placeholder}
-        style={style}
-        loading={loading}
+        width={options.width}
+        height={options.height}
+        className={options.className}
+        quality={options.quality}
+        src={options.src}
+        fill={options.fill}
+        alt={options.alt}
+        placeholder={options.placeholder}
+        style={options.style}
+        loading={options.loading}
         blurDataURL={remoteImageBlurDataURL}
+        sizes={sizes}
         priority={priority}
       />
     </>


### PR DESCRIPTION
Enhancement includes readability improvement and introduction of remoteImageHandler function, responsible for remote image fetching and conversion. Absence of `placeholder` prop causes function to return undefined, preventing image fetching and conversion to base64.

Notably, importation of 'server-only' module prevents use within client components. This is crucial, as 'getBase64FromImageURL' is specifically designed for server-side processing.