### PR TITLE
feat: Transition HomeHeader to appRouter

### DIFF
--- a/app/components/section/section.consts.ts
+++ b/app/components/section/section.consts.ts
@@ -1,9 +1,13 @@
-
-
-
 export const sectionHeroContents = {
   title: 'Simplify your life',
   subTitle: 'Automate your tasks',
   content:
     'Focus on your work more and manage your to-dos less. Enhance your efficiency and improve your productivity.',
+};
+
+export const sectionHeaderContents = {
+  title: 'Simplify your works',
+  subTitle: 'Manage less work better',
+  content:
+    'Unburden yourself from managing time-consuming tasks by allowing app to seamlessly choose the most suitable to-dos for you.',
 };

--- a/app/components/section/sectionHeader/__test__/sectionHeader.test.tsx
+++ b/app/components/section/sectionHeader/__test__/sectionHeader.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { SectionHeader } from '..';
+import { sectionHeaderContents } from '@/section/section.consts';
+
+jest.mock('@/transition/smoothTransitionWithDivRef', () => ({
+  SmoothTransitionWithDivRef: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+describe('SectionHeader', () => {
+  const renderWithSectionHeader = () => render(<SectionHeader />);
+
+  it('should render the gradient pole testid', () => {
+    const { container } = renderWithSectionHeader();
+    const gradientPoleTestId = screen.getByTestId('gradientPole-testid');
+
+    expect(container).toBeInTheDocument();
+    expect(gradientPoleTestId).toBeInTheDocument();
+  });
+
+  it('should render the text contents properly', async () => {
+    renderWithSectionHeader();
+
+    Object.values(sectionHeaderContents).forEach(async (value) => {
+      await waitFor(() => {
+        const text = screen.queryByText(value);
+        expect(text).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/app/components/section/sectionHeader/index.tsx
+++ b/app/components/section/sectionHeader/index.tsx
@@ -1,0 +1,49 @@
+import { DivContainerWithRef } from '@/container/divContainerWithRef';
+import { SmoothTransition } from '@/transition/smoothTransition';
+import { SmoothTransitionWithDivRef } from '@/transition/smoothTransitionWithDivRef';
+import { TRANSITION_TYPE } from '@/transition/transition.consts';
+import { optionsTransition } from '@/transition/transition.utils';
+import { DELAY } from '@constAssertions/ui';
+import { sectionHeaderContents } from '../section.consts';
+import { STYLE_BLUR_GRADIENT_B_MD } from '@data/stylePreset';
+import { classNames } from '@/lib/utils/misc.utils';
+
+export const SectionHeader = () => {
+  const transitionHandler = (transition: TRANSITION_TYPE, delay?: keyof typeof DELAY) => {
+    return optionsTransition({ transition: transition ?? 'fadeIn', delay: delay });
+  };
+  const optionsPoleTransition = { type: TRANSITION_TYPE['scaleY'], delay: DELAY['150'] };
+
+  return (
+    <SmoothTransition>
+      <DivContainerWithRef>
+        <div className='my-5 flex flex-row items-center justify-center'>
+          <div className={'text-sm font-semibold uppercase tracking-widest text-gray-500'}>
+            <SmoothTransitionWithDivRef options={transitionHandler('fadeIn')}>
+              {sectionHeaderContents.title}
+            </SmoothTransitionWithDivRef>
+          </div>
+        </div>
+        <SmoothTransitionWithDivRef options={optionsPoleTransition}>
+          <div className='relative flex h-[15rem] max-h-60 flex-row items-center justify-center'>
+            <div
+              className={classNames(STYLE_BLUR_GRADIENT_B_MD, 'absolute h-full w-3 will-change-transform')}
+              data-testid='gradientPole-testid'
+            />
+            <div className='h-full w-1 rounded-full bg-gradient-to-b from-blue-600' />
+          </div>
+        </SmoothTransitionWithDivRef>
+      </DivContainerWithRef>
+      <div className='flex flex-col items-center justify-center px-5 text-center'>
+        <SmoothTransitionWithDivRef options={transitionHandler('fadeIn', 300)}>
+          <h1 className='my-5 h-full bg-slate-50 text-3xl font-bold tracking-normal text-slate-800 sm:text-5xl'>
+            {sectionHeaderContents.subTitle}
+          </h1>
+        </SmoothTransitionWithDivRef>
+        <SmoothTransitionWithDivRef options={transitionHandler('fadeIn', 500)}>
+          <h2 className='max-w-2xl text-lg text-slate-600 sm:text-xl'>{sectionHeaderContents.content}</h2>
+        </SmoothTransitionWithDivRef>
+      </div>
+    </SmoothTransition>
+  );
+};


### PR DESCRIPTION
Migrate HomeHeader from pageRouter to appRouter, now named SectionHeader. Incorporate server and client-side child components as part of this migration. Integration tests validate rendering of child elements. For improved testing, assign 'gradientPole-testid' to gradientPole element.