### PR TITLE
fix: Resolve console.error in SectionHeader test

### DIFF
--- a/app/components/section/sectionHeader/__test__/sectionHeader.test.tsx
+++ b/app/components/section/sectionHeader/__test__/sectionHeader.test.tsx
@@ -10,15 +10,15 @@ jest.mock('@/transition/smoothTransitionWithDivRef', () => ({
 describe('SectionHeader', () => {
   const renderWithSectionHeader = () => render(<SectionHeader />);
 
-  it('should render the gradient pole testid', () => {
+  it('should render the gradient pole testid', async () => {
     const { container } = renderWithSectionHeader();
-    const gradientPoleTestId = screen.getByTestId('gradientPole-testid');
+    const gradientPoleTestId = await screen.findByTestId('gradientPole-testid');
 
     expect(container).toBeInTheDocument();
     expect(gradientPoleTestId).toBeInTheDocument();
   });
 
-  it('should render the text contents properly', async () => {
+  it('should render the text contents properly', () => {
     renderWithSectionHeader();
 
     Object.values(sectionHeaderContents).forEach(async (value) => {


### PR DESCRIPTION
Correct console.error triggered during SectionHeader component unit testing. Asynchronous behavior, resolved by employing 'findByTestId' for test id retrieval.