### PR TITLE
feat: Add SectionContentText in appRouter

### DIFF
--- a/app/components/section/section.consts.ts
+++ b/app/components/section/section.consts.ts
@@ -11,3 +11,18 @@ export const sectionHeaderContents = {
   content:
     'Unburden yourself from managing time-consuming tasks by allowing app to seamlessly choose the most suitable to-dos for you.',
 };
+
+export const sectionContentTextContents = {
+  spotlight: {
+    title: 'Spotlight your to-dos',
+    subTitle: "View your to-dos that are intelligently and automatically selected in Today's Focus.",
+    content:
+      "Add your to-dos as you please, with or without due dates and priorities. Today's Focus will display your most important to-dos for you.",
+  },
+  overload: {
+    title: 'Free your overload',
+    subTitle: 'Work on a to-do list that is auto-allocated according to your capacity.',
+    content:
+      "Today's Focus efficiently determines the ideal number of to-dos for you. As you consistently complete to-dos, the process adjusts and assigns more or fewer to-dos base on your completion rate.",
+  },
+};

--- a/app/components/section/section.types.ts
+++ b/app/components/section/section.types.ts
@@ -1,0 +1,3 @@
+type TypesSectionContentText = 'title' | 'subTitle' | 'content';
+
+export type PropsSectionContentText = Record<TypesSectionContentText, string>;

--- a/app/components/section/sectionContent/index.tsx
+++ b/app/components/section/sectionContent/index.tsx
@@ -1,0 +1,3 @@
+export const SectionContent = () => {
+  return <div>Section Content Placeholder</div>;
+};

--- a/app/components/section/sectionContent/sectionContentText/__test__/sectionContentText.test.tsx
+++ b/app/components/section/sectionContent/sectionContentText/__test__/sectionContentText.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { SectionContentText } from '..';
+import { PropsSectionContentText } from '@/section/section.types';
+import { sectionContentTextContents } from '@/section/section.consts';
+
+describe('SectionContentText', () => {
+  const renderWithSectionContentText = ({ title, subTitle, content }: PropsSectionContentText) =>
+    render(
+      <SectionContentText
+        title={title}
+        subTitle={subTitle}
+        content={content}
+      />,
+    );
+
+  it('should render the props titles properly', () => {
+    const { container } = renderWithSectionContentText({
+      title: sectionContentTextContents.spotlight.title,
+      subTitle: sectionContentTextContents.spotlight.subTitle,
+      content: sectionContentTextContents.spotlight.content,
+    });
+    Object.values(sectionContentTextContents.spotlight).forEach(async (value) => {
+      await waitFor(() => {
+        const text = screen.queryByText(value);
+        expect(text).toBeInTheDocument();
+      });
+    });
+
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/app/components/section/sectionContent/sectionContentText/index.tsx
+++ b/app/components/section/sectionContent/sectionContentText/index.tsx
@@ -1,0 +1,36 @@
+import { DivContainerWithRef } from '@/container/divContainerWithRef';
+import { STYLE_BLUR_GRADIENT_R_ZR } from '@/lib/consts/style.consts';
+import { classNames } from '@/lib/utils/misc.utils';
+import { PropsSectionContentText } from '@/section/section.types';
+import { SmoothTransitionWithDivRef } from '@/transition/smoothTransitionWithDivRef';
+import { DELAY } from '@/transition/transition.consts';
+import { optionsTransition } from '@/transition/transition.utils';
+
+export const SectionContentText = ({ title, subTitle, content }: PropsSectionContentText) => {
+  const transitionHandler = (delay?: keyof typeof DELAY) => {
+    return optionsTransition({ transition: 'fadeIn', duration: 1000, delay: delay, rate: 0.8 });
+  };
+
+  return (
+    <div className='flex max-w-md flex-col items-center justify-center space-y-3 text-center font-bold md:items-start md:text-start md:leading-relaxed md:tracking-wide'>
+      <DivContainerWithRef className='min-w-max max-w-full overflow-hidden'>
+        <SmoothTransitionWithDivRef options={transitionHandler()}>
+          <p
+            className={classNames(
+              'w-full max-w-sm animate-typing whitespace-nowrap bg-clip-text text-2xl text-transparent will-change-transform md:text-3xl',
+              STYLE_BLUR_GRADIENT_R_ZR,
+            )}
+          >
+            {title}
+          </p>
+        </SmoothTransitionWithDivRef>
+      </DivContainerWithRef>
+      <SmoothTransitionWithDivRef options={transitionHandler(500)}>
+        <p className='text-lg text-slate-800/80 opacity-100 will-change-transform md:text-xl'>{subTitle}</p>
+      </SmoothTransitionWithDivRef>
+      <SmoothTransitionWithDivRef options={transitionHandler(700)}>
+        <p className='text-base font-medium text-slate-800/80 opacity-100 will-change-transform'>{content}</p>
+      </SmoothTransitionWithDivRef>
+    </div>
+  );
+};

--- a/app/components/ui/container/divContainerWithRef/index.tsx
+++ b/app/components/ui/container/divContainerWithRef/index.tsx
@@ -11,7 +11,9 @@ export const DivContainerWithRef = ({ children, className }: PropsDivContainer) 
 
   useEffect(() => {
     setDivRef(divRef);
-  }, [setDivRef]);
+    // set the state only the component mounts
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div


### PR DESCRIPTION
Incorporate SectionContentText component, specific to SectionContent. SectionContent and SectionContentText components are refactored version of HomeContent and HomeContentText within pageRouter.

sectionContentTextContent consts added to section.const for reuse.

Include unit test for SectionContentText, validating rendering of text and component mounting.

DivContainerWithRef no longer dependent within useEffect, to execute side effect solely on component mounting.