### PR TITLE
feat: Extend appRouter with SectionContent component

### DIFF
--- a/app/components/section/sectionContent/__test__/sectionContent.test.tsx
+++ b/app/components/section/sectionContent/__test__/sectionContent.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { SectionContent } from '..';
+import { sectionContentTextContents } from '@/section/section.consts';
+import { ReactNode } from 'react';
+
+jest.mock('@/components/next/imageWithRemotePlaceholder', () => ({
+  ImageWithRemotePlaceholder: () => <div data-testid='mockImage-testid' />,
+}));
+
+jest.mock('@/transition/smoothTransitionWithDivRef', () => ({
+  SmoothTransitionWithDivRef: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+describe('SectionContent', () => {
+  const renderWithSectionContent = () => render(<SectionContent />);
+
+  it('should render the content texts of spotlight and overload', () => {
+    const { container } = renderWithSectionContent();
+
+    Object.values(sectionContentTextContents).forEach((contentObjects) => {
+      Object.values(contentObjects).forEach(async (value) => {
+        await waitFor(() => {
+          const text = screen.queryByText(value);
+          expect(text).toBeInTheDocument();
+        });
+      });
+    });
+    expect(container).toBeInTheDocument();
+  });
+
+  it('should mount the ImageWithRemotePlaceholder properly', async () => {
+    renderWithSectionContent();
+    await waitFor(() => {
+      const imageTestId = screen.getAllByTestId('mockImage-testid');
+
+      imageTestId.forEach((value) => {
+        expect(value).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/app/components/section/sectionContent/index.tsx
+++ b/app/components/section/sectionContent/index.tsx
@@ -1,3 +1,71 @@
+import { SmoothTransition } from '@/transition/smoothTransition';
+import { DELAY } from '@/transition/transition.consts';
+import { optionsTransition } from '@/transition/transition.utils';
+import { SectionContentText } from './sectionContentText';
+import { sectionContentTextContents } from '../section.consts';
+import { DivContainerWithRef } from '@/container/divContainerWithRef';
+import { classNames } from '@/lib/utils/misc.utils';
+import { SmoothTransitionWithDivRef } from '@/transition/smoothTransitionWithDivRef';
+import { PATH_IMAGE } from '@/lib/consts/assertion.consts';
+import { ImageWithRemotePlaceholder } from '@/next/imageWithRemotePlaceholder';
+
+const styleImageWrapper = 'relative w-80 h-auto rounded-xl shadow-2xl shadow-blue-500/40 ring-purple-300/10';
+const styleImage = 'h-auto w-full rounded-xl drop-shadow-2xl';
+const styleImageFrame = 'md:h-[440px]';
+const optionsImageSpotlight = {
+  width: 504,
+  height: 689,
+  className: styleImage,
+  src: PATH_IMAGE['contentFocus'],
+  sizes: '(max-width: 748px) 70vw, 33vw',
+  alt: 'content focus image',
+  priority: true,
+};
+const optionsImageOverload = {
+  width: 494,
+  height: 650,
+  className: styleImage,
+  src: PATH_IMAGE['contentOrganize'],
+  sizes: '(max-width: 748px) 70vw, 33vw',
+  alt: 'content organize image',
+  priority: true,
+};
+
 export const SectionContent = () => {
-  return <div>Section Content Placeholder</div>;
+  const transitionHandler = (delay: keyof typeof DELAY) => {
+    return optionsTransition({ transition: 'scaleCenterSm', duration: 700, delay: delay });
+  };
+
+  return (
+    <SmoothTransition>
+      <div className='relative my-24 flex flex-row items-center justify-center px-5 py-10 sm:px-10 md:my-32 lg:px-28'>
+        <div className='md:min-w-3/4 grid w-full max-w-6xl grid-cols-1 items-center justify-items-center gap-10 md:grid-cols-2'>
+          <SectionContentText
+            title={sectionContentTextContents.spotlight.title}
+            subTitle={sectionContentTextContents.spotlight.subTitle}
+            content={sectionContentTextContents.spotlight.content}
+          />
+          <DivContainerWithRef className={classNames(styleImageFrame)}>
+            <SmoothTransitionWithDivRef options={transitionHandler(500)}>
+              <div className={classNames(styleImageWrapper, 'opacity-100')}>
+                <ImageWithRemotePlaceholder options={optionsImageSpotlight} />
+              </div>
+            </SmoothTransitionWithDivRef>
+          </DivContainerWithRef>
+          <DivContainerWithRef className={classNames('max-md:order-last', styleImageFrame)}>
+            <SmoothTransitionWithDivRef options={transitionHandler(700)}>
+              <div className={classNames(styleImageWrapper, 'opacity-100')}>
+                <ImageWithRemotePlaceholder options={optionsImageOverload} />
+              </div>
+            </SmoothTransitionWithDivRef>
+          </DivContainerWithRef>
+          <SectionContentText
+            title={sectionContentTextContents.overload.title}
+            subTitle={sectionContentTextContents.overload.subTitle}
+            content={sectionContentTextContents.overload.content}
+          />
+        </div>
+      </div>
+    </SmoothTransition>
+  );
 };

--- a/app/components/section/sectionHeader/index.tsx
+++ b/app/components/section/sectionHeader/index.tsx
@@ -16,7 +16,7 @@ export const SectionHeader = () => {
 
   return (
     <SmoothTransition>
-      <DivContainerWithRef>
+      <DivContainerWithRef className='my-10 flex flex-col items-center justify-center'>
         <div className='my-5 flex flex-row items-center justify-center'>
           <div className={'text-sm font-semibold uppercase tracking-widest text-gray-500'}>
             <SmoothTransitionWithDivRef options={transitionHandler('fadeIn')}>

--- a/app/components/section/sectionHero/index.tsx
+++ b/app/components/section/sectionHero/index.tsx
@@ -14,14 +14,14 @@ import { optionsSectionHeroWithSignInButton, optionsSectionHeroWithImage } from 
 
 export const SectionHero = async () => {
   const translateDownHandler = (delay?: keyof typeof DELAY) => {
-    return optionsTransition({ transition: 'translateDown', duration: 1000, delay: delay });
+    return optionsTransition({ transition: 'translateDown', duration: 1000, delay: delay,});
   };
 
   return (
     <div>
       <div className='relative isolate pt-10'>
         <div className='py-24 sm:py-32 lg:pb-40'>
-          <DivContainerWithRef>
+          <DivContainerWithRef className='mx-auto max-w-7xl px-6 lg:px-8 bg-red-300'>
             <SmoothTransition options={translateDownHandler()}>
               <div className='mx-auto max-w-2xl text-center'>
                 <div className='mb-2 text-4xl font-bold text-slate-800 will-change-transform sm:text-6xl'>


### PR DESCRIPTION
Incorporates the SectionContent component into appRouter, as a refactored variant of HomeContent from pageRouter. Ensures the validity of the change through integration tests, assessing the rendering of text content and mocked image component.

Enhances SectionHeader and SectionHero components with the inclusion of previously omitted className attributes.