### PR TITLE
refactor: Optimize atomDivRef and Prettier setting

### DIFF
--- a/app/components/section/sectionContent/index.tsx
+++ b/app/components/section/sectionContent/index.tsx
@@ -32,6 +32,8 @@ const optionsImageOverload = {
 };
 
 export const SectionContent = () => {
+  const divContainerSpotlight_id = 'sectionContent_spotlight';
+  const divContainerOverload_id = 'sectionContent_overload';
   const transitionHandler = (delay: keyof typeof DELAY) => {
     return optionsTransition({ transition: 'scaleCenterSm', duration: 700, delay: delay });
   };
@@ -45,15 +47,27 @@ export const SectionContent = () => {
             subTitle={sectionContentTextContents.spotlight.subTitle}
             content={sectionContentTextContents.spotlight.content}
           />
-          <DivContainerWithRef className={classNames(styleImageFrame)}>
-            <SmoothTransitionWithDivRef options={transitionHandler(500)}>
+          <DivContainerWithRef
+            _id={divContainerSpotlight_id}
+            className={classNames(styleImageFrame)}
+          >
+            <SmoothTransitionWithDivRef
+              _id={divContainerSpotlight_id}
+              options={transitionHandler(500)}
+            >
               <div className={classNames(styleImageWrapper, 'opacity-100')}>
                 <ImageWithRemotePlaceholder options={optionsImageSpotlight} />
               </div>
             </SmoothTransitionWithDivRef>
           </DivContainerWithRef>
-          <DivContainerWithRef className={classNames('max-md:order-last', styleImageFrame)}>
-            <SmoothTransitionWithDivRef options={transitionHandler(700)}>
+          <DivContainerWithRef
+            _id={divContainerOverload_id}
+            className={classNames('max-md:order-last', styleImageFrame)}
+          >
+            <SmoothTransitionWithDivRef
+              _id={divContainerOverload_id}
+              options={transitionHandler(700)}
+            >
               <div className={classNames(styleImageWrapper, 'opacity-100')}>
                 <ImageWithRemotePlaceholder options={optionsImageOverload} />
               </div>

--- a/app/components/section/sectionContent/sectionContentText/index.tsx
+++ b/app/components/section/sectionContent/sectionContentText/index.tsx
@@ -7,14 +7,21 @@ import { DELAY } from '@/transition/transition.consts';
 import { optionsTransition } from '@/transition/transition.utils';
 
 export const SectionContentText = ({ title, subTitle, content }: PropsSectionContentText) => {
+  const divContainer_id = 'sectionContentText';
   const transitionHandler = (delay?: keyof typeof DELAY) => {
     return optionsTransition({ transition: 'fadeIn', duration: 1000, delay: delay, rate: 0.8 });
   };
 
   return (
     <div className='flex max-w-md flex-col items-center justify-center space-y-3 text-center font-bold md:items-start md:text-start md:leading-relaxed md:tracking-wide'>
-      <DivContainerWithRef className='min-w-max max-w-full overflow-hidden'>
-        <SmoothTransitionWithDivRef options={transitionHandler()}>
+      <DivContainerWithRef
+        _id={divContainer_id}
+        className='min-w-max max-w-full overflow-hidden'
+      >
+        <SmoothTransitionWithDivRef
+          _id={divContainer_id}
+          options={transitionHandler()}
+        >
           <p
             className={classNames(
               'w-full max-w-sm animate-typing whitespace-nowrap bg-clip-text text-2xl text-transparent will-change-transform md:text-3xl',
@@ -25,10 +32,16 @@ export const SectionContentText = ({ title, subTitle, content }: PropsSectionCon
           </p>
         </SmoothTransitionWithDivRef>
       </DivContainerWithRef>
-      <SmoothTransitionWithDivRef options={transitionHandler(500)}>
+      <SmoothTransitionWithDivRef
+        _id={divContainer_id}
+        options={transitionHandler(500)}
+      >
         <p className='text-lg text-slate-800/80 opacity-100 will-change-transform md:text-xl'>{subTitle}</p>
       </SmoothTransitionWithDivRef>
-      <SmoothTransitionWithDivRef options={transitionHandler(700)}>
+      <SmoothTransitionWithDivRef
+        _id={divContainer_id}
+        options={transitionHandler(700)}
+      >
         <p className='text-base font-medium text-slate-800/80 opacity-100 will-change-transform'>{content}</p>
       </SmoothTransitionWithDivRef>
     </div>

--- a/app/components/section/sectionHeader/index.tsx
+++ b/app/components/section/sectionHeader/index.tsx
@@ -9,6 +9,7 @@ import { STYLE_BLUR_GRADIENT_B_MD } from '@data/stylePreset';
 import { classNames } from '@/lib/utils/misc.utils';
 
 export const SectionHeader = () => {
+  const divContainer_id = 'sectionHeader';
   const transitionHandler = (transition: TRANSITION_TYPE, delay?: keyof typeof DELAY) => {
     return optionsTransition({ transition: transition ?? 'fadeIn', delay: delay });
   };
@@ -16,15 +17,24 @@ export const SectionHeader = () => {
 
   return (
     <SmoothTransition>
-      <DivContainerWithRef className='my-10 flex flex-col items-center justify-center'>
+      <DivContainerWithRef
+        _id={divContainer_id}
+        className='my-10 flex flex-col items-center justify-center'
+      >
         <div className='my-5 flex flex-row items-center justify-center'>
           <div className={'text-sm font-semibold uppercase tracking-widest text-gray-500'}>
-            <SmoothTransitionWithDivRef options={transitionHandler('fadeIn')}>
+            <SmoothTransitionWithDivRef
+              _id={divContainer_id}
+              options={transitionHandler('fadeIn')}
+            >
               {sectionHeaderContents.title}
             </SmoothTransitionWithDivRef>
           </div>
         </div>
-        <SmoothTransitionWithDivRef options={optionsPoleTransition}>
+        <SmoothTransitionWithDivRef
+          _id={divContainer_id}
+          options={optionsPoleTransition}
+        >
           <div className='relative flex h-[15rem] max-h-60 flex-row items-center justify-center'>
             <div
               className={classNames(STYLE_BLUR_GRADIENT_B_MD, 'absolute h-full w-3 will-change-transform')}
@@ -35,12 +45,18 @@ export const SectionHeader = () => {
         </SmoothTransitionWithDivRef>
       </DivContainerWithRef>
       <div className='flex flex-col items-center justify-center px-5 text-center'>
-        <SmoothTransitionWithDivRef options={transitionHandler('fadeIn', 300)}>
+        <SmoothTransitionWithDivRef
+          _id={divContainer_id}
+          options={transitionHandler('fadeIn', 300)}
+        >
           <h1 className='my-5 h-full bg-slate-50 text-3xl font-bold tracking-normal text-slate-800 sm:text-5xl'>
             {sectionHeaderContents.subTitle}
           </h1>
         </SmoothTransitionWithDivRef>
-        <SmoothTransitionWithDivRef options={transitionHandler('fadeIn', 500)}>
+        <SmoothTransitionWithDivRef
+          _id={divContainer_id}
+          options={transitionHandler('fadeIn', 500)}
+        >
           <h2 className='max-w-2xl text-lg text-slate-600 sm:text-xl'>{sectionHeaderContents.content}</h2>
         </SmoothTransitionWithDivRef>
       </div>

--- a/app/components/section/sectionHero/index.tsx
+++ b/app/components/section/sectionHero/index.tsx
@@ -13,15 +13,31 @@ import { ImageWithRemotePlaceholder } from '@/components/next/imageWithRemotePla
 import { optionsSectionHeroWithSignInButton, optionsSectionHeroWithImage } from './sectionHero.consts';
 
 export const SectionHero = async () => {
+  const divContainer_id = 'sectionHero';
   const translateDownHandler = (delay?: keyof typeof DELAY) => {
-    return optionsTransition({ transition: 'translateDown', duration: 1000, delay: delay,});
+    return optionsTransition({ transition: 'translateDown', duration: 1000, delay: delay });
   };
+  const optionsFadeIn = optionsTransition({
+    transition: 'fadeIn',
+    duration: 1000,
+    delay: 500,
+    rate: 3,
+  });
+  const optionsScaleCenterSm = optionsTransition({
+    transition: 'scaleCenterSm',
+    duration: 700,
+    delay: 300,
+    rate: 3,
+  });
 
   return (
     <div>
       <div className='relative isolate pt-10'>
         <div className='py-24 sm:py-32 lg:pb-40'>
-          <DivContainerWithRef className='mx-auto max-w-7xl px-6 lg:px-8 bg-red-300'>
+          <DivContainerWithRef
+            _id={divContainer_id}
+            className='mx-auto max-w-7xl px-6 lg:px-8 bg-red-300'
+          >
             <SmoothTransition options={translateDownHandler()}>
               <div className='mx-auto max-w-2xl text-center'>
                 <div className='mb-2 text-4xl font-bold text-slate-800 will-change-transform sm:text-6xl'>
@@ -54,12 +70,8 @@ export const SectionHero = async () => {
               <div className='flex justify-center'>
                 <div className='relative mt-16 flow-root max-w-[60rem] sm:mt-24'>
                   <SmoothTransitionWithDivRef
-                    options={optionsTransition({
-                      transition: 'fadeIn',
-                      duration: 1000,
-                      delay: 500,
-                      rate: 3,
-                    })}
+                    _id={divContainer_id}
+                    options={optionsFadeIn}
                   >
                     <div
                       className={classNames(
@@ -70,12 +82,8 @@ export const SectionHero = async () => {
                     />
                   </SmoothTransitionWithDivRef>
                   <SmoothTransitionWithDivRef
-                    options={optionsTransition({
-                      transition: 'scaleCenterSm',
-                      duration: 700,
-                      delay: 300,
-                      rate: 3,
-                    })}
+                    _id={divContainer_id}
+                    options={optionsScaleCenterSm}
                   >
                     <div className='mx-auto flex w-full max-w-[60rem] flex-row items-center justify-center rounded-xl border-none ring-0 lg:rounded-2xl'>
                       <ImageWithRemotePlaceholder options={optionsSectionHeroWithImage} />

--- a/app/components/ui/container/container.states.ts
+++ b/app/components/ui/container/container.states.ts
@@ -1,4 +1,13 @@
-import { atom } from 'jotai';
+import { PrimitiveAtom, atom } from 'jotai';
+import { atomFamily } from 'jotai/utils';
 import { RefObject } from 'react';
+import { TypesContainer } from './container.types';
 
-export const atomDivRef = atom<RefObject<HTMLDivElement> | null>(null);
+export const atomDivRef = atomFamily<TypesContainer['_id'], PrimitiveAtom<RefObject<HTMLDivElement> | null>>(
+  () => atom<RefObject<HTMLDivElement> | null>(null),
+);
+
+// remove the atom from the cache by removing params after one expiration
+const expiration = 3600000; // one hour
+
+atomDivRef.setShouldRemove((createdAt) => Date.now() - createdAt > expiration);

--- a/app/components/ui/container/container.types.ts
+++ b/app/components/ui/container/container.types.ts
@@ -1,4 +1,9 @@
 import { TypesClassNames } from '@/components/components.types';
 import { ReactNode } from 'react';
 
-export type PropsDivContainer = { children: ReactNode } & Partial<Pick<TypesClassNames, 'className'>>;
+export interface TypesContainer {
+  _id: string | null;
+}
+
+export type PropsDivContainer = { children: ReactNode } & Pick<TypesContainer, '_id'> &
+  Partial<Pick<TypesClassNames, 'className'>>;

--- a/app/components/ui/container/divContainerWithRef/__test__/divContainer.test.tsx
+++ b/app/components/ui/container/divContainerWithRef/__test__/divContainer.test.tsx
@@ -4,11 +4,19 @@ import { PropsDivContainer } from '../../container.types';
 import { screen } from '@testing-library/react';
 
 describe('DivContainerWithRef', () => {
-  const renderWithDivContainer = ({ className, children }: PropsDivContainer) =>
-    render(<DivContainerWithRef className={className}>{children}</DivContainerWithRef>);
+  const renderWithDivContainer = ({ className, children, _id }: PropsDivContainer) =>
+    render(
+      <DivContainerWithRef
+        _id={_id}
+        className={className}
+      >
+        {children}
+      </DivContainerWithRef>,
+    );
 
   it('should render the children elements and className', () => {
     const { container } = renderWithDivContainer({
+      _id: null,
       className: 'bg-red-400',
       children: <div>divContainer-test</div>,
     });

--- a/app/components/ui/container/divContainerWithRef/index.tsx
+++ b/app/components/ui/container/divContainerWithRef/index.tsx
@@ -5,9 +5,9 @@ import { PropsDivContainer } from '../container.types';
 import { useSetAtom } from 'jotai';
 import { atomDivRef } from '../container.states';
 
-export const DivContainerWithRef = ({ children, className }: PropsDivContainer) => {
+export const DivContainerWithRef = ({ children, className, _id = null }: PropsDivContainer) => {
   const divRef = useRef<HTMLDivElement | null>(null);
-  const setDivRef = useSetAtom(atomDivRef);
+  const setDivRef = useSetAtom(atomDivRef(_id));
 
   useEffect(() => {
     setDivRef(divRef);

--- a/app/components/ui/transition/smoothTransition/smoothTransition.types.ts
+++ b/app/components/ui/transition/smoothTransition/smoothTransition.types.ts
@@ -6,6 +6,7 @@ import {
   TypesTransitionProperties,
   TypesTransitionDelay,
 } from '../transition.types';
+import { TypesContainer } from '@/container/container.types';
 
 export type PropsSmoothTransition = {
   children: ReactNode;
@@ -20,7 +21,8 @@ export type PropsSmoothTransition = {
   >;
 } & Partial<{ scrollRef: RefObject<HTMLElement> | null }>;
 
-export type PropsSmoothTransitionWithDivRef = Omit<PropsSmoothTransition, 'scrollRef'>;
+export type PropsSmoothTransitionWithDivRef = Omit<PropsSmoothTransition, 'scrollRef'> &
+  Pick<TypesContainer, '_id'>;
 
 export type TypesDataTransition = Record<TypesTransitionProperties, string> & {
   type: TypesTransitionTypes;

--- a/app/components/ui/transition/smoothTransitionWithDivRef/__test__/smoothTransitionWithDivRef.test.tsx
+++ b/app/components/ui/transition/smoothTransitionWithDivRef/__test__/smoothTransitionWithDivRef.test.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from 'react';
 
 describe('SmoothTransitionWithDivRef', () => {
   const renderWithSmoothTransitionWithDivRef = (children: ReactNode) =>
-    render(<SmoothTransitionWithDivRef>{children}</SmoothTransitionWithDivRef>);
+    render(<SmoothTransitionWithDivRef _id={null}>{children}</SmoothTransitionWithDivRef>);
 
   it('should render the child elements', async () => {
     const { container } = renderWithSmoothTransitionWithDivRef(<div>smoothTransition-test</div>);

--- a/app/components/ui/transition/smoothTransitionWithDivRef/index.tsx
+++ b/app/components/ui/transition/smoothTransitionWithDivRef/index.tsx
@@ -5,8 +5,12 @@ import { atomDivRef } from '@/container/container.states';
 import { SmoothTransition } from '../smoothTransition';
 import { PropsSmoothTransitionWithDivRef } from '../smoothTransition/smoothTransition.types';
 
-export const SmoothTransitionWithDivRef = ({ children, options }: PropsSmoothTransitionWithDivRef) => {
-  const divRef = useAtomValue(atomDivRef);
+export const SmoothTransitionWithDivRef = ({
+  children,
+  options,
+  _id = null,
+}: PropsSmoothTransitionWithDivRef) => {
+  const divRef = useAtomValue(atomDivRef(_id));
 
   return (
     <SmoothTransition

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -4,7 +4,7 @@ module.exports = {
   jsxSingleQuote: true,
   tabWidth: 2,
   semi: true,
-  printWidth: 110,
+  printWidth: 120,
   tailwindConfig: './tailwind.config.ts',
   singleAttributePerLine: true,
   trailingComma: 'all',


### PR DESCRIPTION
Transition atomDivRef to `atomFamily`, generating distinct cache atoms with new parameters. A cache expiration policy is in place with a 1-hour timestamp to curb memory leaks from infinite atom creation.

Changes are applied to DivContainerWithRef and
SmoothTransitionWithDivRef, both now use _id string for specific atomFamily activation.

Rendering performance and efficiency improvements are noted.

Modify Prettier settings by updating printWidth to 120 from 110.