### PR TITLE
feat: Implement SectionStartToday in appRouter

### DIFF
--- a/app/components/section/section.consts.ts
+++ b/app/components/section/section.consts.ts
@@ -26,3 +26,10 @@ export const sectionContentTextContents = {
       "Today's Focus efficiently determines the ideal number of to-dos for you. As you consistently complete to-dos, the process adjusts and assigns more or fewer to-dos base on your completion rate.",
   },
 };
+
+export const sectionStartTodayContents = {
+  title: 'Achieve More with Less.',
+  subTitle: 'Get started today.',
+  content:
+    'Elevate your efficiency and unlock the key to accomplishing more with our productivity-boosting app.',
+};

--- a/app/components/section/sectionHero/__test__/sectionHero.test.tsx
+++ b/app/components/section/sectionHero/__test__/sectionHero.test.tsx
@@ -3,8 +3,8 @@ import { render, screen } from '@testing-library/react';
 import { SectionHero } from '..';
 import { ReactNode } from 'react';
 import { getResolvedComponent } from '@/lib/utils/test.utils';
-import { optionsSectionHeroWithSignInButton } from '../sectionHero.consts';
 import { TypesButtons } from '@/button/button.types';
+import { optionsSignInButton } from '../sectionHero.consts';
 
 jest.mock('@/transition/smoothTransitionWithDivRef', () => ({
   SmoothTransitionWithDivRef: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -37,8 +37,7 @@ describe('SectionHero', () => {
   it('should render the signInButton and link button', async () => {
     await renderAsyncComponent();
 
-    const signInButtonName =
-      optionsSectionHeroWithSignInButton.signInButtonName as TypesButtons['signInButtonName'];
+    const signInButtonName = optionsSignInButton.signInButtonName as TypesButtons['signInButtonName'];
     const signInButton = await screen.findByText(signInButtonName);
     const linkButton = await screen.findByText('Learn more');
 

--- a/app/components/section/sectionHero/index.tsx
+++ b/app/components/section/sectionHero/index.tsx
@@ -10,7 +10,7 @@ import { PATH_HOME } from '@/lib/consts/assertion.consts';
 import { STYLE_BLUR_GRADIENT_R_LG } from '@/lib/consts/style.consts';
 import { classNames } from '@/lib/utils/misc.utils';
 import { ImageWithRemotePlaceholder } from '@/components/next/imageWithRemotePlaceholder';
-import { optionsSectionHeroWithSignInButton, optionsSectionHeroWithImage } from './sectionHero.consts';
+import { optionsSignInButton, optionsSectionHeroWithImage } from './sectionHero.consts';
 
 export const SectionHero = async () => {
   const divContainer_id = 'sectionHero';
@@ -57,7 +57,7 @@ export const SectionHero = async () => {
             </SmoothTransition>
             <SmoothTransition options={translateDownHandler(700)}>
               <div className='mt-10 flex items-center justify-center gap-x-6'>
-                <SignInButton options={optionsSectionHeroWithSignInButton} />
+                <SignInButton options={optionsSignInButton} />
                 <Link
                   className='text-sm font-semibold leading-6 text-gray-900'
                   href={PATH_HOME['features']}

--- a/app/components/section/sectionHero/sectionHero.consts.ts
+++ b/app/components/section/sectionHero/sectionHero.consts.ts
@@ -3,7 +3,7 @@ import { TypesImageWithRemotePlaceholder } from '@/components/next/imageWithRemo
 import { PATH_IMAGE } from '@/lib/consts/assertion.consts';
 import { STYLE_BUTTON_NORMAL_BLUE } from '@data/stylePreset';
 
-export const optionsSectionHeroWithSignInButton: Partial<TypesOptionsButtonWithTooltip> = {
+export const optionsSignInButton: Partial<TypesOptionsButtonWithTooltip> = {
   signInButtonName: 'Get started',
   className: STYLE_BUTTON_NORMAL_BLUE,
 };

--- a/app/components/section/sectionStartToday/__test__/sectionStartToday.test.tsx
+++ b/app/components/section/sectionStartToday/__test__/sectionStartToday.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { SectionStartToday } from '..';
+import { sectionStartTodayContents } from '@/section/section.consts';
+import { optionsSignInButton } from '@/section/sectionHero/sectionHero.consts';
+import { ReactNode } from 'react';
+
+jest.mock('@/transition/smoothTransitionWithDivRef', () => ({
+  SmoothTransitionWithDivRef: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+describe('SectionStartToday', () => {
+  const renderWithSectionStartToday = () => render(<SectionStartToday />);
+
+  it('should render the gradients element properly', async () => {
+    const { container } = renderWithSectionStartToday();
+    const gradientElement = await screen.findByTestId('gradient-testid');
+
+    expect(container).toBeInTheDocument();
+    expect(gradientElement).toBeInTheDocument();
+  });
+
+  it('should render the content texts properly', () => {
+    renderWithSectionStartToday();
+
+    Object.values(sectionStartTodayContents).forEach(async (value) => {
+      await waitFor(() => {
+        const text = screen.queryByText(value);
+        expect(text).toBeInTheDocument();
+      });
+    });
+  });
+
+  it('should render the signInButton', async () => {
+    renderWithSectionStartToday();
+    const signInButtonText = optionsSignInButton.signInButtonName as string;
+    const signInButton = await screen.findByText(signInButtonText);
+
+    expect(signInButton).toBeInTheDocument();
+  });
+});

--- a/app/components/section/sectionStartToday/index.tsx
+++ b/app/components/section/sectionStartToday/index.tsx
@@ -1,0 +1,69 @@
+import { DivContainerWithRef } from '@/container/divContainerWithRef';
+import { STYLE_BLUR_GRADIENT_R_LG } from '@/lib/consts/style.consts';
+import { classNames } from '@/lib/utils/misc.utils';
+import { SmoothTransition } from '@/transition/smoothTransition';
+import { SmoothTransitionWithDivRef } from '@/transition/smoothTransitionWithDivRef';
+import { DELAY } from '@/transition/transition.consts';
+import { optionsTransition } from '@/transition/transition.utils';
+import { sectionStartTodayContents } from '../section.consts';
+import { SignInButton } from '@/button/signInButton';
+import { optionsSignInButton } from '../sectionHero/sectionHero.consts';
+
+export const SectionStartToday = () => {
+  const divContainer_id = 'sectionStartToday';
+  const transitionHandler = (delay?: keyof typeof DELAY) => {
+    return optionsTransition({ transition: 'translateDown', duration: 1000, delay: delay, rate: 0.7 });
+  };
+
+  return (
+    <SmoothTransition>
+      <div className='py-18 relative isolate my-10 px-6 md:mt-12 md:py-24 lg:px-8'>
+        <div
+          className='absolute inset-x-0 top-0 -z-10 flex transform-gpu justify-center overflow-hidden blur-3xl'
+          aria-hidden='true'
+        >
+          <SmoothTransition options={transitionHandler()}>
+            <div
+              className={classNames(
+                'custom-clip-path aspect-[2500/600] w-[70rem] flex-none opacity-40 will-change-transform md:aspect-[1400/600]',
+                STYLE_BLUR_GRADIENT_R_LG,
+              )}
+              data-testid='gradient-testid'
+            />
+          </SmoothTransition>
+        </div>
+        <DivContainerWithRef
+          _id={divContainer_id}
+          className='mx-auto max-w-2xl text-center'
+        >
+          <SmoothTransitionWithDivRef
+            _id={divContainer_id}
+            options={transitionHandler()}
+          >
+            <h2 className='text-3xl font-bold tracking-tight text-slate-800 will-change-transform sm:text-4xl'>
+              {sectionStartTodayContents.title}
+              <br />
+              {sectionStartTodayContents.subTitle}
+            </h2>
+          </SmoothTransitionWithDivRef>
+          <SmoothTransitionWithDivRef
+            _id={divContainer_id}
+            options={transitionHandler(300)}
+          >
+            <p className='mx-auto mt-6 max-w-xl text-lg leading-8 text-slate-600 will-change-transform'>
+              {sectionStartTodayContents.content}
+            </p>
+          </SmoothTransitionWithDivRef>
+          <SmoothTransitionWithDivRef
+            _id={divContainer_id}
+            options={transitionHandler(700)}
+          >
+            <div className='mt-10 flex items-center justify-center will-change-transform'>
+              <SignInButton options={optionsSignInButton} />
+            </div>
+          </SmoothTransitionWithDivRef>
+        </DivContainerWithRef>
+      </div>
+    </SmoothTransition>
+  );
+};


### PR DESCRIPTION
Implement SectionStartToday, functioning as a transitional component from HomeStartToday. Renamed `optionsSectionHeroSignIn` to `optionsSignInButton` for reusability across components, including SectionStartToday.

Supplement with integration tests for verifying child elements and component rendering.