### PR TITLE
feat: Implement SvgIcon in appRouter

### DIFF
--- a/app/_components/ui/icon/icon.consts.ts
+++ b/app/_components/ui/icon/icon.consts.ts
@@ -1,0 +1,5 @@
+export type VIEWBOX = (typeof VIEWBOX)[keyof typeof VIEWBOX];
+export const VIEWBOX = {
+  24: '0 0 24 24',
+  96: '0 96 960 960',
+} as const;

--- a/app/_components/ui/icon/icon.types.ts
+++ b/app/_components/ui/icon/icon.types.ts
@@ -1,0 +1,15 @@
+import { TypesClassNames } from '@/_components/components.types';
+import { VIEWBOX } from './icon.consts';
+
+export interface TypesSvgAttributes {
+  path: string;
+  height: string | number;
+  width: string | number;
+  viewBox: VIEWBOX;
+  isAriaHidden: boolean;
+  testId: string;
+}
+
+type ExtendedSvgAttributes = Partial<TypesSvgAttributes & Pick<TypesClassNames, 'className'>>;
+
+export type PropsSvgIcon = Partial<{ options: ExtendedSvgAttributes }>;

--- a/app/_components/ui/icon/svgIcon/__test__/svgIcon.test.tsx
+++ b/app/_components/ui/icon/svgIcon/__test__/svgIcon.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import { SvgIcon } from '..';
+
+describe('SvgIcon', () => {
+  it('should render the svgIcon component', () => {
+    render(<SvgIcon />);
+    const svgIconWithTestId = screen.getByTestId('svgIcon-testid');
+
+    expect(svgIconWithTestId).toBeInTheDocument();
+  });
+});

--- a/app/_components/ui/icon/svgIcon/index.tsx
+++ b/app/_components/ui/icon/svgIcon/index.tsx
@@ -1,0 +1,27 @@
+import { VIEWBOX } from '../icon.consts';
+import { PropsSvgIcon } from '../icon.types';
+
+export const SvgIcon = ({ options = {} }: PropsSvgIcon) => {
+  const {
+    isAriaHidden = true,
+    height = '24',
+    width = '24',
+    viewBox = VIEWBOX['24'],
+    className = 'h-5 w-5 fill-gray-500 hover:fill-gray-700',
+    testId = 'svgIcon-testid',
+  } = options;
+
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      aria-hidden={isAriaHidden}
+      height={height}
+      width={width}
+      viewBox={viewBox}
+      className={className}
+      data-testid={testId}
+    >
+      <path d={options.path} />
+    </svg>
+  );
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,13 +21,14 @@ const customJestConfig = {
   testEnvironment: 'jest-environment-jsdom',
   moduleNameMapper: {
     //app router
+    '^@/section/(.*)$': ['<rootDir>/app/_components/section/$1'],
+    '^@/next/(.*)$': ['<rootDir>/app/_components/next/$1'],
     '^@/button/(.*)$': ['<rootDir>/app/_components/ui/button/$1'],
     '^@/tooltip/(.*)$': ['<rootDir>/app/_components/ui/tooltip/$1'],
     '^@/transition/(.*)$': ['<rootDir>/app/_components/ui/transition/$1'],
     '^@/container/(.*)$': ['<rootDir>/app/_components/ui/container/$1'],
+    '^@/icon/(.*)$': ['<rootDir>/app/_components/ui/icon/$1'],
     '^@/ui/(.*)$': ['<rootDir>/app/_components/ui/$1'],
-    '^@/section/(.*)$': ['<rootDir>/app/_components/section/$1'],
-    '^@/next/(.*)$': ['<rootDir>/app/_components/next/$1'],
     '^@/_components/(.*)$': ['<rootDir>/app/_components/$1'],
     '^@/_lib/(.*)$': ['<rootDir>/app/_lib/$1'],
     '^@/(.*)$': ['<rootDir>/app/$1'],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,12 +3,13 @@
     "baseUrl": ".",
     "paths": {
       //app Router
+      "@/section/*": ["app/_components/section/*"],
+      "@/next/*": ["app/_components/next/*"],
       "@/button/*": ["app/_components/ui/button/*"],
       "@/tooltip/*": ["app/_components/ui/tooltip/*"],
       "@/transition/*": ["app/_components/ui/transition/*"],
       "@/container/*": ["app/_components/ui/container/*"],
-      "@/section/*": ["app/_components/section/*"],
-      "@/next/*": ["app/_components/next/*"],
+      "@/icon/*": ["app/_components/ui/icon/*"],
       "@/ui/*": ["app/_components/ui/*"],
       "@/_components/*": ["app/_components/*"],
       "@/_lib/*": ["app/_lib/*"],


### PR DESCRIPTION
PageRouter's SvgIcon component has been refashioned under appRouter with identical nomenclature. A rudimentary unit test verifying its correct rendering accompanies the change. The fresh SvgIcon component, now being a server component, has eliminated React.memo due to insufficient benefits it offers in this context.

In conjunction, alias paths for tsconfig and jest.config have been instituted, along with icon.consts and icon.types requisite for SvgIcon.