### PR TITLE
refactor: Update the appRouter Tooltip component

### DIFF
--- a/app/_components/ui/tooltip/index.tsx
+++ b/app/_components/ui/tooltip/index.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { Portal } from '@headlessui/react';
-import { classNames } from '@stateLogics/utils';
 import { memo } from 'react';
 import { isMobile } from 'react-device-detect';
 import { usePopperTooltip } from 'react-popper-tooltip';
 import { PropsTooltip } from './tooltip.types';
+import { mergeClasses } from '@/_lib/utils/misc.utils';
 
-export const Tooltip = memo(({ options = {}, children }: PropsTooltip) => {
+export const Tooltip = memo(({ options = {}, className, children }: PropsTooltip) => {
   const { getTooltipProps, setTooltipRef, setTriggerRef, visible } = usePopperTooltip({
     trigger: options.trigger ?? 'hover',
     delayShow: options.delayShow ?? 50,
@@ -22,8 +22,8 @@ export const Tooltip = memo(({ options = {}, children }: PropsTooltip) => {
   return (
     <>
       <span
-        className={classNames(options.container)}
         ref={setTriggerRef}
+        className={className}
       >
         {children}
       </span>
@@ -34,14 +34,14 @@ export const Tooltip = memo(({ options = {}, children }: PropsTooltip) => {
               <div
                 ref={setTooltipRef}
                 {...getTooltipProps()}
-                className={classNames(
+                className={mergeClasses(
                   options.tooltip &&
                     'z-50 max-w-[15rem] truncate whitespace-nowrap rounded-lg bg-gray-700 p-2 text-xs text-white opacity-90',
                 )}
               >
                 <span>{options.tooltip}</span>
                 <kbd
-                  className={classNames(
+                  className={mergeClasses(
                     options.kbd &&
                       'ml-2 h-6 rounded border-x border-y py-px px-1.5 font-sans tracking-normal subpixel-antialiased',
                   )}

--- a/app/_components/ui/tooltip/tooltip.types.ts
+++ b/app/_components/ui/tooltip/tooltip.types.ts
@@ -1,6 +1,7 @@
 import { ReactElement, ReactNode } from 'react';
 import { TriggerType } from 'react-popper-tooltip';
 import { Placement } from '@popperjs/core';
+import { TypesClassNames } from '@/_components/components.types';
 
 export interface TypesTooltips {
   tooltip: string | ReactElement | null;
@@ -11,9 +12,12 @@ export interface TypesTooltips {
   placement: Placement;
   isVisible: boolean;
   isCloseOnTriggerHidden: boolean;
-  container: string;
 }
 
-export type PropsTooltip = { options?: Partial<TypesTooltips> } & {
+export type PropsTooltip = Partial<
+  {
+    options: Partial<TypesTooltips>;
+  } & Pick<TypesClassNames, 'className'>
+> & {
   children: ReactNode;
 };


### PR DESCRIPTION
Update the appRouter's Tooltip component with mergeClasses utility functions by replacing the deprecating classNames utility function.