### PR TITLE
refactor: Rename object props to configs

### DIFF
--- a/app/_components/next/imageWithRemotePlaceholder/__test__/imageWithRemotePlaceholder.test.tsx
+++ b/app/_components/next/imageWithRemotePlaceholder/__test__/imageWithRemotePlaceholder.test.tsx
@@ -3,12 +3,12 @@ import { ImageWithRemotePlaceholder } from '..';
 import { TypesImageWithRemotePlaceholder } from '../imageWithRemotePlaceholder.types';
 import { PATH_IMAGE } from '@/_lib/consts/assertion.consts';
 
-type typesForTest = { options: Pick<TypesImageWithRemotePlaceholder, 'width' | 'height' | 'src' | 'alt'> };
+type typesForTest = { configs: Pick<TypesImageWithRemotePlaceholder, 'width' | 'height' | 'src' | 'alt'> };
 
 jest.mock('@/_components/next/imageWithRemotePlaceholder', () => ({
-  ImageWithRemotePlaceholder: ({ options }: typesForTest) => (
+  ImageWithRemotePlaceholder: ({ configs }: typesForTest) => (
     <>
-      {Object.entries(options).map(([key, value]) => (
+      {Object.entries(configs).map(([key, value]) => (
         <div
           key={key}
           data-testid={`mockImage-${key}`}
@@ -28,11 +28,11 @@ const mockImageOptions: TypesImageWithRemotePlaceholder = {
 };
 
 describe('ImageWithRemotePlaceholder', () => {
-  const renderWithImageWithRemotePlaceholder = ({ options }: typesForTest) =>
-    render(<ImageWithRemotePlaceholder options={options} />);
+  const renderWithImageWithRemotePlaceholder = ({ configs }: typesForTest) =>
+    render(<ImageWithRemotePlaceholder configs={configs} />);
 
   it('should properly passes the option props', async () => {
-    const { container } = renderWithImageWithRemotePlaceholder({ options: mockImageOptions });
+    const { container } = renderWithImageWithRemotePlaceholder({ configs: mockImageOptions });
 
     expect(container).toBeInTheDocument();
     Object.entries(mockImageOptions).forEach(([key, value]) => {

--- a/app/_components/next/imageWithRemotePlaceholder/imageWithRemotePlaceholder.types.ts
+++ b/app/_components/next/imageWithRemotePlaceholder/imageWithRemotePlaceholder.types.ts
@@ -3,4 +3,4 @@ import { TypesNextImage } from '../next.types';
 export type TypesImageWithRemotePlaceholder = Pick<TypesNextImage, 'src' | 'width' | 'height' | 'alt'> &
   Partial<Omit<TypesNextImage, 'src' | 'width' | 'height' | 'alt'>>;
 
-export type PropsImageWithRemotePlaceholder = { options: TypesImageWithRemotePlaceholder };
+export type PropsImageWithRemotePlaceholder = { configs: TypesImageWithRemotePlaceholder };

--- a/app/_components/next/imageWithRemotePlaceholder/index.tsx
+++ b/app/_components/next/imageWithRemotePlaceholder/index.tsx
@@ -3,10 +3,10 @@ import getBase64FromImageURL from '@/_lib/utils/base64Converter.utils';
 import Image from 'next/image';
 import { PropsImageWithRemotePlaceholder } from './imageWithRemotePlaceholder.types';
 
-export const ImageWithRemotePlaceholder = async ({ options }: PropsImageWithRemotePlaceholder) => {
-  const { sizes = '100vw', priority = true } = options;
+export const ImageWithRemotePlaceholder = async ({ configs }: PropsImageWithRemotePlaceholder) => {
+  const { sizes = '100vw', priority = true } = configs;
   const remoteImageHandler = async () => {
-    if (options.placeholder === 'blur') return await getBase64FromImageURL(options.src);
+    if (configs.placeholder === 'blur') return await getBase64FromImageURL(configs.src);
     return;
   };
   const remoteImageBlurDataURL = await remoteImageHandler();
@@ -14,16 +14,16 @@ export const ImageWithRemotePlaceholder = async ({ options }: PropsImageWithRemo
   return (
     <>
       <Image
-        width={options.width}
-        height={options.height}
-        className={options.className}
-        quality={options.quality}
-        src={options.src}
-        fill={options.fill}
-        alt={options.alt}
-        placeholder={options.placeholder}
-        style={options.style}
-        loading={options.loading}
+        width={configs.width}
+        height={configs.height}
+        className={configs.className}
+        quality={configs.quality}
+        src={configs.src}
+        fill={configs.fill}
+        alt={configs.alt}
+        placeholder={configs.placeholder}
+        style={configs.style}
+        loading={configs.loading}
         blurDataURL={remoteImageBlurDataURL}
         sizes={sizes}
         priority={priority}

--- a/app/_components/section/section.consts.ts
+++ b/app/_components/section/section.consts.ts
@@ -1,18 +1,18 @@
-export const sectionHeroContents = {
-  title: 'Simplify your life',
-  subTitle: 'Automate your tasks',
-  content:
-    'Focus on your work more and manage your to-dos less. Enhance your efficiency and improve your productivity.',
-};
+import { TypesSectionContents, TypesContents } from './section.types';
 
-export const sectionHeaderContents = {
-  title: 'Simplify your works',
-  subTitle: 'Manage less work better',
-  content:
-    'Unburden yourself from managing time-consuming tasks by allowing app to seamlessly choose the most suitable to-dos for you.',
-};
-
-export const sectionContentTextContents = {
+export const sectionContents: TypesSectionContents<TypesContents> = {
+  hero: {
+    title: 'Simplify your life',
+    subTitle: 'Automate your tasks',
+    content:
+      'Focus on your work more and manage your to-dos less. Enhance your efficiency and improve your productivity.',
+  },
+  headerContent: {
+    title: 'Simplify your works',
+    subTitle: 'Manage less work better',
+    content:
+      'Unburden yourself from managing time-consuming tasks by allowing app to seamlessly choose the most suitable to-dos for you.',
+  },
   spotlight: {
     title: 'Spotlight your to-dos',
     subTitle: "View your to-dos that are intelligently and automatically selected in Today's Focus.",
@@ -25,11 +25,10 @@ export const sectionContentTextContents = {
     content:
       "Today's Focus efficiently determines the ideal number of to-dos for you. As you consistently complete to-dos, the process adjusts and assigns more or fewer to-dos base on your completion rate.",
   },
-};
-
-export const sectionStartTodayContents = {
-  title: 'Achieve More with Less.',
-  subTitle: 'Get started today.',
-  content:
-    'Elevate your efficiency and unlock the key to accomplishing more with our productivity-boosting app.',
+  startToday: {
+    title: 'Achieve More with Less.',
+    subTitle: 'Get started today.',
+    content:
+      'Elevate your efficiency and unlock the key to accomplishing more with our productivity-boosting app.',
+  },
 };

--- a/app/_components/section/section.types.ts
+++ b/app/_components/section/section.types.ts
@@ -1,5 +1,14 @@
 import { TypesContainer } from '@/container/container.types';
 
 type TypesSectionContentText = 'title' | 'subTitle' | 'content';
+export type TypesContents = Record<TypesSectionContentText, string>;
 
-export type PropsSectionContentText = Record<TypesSectionContentText, string> & Pick<TypesContainer, '_id'>;
+export type PropsSectionContentText = Partial<TypesContents> & Pick<TypesContainer, '_id'>;
+
+export type TypesSectionContents<T> = {
+  hero: T;
+  headerContent: T;
+  spotlight: T;
+  overload: T;
+  startToday: T;
+};

--- a/app/_components/section/sectionContent/__test__/sectionContent.test.tsx
+++ b/app/_components/section/sectionContent/__test__/sectionContent.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { SectionContent } from '..';
-import { sectionContentTextContents } from '@/section/section.consts';
 import { ReactNode } from 'react';
+import { sectionContents } from '@/section/section.consts';
 
 jest.mock('@/_components/next/imageWithRemotePlaceholder', () => ({
   ImageWithRemotePlaceholder: () => <div data-testid='mockImage-testid' />,
@@ -17,7 +17,7 @@ describe('SectionContent', () => {
   it('should render the content texts of spotlight and overload', () => {
     const { container } = renderWithSectionContent();
 
-    Object.values(sectionContentTextContents).forEach((contentObjects) => {
+    Object.values(sectionContents).forEach((contentObjects) => {
       Object.values(contentObjects).forEach(async (value) => {
         await waitFor(() => {
           const text = screen.queryByText(value);

--- a/app/_components/section/sectionContent/index.tsx
+++ b/app/_components/section/sectionContent/index.tsx
@@ -1,13 +1,13 @@
 import { SmoothTransition } from '@/transition/smoothTransition';
 import { DELAY } from '@/transition/transition.consts';
-import { optionsTransition } from '@/transition/transition.utils';
+import { configsTransition } from '@/transition/transition.utils';
 import { SectionContentText } from './sectionContentText';
-import { sectionContentTextContents } from '../section.consts';
 import { DivContainerWithRef } from '@/container/divContainerWithRef';
 import { SmoothTransitionWithDivRef } from '@/transition/smoothTransitionWithDivRef';
 import { PATH_IMAGE } from '@/_lib/consts/assertion.consts';
 import { ImageWithRemotePlaceholder } from '@/next/imageWithRemotePlaceholder';
 import { mergeClasses } from '@/_lib/utils/misc.utils';
+import { sectionContents } from '../section.consts';
 
 const styleImageWrapper = 'relative w-80 h-auto rounded-xl shadow-2xl shadow-blue-500/40 ring-purple-300/10';
 const styleImage = 'h-auto w-full rounded-xl drop-shadow-2xl';
@@ -35,7 +35,7 @@ export const SectionContent = () => {
   const divContainerSpotlight_id = 'sectionContent_spotlight';
   const divContainerOverload_id = 'sectionContent_overload';
   const transitionHandler = (delay: keyof typeof DELAY) => {
-    return optionsTransition({ transition: 'scaleCenterSm', duration: 700, delay: delay, rate: 1.5 });
+    return configsTransition({ transition: 'scaleCenterSm', duration: 700, delay: delay, rate: 1.5 });
   };
 
   return (
@@ -44,9 +44,9 @@ export const SectionContent = () => {
         <div className='md:min-w-3/4 grid w-full max-w-6xl grid-cols-1 items-center justify-items-center gap-10 md:grid-cols-2'>
           <SectionContentText
             _id={divContainerSpotlight_id}
-            title={sectionContentTextContents.spotlight.title}
-            subTitle={sectionContentTextContents.spotlight.subTitle}
-            content={sectionContentTextContents.spotlight.content}
+            title={sectionContents.spotlight.title}
+            subTitle={sectionContents.spotlight.subTitle}
+            content={sectionContents.spotlight.content}
           />
           <DivContainerWithRef
             _id={divContainerSpotlight_id}
@@ -54,10 +54,10 @@ export const SectionContent = () => {
           >
             <SmoothTransitionWithDivRef
               _id={divContainerSpotlight_id}
-              options={transitionHandler(500)}
+              configs={transitionHandler(500)}
             >
               <div className={mergeClasses(styleImageWrapper, 'opacity-100')}>
-                <ImageWithRemotePlaceholder options={optionsImageSpotlight} />
+                <ImageWithRemotePlaceholder configs={optionsImageSpotlight} />
               </div>
             </SmoothTransitionWithDivRef>
           </DivContainerWithRef>
@@ -67,18 +67,18 @@ export const SectionContent = () => {
           >
             <SmoothTransitionWithDivRef
               _id={divContainerOverload_id}
-              options={transitionHandler(700)}
+              configs={transitionHandler(700)}
             >
               <div className={mergeClasses(styleImageWrapper, 'opacity-100')}>
-                <ImageWithRemotePlaceholder options={optionsImageOverload} />
+                <ImageWithRemotePlaceholder configs={optionsImageOverload} />
               </div>
             </SmoothTransitionWithDivRef>
           </DivContainerWithRef>
           <SectionContentText
             _id={divContainerOverload_id}
-            title={sectionContentTextContents.overload.title}
-            subTitle={sectionContentTextContents.overload.subTitle}
-            content={sectionContentTextContents.overload.content}
+            title={sectionContents.overload.title}
+            subTitle={sectionContents.overload.subTitle}
+            content={sectionContents.overload.content}
           />
         </div>
       </div>

--- a/app/_components/section/sectionContent/sectionContentText/__test__/sectionContentText.test.tsx
+++ b/app/_components/section/sectionContent/sectionContentText/__test__/sectionContentText.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { SectionContentText } from '..';
 import { PropsSectionContentText } from '@/section/section.types';
-import { sectionContentTextContents } from '@/section/section.consts';
+import { sectionContents } from '@/section/section.consts';
 
 describe('SectionContentText', () => {
   const renderWithSectionContentText = ({ title, subTitle, content, _id }: PropsSectionContentText) =>
@@ -17,11 +17,11 @@ describe('SectionContentText', () => {
   it('should render the props titles properly', () => {
     const { container } = renderWithSectionContentText({
       _id: null,
-      title: sectionContentTextContents.spotlight.title,
-      subTitle: sectionContentTextContents.spotlight.subTitle,
-      content: sectionContentTextContents.spotlight.content,
+      title: sectionContents.spotlight.title,
+      subTitle: sectionContents.spotlight.subTitle,
+      content: sectionContents.spotlight.content,
     });
-    Object.values(sectionContentTextContents.spotlight).forEach(async (value) => {
+    Object.values(sectionContents.spotlight).forEach(async (value) => {
       await waitFor(() => {
         const text = screen.queryByText(value);
         expect(text).toBeInTheDocument();

--- a/app/_components/section/sectionContent/sectionContentText/index.tsx
+++ b/app/_components/section/sectionContent/sectionContentText/index.tsx
@@ -3,12 +3,12 @@ import { STYLE_BLUR_GRADIENT_R_ZR } from '@/_lib/consts/style.consts';
 import { PropsSectionContentText } from '@/section/section.types';
 import { SmoothTransitionWithDivRef } from '@/transition/smoothTransitionWithDivRef';
 import { DELAY } from '@/transition/transition.consts';
-import { optionsTransition } from '@/transition/transition.utils';
+import { configsTransition } from '@/transition/transition.utils';
 import { mergeClasses } from '@/_lib/utils/misc.utils';
 
 export const SectionContentText = ({ title, subTitle, content, _id = null }: PropsSectionContentText) => {
   const transitionHandler = (delay?: keyof typeof DELAY) => {
-    return optionsTransition({ transition: 'fadeIn', duration: 1000, delay: delay, rate: 0.8 });
+    return configsTransition({ transition: 'fadeIn', duration: 1000, delay: delay, rate: 0.8 });
   };
 
   return (
@@ -19,7 +19,7 @@ export const SectionContentText = ({ title, subTitle, content, _id = null }: Pro
       >
         <SmoothTransitionWithDivRef
           _id={_id}
-          options={transitionHandler()}
+          configs={transitionHandler()}
         >
           <p
             className={mergeClasses(
@@ -33,13 +33,13 @@ export const SectionContentText = ({ title, subTitle, content, _id = null }: Pro
       </DivContainerWithRef>
       <SmoothTransitionWithDivRef
         _id={_id}
-        options={transitionHandler(500)}
+        configs={transitionHandler(500)}
       >
         <p className='text-lg text-slate-800/80 opacity-100 will-change-transform md:text-xl'>{subTitle}</p>
       </SmoothTransitionWithDivRef>
       <SmoothTransitionWithDivRef
         _id={_id}
-        options={transitionHandler(700)}
+        configs={transitionHandler(700)}
       >
         <p className='text-base font-medium text-slate-800/80 opacity-100 will-change-transform'>{content}</p>
       </SmoothTransitionWithDivRef>

--- a/app/_components/section/sectionHeader/__test__/sectionHeader.test.tsx
+++ b/app/_components/section/sectionHeader/__test__/sectionHeader.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { ReactNode } from 'react';
 import { SectionHeader } from '..';
-import { sectionHeaderContents } from '@/section/section.consts';
+import { sectionContents } from '@/section/section.consts';
 
 jest.mock('@/transition/smoothTransitionWithDivRef', () => ({
   SmoothTransitionWithDivRef: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -21,7 +21,7 @@ describe('SectionHeader', () => {
   it('should render the text contents properly', () => {
     renderWithSectionHeader();
 
-    Object.values(sectionHeaderContents).forEach(async (value) => {
+    Object.values(sectionContents.headerContent).forEach(async (value) => {
       await waitFor(() => {
         const text = screen.queryByText(value);
         expect(text).toBeInTheDocument();

--- a/app/_components/section/sectionHeader/index.tsx
+++ b/app/_components/section/sectionHeader/index.tsx
@@ -2,16 +2,16 @@ import { DivContainerWithRef } from '@/container/divContainerWithRef';
 import { SmoothTransition } from '@/transition/smoothTransition';
 import { SmoothTransitionWithDivRef } from '@/transition/smoothTransitionWithDivRef';
 import { TRANSITION_TYPE } from '@/transition/transition.consts';
-import { optionsTransition } from '@/transition/transition.utils';
+import { configsTransition } from '@/transition/transition.utils';
 import { DELAY } from '@constAssertions/ui';
-import { sectionHeaderContents } from '../section.consts';
 import { STYLE_BLUR_GRADIENT_B_MD } from '@data/stylePreset';
 import { mergeClasses } from '@/_lib/utils/misc.utils';
+import { sectionContents } from '../section.consts';
 
 export const SectionHeader = () => {
   const divContainer_id = 'sectionHeader';
   const transitionHandler = (transition: TRANSITION_TYPE, delay?: keyof typeof DELAY) => {
-    return optionsTransition({ transition: transition ?? 'fadeIn', delay: delay });
+    return configsTransition({ transition: transition ?? 'fadeIn', delay: delay });
   };
   const optionsPoleTransition = { type: TRANSITION_TYPE['scaleY'], delay: DELAY['150'] };
 
@@ -25,15 +25,15 @@ export const SectionHeader = () => {
           <div className={'text-sm font-semibold uppercase tracking-widest text-gray-500'}>
             <SmoothTransitionWithDivRef
               _id={divContainer_id}
-              options={transitionHandler('fadeIn')}
+              configs={transitionHandler('fadeIn')}
             >
-              {sectionHeaderContents.title}
+              {sectionContents.headerContent.title}
             </SmoothTransitionWithDivRef>
           </div>
         </div>
         <SmoothTransitionWithDivRef
           _id={divContainer_id}
-          options={optionsPoleTransition}
+          configs={optionsPoleTransition}
         >
           <div className='relative flex h-[15rem] max-h-60 flex-row items-center justify-center'>
             <div
@@ -47,17 +47,19 @@ export const SectionHeader = () => {
       <div className='flex flex-col items-center justify-center px-5 text-center'>
         <SmoothTransitionWithDivRef
           _id={divContainer_id}
-          options={transitionHandler('fadeIn', 300)}
+          configs={transitionHandler('fadeIn', 300)}
         >
           <h1 className='my-5 h-full bg-slate-50 text-3xl font-bold tracking-normal text-slate-800 sm:text-5xl'>
-            {sectionHeaderContents.subTitle}
+            {sectionContents.headerContent.subTitle}
           </h1>
         </SmoothTransitionWithDivRef>
         <SmoothTransitionWithDivRef
           _id={divContainer_id}
-          options={transitionHandler('fadeIn', 500)}
+          configs={transitionHandler('fadeIn', 500)}
         >
-          <h2 className='max-w-2xl text-lg text-slate-600 sm:text-xl'>{sectionHeaderContents.content}</h2>
+          <h2 className='max-w-2xl text-lg text-slate-600 sm:text-xl'>
+            {sectionContents.headerContent.content}
+          </h2>
         </SmoothTransitionWithDivRef>
       </div>
     </SmoothTransition>

--- a/app/_components/section/sectionHero/__test__/sectionHero.test.tsx
+++ b/app/_components/section/sectionHero/__test__/sectionHero.test.tsx
@@ -1,9 +1,9 @@
-import { sectionHeroContents } from '@/section/section.consts';
 import { render, screen } from '@testing-library/react';
 import { SectionHero } from '..';
 import { ReactNode } from 'react';
 import { getResolvedComponent } from '@/_lib/utils/test.utils';
 import { configsSignInButton } from '@/button/button.configs';
+import { sectionContents } from '@/section/section.consts';
 
 jest.mock('@/transition/smoothTransitionWithDivRef', () => ({
   SmoothTransitionWithDivRef: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -24,9 +24,9 @@ describe('SectionHero', () => {
   it('should render the text contents', async () => {
     await renderAsyncComponent();
 
-    const titleText = await screen.findByText(sectionHeroContents.title);
-    const subTitleText = await screen.findByText(sectionHeroContents.subTitle);
-    const contentText = await screen.findByText(sectionHeroContents.content);
+    const titleText = await screen.findByText(sectionContents.hero.title);
+    const subTitleText = await screen.findByText(sectionContents.hero.subTitle);
+    const contentText = await screen.findByText(sectionContents.hero.content);
 
     expect(titleText).toBeInTheDocument();
     expect(subTitleText).toBeInTheDocument();

--- a/app/_components/section/sectionHero/index.tsx
+++ b/app/_components/section/sectionHero/index.tsx
@@ -1,8 +1,7 @@
 import { DivContainerWithRef } from '@/container/divContainerWithRef';
 import { SmoothTransition } from '@/transition/smoothTransition';
-import { optionsTransition } from '@/transition/transition.utils';
+import { configsTransition } from '@/transition/transition.utils';
 import { DELAY } from '@constAssertions/ui';
-import { sectionHeroContents } from '../section.consts';
 import Link from 'next/link';
 import { SignInButton } from '@/button/signInButton';
 import { SmoothTransitionWithDivRef } from '@/transition/smoothTransitionWithDivRef';
@@ -12,19 +11,20 @@ import { mergeClasses } from '@/_lib/utils/misc.utils';
 import { ImageWithRemotePlaceholder } from '@/_components/next/imageWithRemotePlaceholder';
 import { configsSignInButton } from '@/button/button.configs';
 import { optionsSectionHeroWithImage } from './sectionHero.consts';
+import { sectionContents } from '../section.consts';
 
 export const SectionHero = async () => {
   const divContainer_id = 'sectionHero';
   const translateDownHandler = (delay?: keyof typeof DELAY) => {
-    return optionsTransition({ transition: 'translateDown', duration: 1000, delay: delay });
+    return configsTransition({ transition: 'translateDown', duration: 1000, delay: delay });
   };
-  const optionsFadeIn = optionsTransition({
+  const optionsFadeIn = configsTransition({
     transition: 'fadeIn',
     duration: 1000,
     delay: 300,
     rate: 4,
   });
-  const optionsScaleCenterSm = optionsTransition({
+  const optionsScaleCenterSm = configsTransition({
     transition: 'scaleCenterSm',
     duration: 700,
     delay: 150,
@@ -39,24 +39,24 @@ export const SectionHero = async () => {
             _id={divContainer_id}
             className='mx-auto max-w-7xl px-6 lg:px-8'
           >
-            <SmoothTransition options={translateDownHandler()}>
+            <SmoothTransition configs={translateDownHandler()}>
               <div className='mx-auto max-w-2xl text-center'>
                 <div className='mb-2 text-4xl font-bold text-slate-800 will-change-transform sm:text-6xl'>
-                  {sectionHeroContents.title}
+                  {sectionContents.hero.title}
                 </div>
                 <div className='text-4xl font-bold text-slate-800 will-change-transform sm:text-6xl'>
-                  {sectionHeroContents.subTitle}
+                  {sectionContents.hero.subTitle}
                 </div>
               </div>
             </SmoothTransition>
-            <SmoothTransition options={translateDownHandler(300)}>
+            <SmoothTransition configs={translateDownHandler(300)}>
               <div className='mx-auto max-w-2xl text-center'>
                 <p className='mt-6 text-xl leading-8 text-gray-600 will-change-transform'>
-                  {sectionHeroContents.content}
+                  {sectionContents.hero.content}
                 </p>
               </div>
             </SmoothTransition>
-            <SmoothTransition options={translateDownHandler(700)}>
+            <SmoothTransition configs={translateDownHandler(700)}>
               <div className='mt-10 flex items-center justify-center gap-x-6'>
                 <SignInButton configs={configsSignInButton['getStarted']} />
                 <Link
@@ -72,7 +72,7 @@ export const SectionHero = async () => {
                 <div className='relative mt-16 flow-root max-w-[60rem] sm:mt-24'>
                   <SmoothTransitionWithDivRef
                     _id={divContainer_id}
-                    options={optionsFadeIn}
+                    configs={optionsFadeIn}
                   >
                     <div
                       className={mergeClasses(
@@ -84,10 +84,10 @@ export const SectionHero = async () => {
                   </SmoothTransitionWithDivRef>
                   <SmoothTransitionWithDivRef
                     _id={divContainer_id}
-                    options={optionsScaleCenterSm}
+                    configs={optionsScaleCenterSm}
                   >
                     <div className='mx-auto flex w-full max-w-[60rem] flex-row items-center justify-center rounded-xl border-none ring-0 lg:rounded-2xl'>
-                      <ImageWithRemotePlaceholder options={optionsSectionHeroWithImage} />
+                      <ImageWithRemotePlaceholder configs={optionsSectionHeroWithImage} />
                     </div>
                   </SmoothTransitionWithDivRef>
                 </div>

--- a/app/_components/section/sectionStartToday/__test__/sectionStartToday.test.tsx
+++ b/app/_components/section/sectionStartToday/__test__/sectionStartToday.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { SectionStartToday } from '..';
-import { sectionStartTodayContents } from '@/section/section.consts';
 import { ReactNode } from 'react';
 import { configsSignInButton } from '@/button/button.configs';
+import { sectionContents } from '@/section/section.consts';
 
 jest.mock('@/transition/smoothTransitionWithDivRef', () => ({
   SmoothTransitionWithDivRef: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -22,7 +22,7 @@ describe('SectionStartToday', () => {
   it('should render the content texts properly', () => {
     renderWithSectionStartToday();
 
-    Object.values(sectionStartTodayContents).forEach(async (value) => {
+    Object.values(sectionContents.startToday).forEach(async (value) => {
       await waitFor(() => {
         const text = screen.queryByText(value);
         expect(text).toBeInTheDocument();

--- a/app/_components/section/sectionStartToday/index.tsx
+++ b/app/_components/section/sectionStartToday/index.tsx
@@ -3,16 +3,16 @@ import { STYLE_BLUR_GRADIENT_R_LG } from '@/_lib/consts/style.consts';
 import { SmoothTransition } from '@/transition/smoothTransition';
 import { SmoothTransitionWithDivRef } from '@/transition/smoothTransitionWithDivRef';
 import { DELAY } from '@/transition/transition.consts';
-import { optionsTransition } from '@/transition/transition.utils';
-import { sectionStartTodayContents } from '../section.consts';
+import { configsTransition } from '@/transition/transition.utils';
 import { SignInButton } from '@/button/signInButton';
 import { mergeClasses } from '@/_lib/utils/misc.utils';
 import { configsSignInButton } from '@/button/button.configs';
+import { sectionContents } from '../section.consts';
 
 export const SectionStartToday = () => {
   const divContainer_id = 'sectionStartToday';
   const transitionHandler = (delay?: keyof typeof DELAY) => {
-    return optionsTransition({ transition: 'translateDown', duration: 1000, delay: delay, rate: 0.7 });
+    return configsTransition({ transition: 'translateDown', duration: 1000, delay: delay, rate: 0.7 });
   };
 
   return (
@@ -22,7 +22,7 @@ export const SectionStartToday = () => {
           className='absolute inset-x-0 top-0 -z-10 flex transform-gpu justify-center overflow-hidden blur-3xl'
           aria-hidden='true'
         >
-          <SmoothTransition options={transitionHandler()}>
+          <SmoothTransition configs={transitionHandler()}>
             <div
               className={mergeClasses(
                 'custom-clip-path aspect-[2500/600] w-[70rem] flex-none opacity-40 will-change-transform md:aspect-[1400/600]',
@@ -38,25 +38,25 @@ export const SectionStartToday = () => {
         >
           <SmoothTransitionWithDivRef
             _id={divContainer_id}
-            options={transitionHandler()}
+            configs={transitionHandler()}
           >
             <h2 className='text-3xl font-bold tracking-tight text-slate-800 will-change-transform sm:text-4xl'>
-              {sectionStartTodayContents.title}
+              {sectionContents.startToday.title}
               <br />
-              {sectionStartTodayContents.subTitle}
+              {sectionContents.startToday.subTitle}
             </h2>
           </SmoothTransitionWithDivRef>
           <SmoothTransitionWithDivRef
             _id={divContainer_id}
-            options={transitionHandler(300)}
+            configs={transitionHandler(300)}
           >
             <p className='mx-auto mt-6 max-w-xl text-lg leading-8 text-slate-600 will-change-transform'>
-              {sectionStartTodayContents.content}
+              {sectionContents.startToday.content}
             </p>
           </SmoothTransitionWithDivRef>
           <SmoothTransitionWithDivRef
             _id={divContainer_id}
-            options={transitionHandler(700)}
+            configs={transitionHandler(700)}
           >
             <div className='mt-10 flex items-center justify-center will-change-transform'>
               <SignInButton configs={configsSignInButton['getStarted']} />

--- a/app/_components/ui/icon/icon.types.ts
+++ b/app/_components/ui/icon/icon.types.ts
@@ -12,4 +12,4 @@ export interface TypesSvgAttributes {
 
 type ExtendedSvgAttributes = Partial<TypesSvgAttributes & Pick<TypesStyles, 'className'>>;
 
-export type PropsSvgIcon = Partial<{ options: ExtendedSvgAttributes }>;
+export type PropsSvgIcon = Partial<{ configs: ExtendedSvgAttributes }>;

--- a/app/_components/ui/icon/svgIcon/index.tsx
+++ b/app/_components/ui/icon/svgIcon/index.tsx
@@ -1,7 +1,7 @@
 import { VIEWBOX } from '../icon.consts';
 import { PropsSvgIcon } from '../icon.types';
 
-export const SvgIcon = ({ options = {} }: PropsSvgIcon) => {
+export const SvgIcon = ({ configs = {} }: PropsSvgIcon) => {
   const {
     isAriaHidden = true,
     height = '24',
@@ -9,7 +9,7 @@ export const SvgIcon = ({ options = {} }: PropsSvgIcon) => {
     viewBox = VIEWBOX['24'],
     className = 'h-5 w-5 fill-gray-500 hover:fill-gray-700',
     testId = 'svgIcon-testid',
-  } = options;
+  } = configs;
 
   return (
     <svg
@@ -21,7 +21,7 @@ export const SvgIcon = ({ options = {} }: PropsSvgIcon) => {
       className={className}
       data-testid={testId}
     >
-      <path d={options.path} />
+      <path d={configs.path} />
     </svg>
   );
 };

--- a/app/_components/ui/transition/smoothTransition/index.tsx
+++ b/app/_components/ui/transition/smoothTransition/index.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from 'react';
 import { useVerticalScrollPositionTrigger } from '../transition.hooks';
 import { mergeClasses } from '@/_lib/utils/misc.utils';
 
-export const SmoothTransition = ({ children, scrollRef, options }: PropsSmoothTransition) => {
+export const SmoothTransition = ({ children, scrollRef, configs }: PropsSmoothTransition) => {
   const [hasShown, setHasShown] = useState(false);
   const {
     appear = true,
@@ -15,9 +15,9 @@ export const SmoothTransition = ({ children, scrollRef, options }: PropsSmoothTr
     leaveDuration = 'duration-500',
     type = 'fadeIn',
     delay,
-  } = options || {};
+  } = configs || {};
   const data = DATA_SMOOTH_TRANSITION.find((data) => data.type === type) || ({} as TypesDataTransition);
-  const triggerRate = !!scrollRef ? options?.rate : undefined;
+  const triggerRate = !!scrollRef ? configs?.rate : undefined;
   const isTriggered = useVerticalScrollPositionTrigger(scrollRef, triggerRate);
   const isShowing = !!scrollRef ? isTriggered : hasShown;
 

--- a/app/_components/ui/transition/smoothTransition/smoothTransition.types.ts
+++ b/app/_components/ui/transition/smoothTransition/smoothTransition.types.ts
@@ -10,7 +10,7 @@ import { TypesContainer } from '@/container/container.types';
 
 export type PropsSmoothTransition = {
   children: ReactNode;
-  options?: Partial<
+  configs?: Partial<
     Record<TypesTransitionShow, boolean> & {
       enterDuration: TypesTransitionDuration;
       leaveDuration: TypesTransitionDuration;

--- a/app/_components/ui/transition/smoothTransitionWithDivRef/index.tsx
+++ b/app/_components/ui/transition/smoothTransitionWithDivRef/index.tsx
@@ -7,14 +7,14 @@ import { PropsSmoothTransitionWithDivRef } from '../smoothTransition/smoothTrans
 
 export const SmoothTransitionWithDivRef = ({
   children,
-  options,
+  configs,
   _id = null,
 }: PropsSmoothTransitionWithDivRef) => {
   const divRef = useAtomValue(atomDivRef(_id));
 
   return (
     <SmoothTransition
-      options={options}
+      configs={configs}
       scrollRef={divRef}
     >
       {children}

--- a/app/_components/ui/transition/transition.types.ts
+++ b/app/_components/ui/transition/transition.types.ts
@@ -1,3 +1,5 @@
+import { TRANSITION_TYPE, DURATION, DELAY } from './transition.consts';
+
 export type TypesTransitionTypes =
   | 'fadeIn'
   | 'scaleX'
@@ -10,6 +12,13 @@ export type TypesTransitionTypes =
 export type TypesTransitionShow = 'show' | 'appear';
 
 export type TypesTransitionProperties = 'enter' | 'enterFrom' | 'enterTo' | 'leave' | 'leaveFrom' | 'leaveTo';
+
+export type PropsTransitionConfigs = {
+  transition: keyof typeof TRANSITION_TYPE;
+  duration?: keyof typeof DURATION;
+  delay?: keyof typeof DELAY;
+  rate?: number;
+};
 
 export type TypesTransitionDuration =
   | 'duration-75'

--- a/app/_components/ui/transition/transition.utils.ts
+++ b/app/_components/ui/transition/transition.utils.ts
@@ -1,13 +1,7 @@
 import { TRANSITION_TYPE, DURATION, DELAY } from './transition.consts';
+import { PropsTransitionConfigs } from './transition.types';
 
-type Props = {
-  transition: keyof typeof TRANSITION_TYPE;
-  duration?: keyof typeof DURATION;
-  delay?: keyof typeof DELAY;
-  rate?: number;
-};
-
-export const optionsTransition = ({ transition, duration, delay, rate }: Props) => {
+export const configsTransition = ({ transition, duration, delay, rate }: PropsTransitionConfigs) => {
   return Object.assign(
     { type: TRANSITION_TYPE[transition] },
     !!duration && { enterDuration: DURATION[duration] },


### PR DESCRIPTION
Object props have been renamed to configs for improved naming clarity. Configurations will now be maintained under the filename `file.configs.ts` for streamlined management.