### PR TITLE
feat: Add createConfigs utility function

### DIFF
--- a/app/_lib/utils/createConfigs.utils.ts
+++ b/app/_lib/utils/createConfigs.utils.ts
@@ -1,0 +1,36 @@
+type options<T> = {
+  [K in keyof T]: {
+    [P in keyof T[K]]: T[K][P];
+  };
+};
+
+/**
+ * A utility function to create config object motivated by class-variance-authority.
+ *
+ * Usage:
+ * This function is designed to provide a structured way to define object properties or
+ * options, particularly suitable for server components. It allows for the definition of
+ * variables and corresponding defaults.
+ *
+ * Note:
+ * Nesting within the options is currently not supported. This design decision keeps the
+ * configuration schema simple and avoids unnecessary complexity, especially considering
+ * that the object configs used as prop values can already be intricate.
+ *
+ * */
+export function createConfigs<T extends options<T>>(config: {
+  options: T;
+  defaultOptions: { [K in keyof T]: keyof T[K] };
+}) {
+  return (props?: Partial<{ [K in keyof T]: keyof T[K] }>): { [K in keyof T]: T[K][keyof T[K]] } => {
+    const result: { [K in keyof T]?: T[K][keyof T[K]] } = {};
+
+    for (const key in config.options) {
+      const k = key as keyof T;
+      const variant = props?.[k] || config.defaultOptions[k];
+      result[k] = config.options[k][variant];
+    }
+
+    return result as { [K in keyof T]: T[K][keyof T[K]] };
+  };
+}


### PR DESCRIPTION
Add the createConfigs utility function for structured object creation that can be consumed as object props, inspired by the class-variants-authority library. Prior to server components, the function might have added unnecessary overhead and complexity. With server components, it can define the schema of multiple objects together, centralizing object management.

Note that nesting objects is intentionally unsupported to avoid further complexity, as maintaining object props is already intricate.