### PR TITLE
fix: Revert global custom imageLoader in next.configs

### DIFF
--- a/app/_components/next/imageWithRemotePlaceholder/index.tsx
+++ b/app/_components/next/imageWithRemotePlaceholder/index.tsx
@@ -2,6 +2,7 @@ import 'server-only';
 import getBase64FromImageURL from '@/_lib/utils/base64Converter.utils';
 import Image from 'next/image';
 import { PropsImageWithRemotePlaceholder } from './imageWithRemotePlaceholder.types';
+import cloudflareLoader from '@/_lib/utils/imageLoader.utils';
 
 export const ImageWithRemotePlaceholder = async ({ configs }: PropsImageWithRemotePlaceholder) => {
   const { sizes = '100vw', priority = true } = configs;
@@ -14,6 +15,7 @@ export const ImageWithRemotePlaceholder = async ({ configs }: PropsImageWithRemo
   return (
     <>
       <Image
+        loader={cloudflareLoader}
         width={configs.width}
         height={configs.height}
         className={configs.className}

--- a/next.config.js
+++ b/next.config.js
@@ -14,8 +14,8 @@ module.exports = withBundleAnalyzer({
     ignoreDuringBuilds: false,
   },
   images: {
-    loader: 'custom',
-    loaderFile: './app/_lib/utils/imageLoader.utils.ts',
+    // loader: 'custom',
+    // loaderFile: './app/_lib/utils/imageLoader.utils.ts',
     domains: imageDomains,
   },
   output: 'standalone',


### PR DESCRIPTION
Comment out global custom imageLoader from next.configs. Some images require external fetching without imageLoader, but global custom imageLoader lacks settings to disable imageLoader on a sepcific imageLoader.