### PR TITLE
refactor: Replace mergeClasses with cx

### DIFF
--- a/app/_components/section/sectionContent/index.tsx
+++ b/app/_components/section/sectionContent/index.tsx
@@ -6,8 +6,8 @@ import { DivContainerWithRef } from '@/container/divContainerWithRef';
 import { SmoothTransitionWithDivRef } from '@/transition/smoothTransitionWithDivRef';
 import { PATH_IMAGE } from '@/_lib/consts/assertion.consts';
 import { ImageWithRemotePlaceholder } from '@/next/imageWithRemotePlaceholder';
-import { mergeClasses } from '@/_lib/utils/misc.utils';
 import { sectionContents } from '../section.consts';
+import { cx } from 'class-variance-authority';
 
 const styleImageWrapper = 'relative w-80 h-auto rounded-xl shadow-2xl shadow-blue-500/40 ring-purple-300/10';
 const styleImage = 'h-auto w-full rounded-xl drop-shadow-2xl';
@@ -50,26 +50,26 @@ export const SectionContent = () => {
           />
           <DivContainerWithRef
             _id={divContainerSpotlight_id}
-            className={mergeClasses(styleImageFrame)}
+            className={cx(styleImageFrame)}
           >
             <SmoothTransitionWithDivRef
               _id={divContainerSpotlight_id}
               configs={transitionHandler(500)}
             >
-              <div className={mergeClasses(styleImageWrapper, 'opacity-100')}>
+              <div className={cx(styleImageWrapper, 'opacity-100')}>
                 <ImageWithRemotePlaceholder configs={optionsImageSpotlight} />
               </div>
             </SmoothTransitionWithDivRef>
           </DivContainerWithRef>
           <DivContainerWithRef
             _id={divContainerOverload_id}
-            className={mergeClasses('max-md:order-last', styleImageFrame)}
+            className={cx('max-md:order-last', styleImageFrame)}
           >
             <SmoothTransitionWithDivRef
               _id={divContainerOverload_id}
               configs={transitionHandler(700)}
             >
-              <div className={mergeClasses(styleImageWrapper, 'opacity-100')}>
+              <div className={cx(styleImageWrapper, 'opacity-100')}>
                 <ImageWithRemotePlaceholder configs={optionsImageOverload} />
               </div>
             </SmoothTransitionWithDivRef>

--- a/app/_components/section/sectionContent/sectionContentText/index.tsx
+++ b/app/_components/section/sectionContent/sectionContentText/index.tsx
@@ -4,7 +4,7 @@ import { PropsSectionContentText } from '@/section/section.types';
 import { SmoothTransitionWithDivRef } from '@/transition/smoothTransitionWithDivRef';
 import { DELAY } from '@/transition/transition.consts';
 import { configsTransition } from '@/transition/transition.utils';
-import { mergeClasses } from '@/_lib/utils/misc.utils';
+import { cx } from 'class-variance-authority';
 
 export const SectionContentText = ({ title, subTitle, content, _id = null }: PropsSectionContentText) => {
   const transitionHandler = (delay?: keyof typeof DELAY) => {
@@ -22,7 +22,7 @@ export const SectionContentText = ({ title, subTitle, content, _id = null }: Pro
           configs={transitionHandler()}
         >
           <p
-            className={mergeClasses(
+            className={cx(
               'w-full max-w-sm animate-typing whitespace-nowrap bg-clip-text text-2xl text-transparent will-change-transform md:text-3xl',
               STYLE_BLUR_GRADIENT_R_ZR,
             )}

--- a/app/_components/section/sectionHeader/index.tsx
+++ b/app/_components/section/sectionHeader/index.tsx
@@ -5,8 +5,8 @@ import { TRANSITION_TYPE } from '@/transition/transition.consts';
 import { configsTransition } from '@/transition/transition.utils';
 import { DELAY } from '@constAssertions/ui';
 import { STYLE_BLUR_GRADIENT_B_MD } from '@data/stylePreset';
-import { mergeClasses } from '@/_lib/utils/misc.utils';
 import { sectionContents } from '../section.consts';
+import { cx } from 'class-variance-authority';
 
 export const SectionHeader = () => {
   const divContainer_id = 'sectionHeader';
@@ -37,7 +37,7 @@ export const SectionHeader = () => {
         >
           <div className='relative flex h-[15rem] max-h-60 flex-row items-center justify-center'>
             <div
-              className={mergeClasses(STYLE_BLUR_GRADIENT_B_MD, 'absolute h-full w-3 will-change-transform')}
+              className={cx(STYLE_BLUR_GRADIENT_B_MD, 'absolute h-full w-3 will-change-transform')}
               data-testid='gradientPole-testid'
             />
             <div className='h-full w-1 rounded-full bg-gradient-to-b from-blue-600' />

--- a/app/_components/section/sectionHero/index.tsx
+++ b/app/_components/section/sectionHero/index.tsx
@@ -7,11 +7,11 @@ import { SignInButton } from '@/button/signInButton';
 import { SmoothTransitionWithDivRef } from '@/transition/smoothTransitionWithDivRef';
 import { PATH_HOME } from '@/_lib/consts/assertion.consts';
 import { STYLE_BLUR_GRADIENT_R_LG } from '@/_lib/consts/style.consts';
-import { mergeClasses } from '@/_lib/utils/misc.utils';
 import { ImageWithRemotePlaceholder } from '@/_components/next/imageWithRemotePlaceholder';
 import { configsSignInButton } from '@/button/button.configs';
 import { optionsSectionHeroWithImage } from './sectionHero.consts';
 import { sectionContents } from '../section.consts';
+import { cx } from 'class-variance-authority';
 
 export const SectionHero = async () => {
   const divContainer_id = 'sectionHero';
@@ -75,7 +75,7 @@ export const SectionHero = async () => {
                     configs={optionsFadeIn}
                   >
                     <div
-                      className={mergeClasses(
+                      className={cx(
                         'absolute h-full w-full rounded-xl will-change-transform',
                         STYLE_BLUR_GRADIENT_R_LG,
                       )}

--- a/app/_components/section/sectionStartToday/index.tsx
+++ b/app/_components/section/sectionStartToday/index.tsx
@@ -5,9 +5,9 @@ import { SmoothTransitionWithDivRef } from '@/transition/smoothTransitionWithDiv
 import { DELAY } from '@/transition/transition.consts';
 import { configsTransition } from '@/transition/transition.utils';
 import { SignInButton } from '@/button/signInButton';
-import { mergeClasses } from '@/_lib/utils/misc.utils';
 import { configsSignInButton } from '@/button/button.configs';
 import { sectionContents } from '../section.consts';
+import { cx } from 'class-variance-authority';
 
 export const SectionStartToday = () => {
   const divContainer_id = 'sectionStartToday';
@@ -24,7 +24,7 @@ export const SectionStartToday = () => {
         >
           <SmoothTransition configs={transitionHandler()}>
             <div
-              className={mergeClasses(
+              className={cx(
                 'custom-clip-path aspect-[2500/600] w-[70rem] flex-none opacity-40 will-change-transform md:aspect-[1400/600]',
                 STYLE_BLUR_GRADIENT_R_LG,
               )}

--- a/app/_components/ui/tooltip/index.tsx
+++ b/app/_components/ui/tooltip/index.tsx
@@ -5,7 +5,7 @@ import { memo } from 'react';
 import { isMobile } from 'react-device-detect';
 import { usePopperTooltip } from 'react-popper-tooltip';
 import { PropsTooltip } from './tooltip.types';
-import { mergeClasses } from '@/_lib/utils/misc.utils';
+import { cx } from 'class-variance-authority';
 
 export const Tooltip = memo(({ configs = {}, children }: PropsTooltip) => {
   const { getTooltipProps, setTooltipRef, setTriggerRef, visible } = usePopperTooltip({
@@ -29,14 +29,14 @@ export const Tooltip = memo(({ configs = {}, children }: PropsTooltip) => {
               <div
                 ref={setTooltipRef}
                 {...getTooltipProps()}
-                className={mergeClasses(
+                className={cx(
                   configs.tooltip &&
                     'z-50 max-w-[15rem] truncate whitespace-nowrap rounded-lg bg-gray-700 p-2 text-xs text-white opacity-90',
                 )}
               >
                 <span>{configs.tooltip}</span>
                 <kbd
-                  className={mergeClasses(
+                  className={cx(
                     configs.kbd &&
                       'ml-2 h-6 rounded border-x border-y py-px px-1.5 font-sans tracking-normal subpixel-antialiased',
                   )}

--- a/app/_components/ui/transition/smoothTransition/index.tsx
+++ b/app/_components/ui/transition/smoothTransition/index.tsx
@@ -5,7 +5,7 @@ import { DATA_SMOOTH_TRANSITION } from './smoothTransition.data';
 import { TypesDataTransition, PropsSmoothTransition } from './smoothTransition.types';
 import { useEffect, useState } from 'react';
 import { useVerticalScrollPositionTrigger } from '../transition.hooks';
-import { mergeClasses } from '@/_lib/utils/misc.utils';
+import { cx } from 'class-variance-authority';
 
 export const SmoothTransition = ({ children, scrollRef, configs }: PropsSmoothTransition) => {
   const [hasShown, setHasShown] = useState(false);
@@ -29,12 +29,12 @@ export const SmoothTransition = ({ children, scrollRef, configs }: PropsSmoothTr
     <Transition
       appear={appear}
       show={isShowing}
-      enter={mergeClasses(data.enter, enterDuration, delay)}
-      enterFrom={mergeClasses(data.enterFrom)}
-      enterTo={mergeClasses(data.enterTo)}
-      leave={mergeClasses(data.leave, leaveDuration, delay)}
-      leaveFrom={mergeClasses(data.leaveFrom)}
-      leaveTo={mergeClasses(data.leaveTo)}
+      enter={cx(data.enter, enterDuration, delay)}
+      enterFrom={cx(data.enterFrom)}
+      enterTo={cx(data.enterTo)}
+      leave={cx(data.leave, leaveDuration, delay)}
+      leaveFrom={cx(data.leaveFrom)}
+      leaveTo={cx(data.leaveTo)}
     >
       {children}
     </Transition>

--- a/app/_lib/consts/style.consts.ts
+++ b/app/_lib/consts/style.consts.ts
@@ -1,25 +1,25 @@
+import { cx } from 'class-variance-authority';
+
 /*
  * gradient-wave-effect
  **/
 
-import { mergeClasses } from '../utils/misc.utils';
-
 // Gradient Base
 export const STYLE_BLUR_GRADIENT_BASE = 'from-pink-600 from-10% via-purple-600 via-20% to-blue-600 to-90%';
-const STYLE_BLUR_GRADIENT_ZR = mergeClasses(STYLE_BLUR_GRADIENT_BASE, 'blur-0');
-const STYLE_BLUR_GRADIENT_SM = mergeClasses(STYLE_BLUR_GRADIENT_BASE, 'blur-sm');
-const STYLE_BLUR_GRADIENT_MD = mergeClasses(STYLE_BLUR_GRADIENT_BASE, 'blur-md');
-const STYLE_BLUR_GRADIENT_LG = mergeClasses(STYLE_BLUR_GRADIENT_BASE, 'blur-lg');
+const STYLE_BLUR_GRADIENT_ZR = cx(STYLE_BLUR_GRADIENT_BASE, 'blur-0');
+const STYLE_BLUR_GRADIENT_SM = cx(STYLE_BLUR_GRADIENT_BASE, 'blur-sm');
+const STYLE_BLUR_GRADIENT_MD = cx(STYLE_BLUR_GRADIENT_BASE, 'blur-md');
+const STYLE_BLUR_GRADIENT_LG = cx(STYLE_BLUR_GRADIENT_BASE, 'blur-lg');
 // Right
-export const STYLE_BLUR_GRADIENT_R_ZR = mergeClasses(STYLE_BLUR_GRADIENT_ZR, 'bg-gradient-to-r');
-export const STYLE_BLUR_GRADIENT_R_SM = mergeClasses(STYLE_BLUR_GRADIENT_SM, 'bg-gradient-to-r');
-export const STYLE_BLUR_GRADIENT_R_MD = mergeClasses(STYLE_BLUR_GRADIENT_MD, 'bg-gradient-to-r');
-export const STYLE_BLUR_GRADIENT_R_LG = mergeClasses(STYLE_BLUR_GRADIENT_LG, 'bg-gradient-to-r');
+export const STYLE_BLUR_GRADIENT_R_ZR = cx(STYLE_BLUR_GRADIENT_ZR, 'bg-gradient-to-r');
+export const STYLE_BLUR_GRADIENT_R_SM = cx(STYLE_BLUR_GRADIENT_SM, 'bg-gradient-to-r');
+export const STYLE_BLUR_GRADIENT_R_MD = cx(STYLE_BLUR_GRADIENT_MD, 'bg-gradient-to-r');
+export const STYLE_BLUR_GRADIENT_R_LG = cx(STYLE_BLUR_GRADIENT_LG, 'bg-gradient-to-r');
 // Bottom
-export const STYLE_BLUR_GRADIENT_B_ZR = mergeClasses(STYLE_BLUR_GRADIENT_ZR, 'bg-gradient-to-b');
-export const STYLE_BLUR_GRADIENT_B_SM = mergeClasses(STYLE_BLUR_GRADIENT_SM, 'bg-gradient-to-b');
-export const STYLE_BLUR_GRADIENT_B_MD = mergeClasses(STYLE_BLUR_GRADIENT_MD, 'bg-gradient-to-b');
-export const STYLE_BLUR_GRADIENT_B_LG = mergeClasses(STYLE_BLUR_GRADIENT_LG, 'bg-gradient-to-b');
+export const STYLE_BLUR_GRADIENT_B_ZR = cx(STYLE_BLUR_GRADIENT_ZR, 'bg-gradient-to-b');
+export const STYLE_BLUR_GRADIENT_B_SM = cx(STYLE_BLUR_GRADIENT_SM, 'bg-gradient-to-b');
+export const STYLE_BLUR_GRADIENT_B_MD = cx(STYLE_BLUR_GRADIENT_MD, 'bg-gradient-to-b');
+export const STYLE_BLUR_GRADIENT_B_LG = cx(STYLE_BLUR_GRADIENT_LG, 'bg-gradient-to-b');
 
 /**
  * Hover Effect

--- a/app/_lib/utils/misc.utils.ts
+++ b/app/_lib/utils/misc.utils.ts
@@ -1,1 +1,0 @@
-export const mergeClasses = (...classes: unknown[]) => classes.filter(Boolean).join(' ') || undefined;


### PR DESCRIPTION
Replace mergeClasses util with cx from class-variance-authority library. Functionality to merge classes remains consistent.