### PR TITLE
feat: Enhance `createConfigs` util function

### DIFF
--- a/app/_lib/utils/createConfigs.utils.ts
+++ b/app/_lib/utils/createConfigs.utils.ts
@@ -21,15 +21,19 @@ type Options<T> = {
 
 export const createConfigs = <T extends Options<T>>(config: {
   options: T;
-  defaultOptions: { [K in keyof T]: keyof T[K] };
+  defaultOptions: Partial<{ [K in keyof T]: keyof T[K] | null | undefined }>;
 }) => {
-  const main = (props?: Partial<{ [K in keyof T]: keyof T[K] }>): { [K in keyof T]: T[K][keyof T[K]] } => {
+  const main = (
+    props?: Partial<{ [K in keyof T]: keyof T[K] | null | undefined }>,
+  ): { [K in keyof T]: T[K][keyof T[K]] } => {
     const result: { [K in keyof T]?: T[K][keyof T[K]] } = {};
 
     Object.keys(config.options).forEach((key) => {
       const k = key as keyof T;
-      const variant = props?.[k] || config.defaultOptions[k];
-      result[k] = config.options[k][variant];
+      const variant = props?.[k] ?? config.defaultOptions[k];
+      if (variant != null) {
+        result[k] = config.options[k][variant];
+      }
     });
 
     return result as { [K in keyof T]: T[K][keyof T[K]] };


### PR DESCRIPTION
`createConfigs` util now allows optional value of null or undefined for defaultOptions properties. If a defaultOption's property is undefined or null, it will not appear in the final object. Providing an empty object as defaultOptions will result in no objects being passed to the final output, while omitting defaultOptions entirely will result in a type error. This functionality facilitates selective inclusion of properties in the options.