### PR TITLE
fix: Resolve required field issue in createConfigs

### DIFF
--- a/app/_lib/utils/createConfigs.utils.ts
+++ b/app/_lib/utils/createConfigs.utils.ts
@@ -19,17 +19,20 @@ type Options<T> = {
   };
 };
 
+type RequiredProps<T, R> = R extends (keyof T)[] ? { [K in R[number] & keyof T]: keyof T[K] } : {};
+
 export const createConfigs = <T extends Options<T>, R extends (keyof T)[] | undefined = undefined>(config: {
   options: T;
   defaultOptions: Partial<{ [K in keyof T]: keyof T[K] | null | undefined }>;
   required?: R;
 }) => {
-  type RequiredProps = R extends (keyof T)[] ? { [K in R[number]]: keyof T[K] } : {};
+  type PropsType = Partial<{ [K in keyof T]: keyof T[K] | null | undefined }> & RequiredProps<T, R>;
 
   const main = (
-    props: Partial<{ [K in keyof T]: keyof T[K] | null | undefined }> & RequiredProps,
+    ...[props]: R extends undefined ? [PropsType?] : [PropsType]
   ): { [K in keyof T]: T[K][keyof T[K]] } => {
     const result: { [K in keyof T]?: T[K][keyof T[K]] } = {};
+    props = props ?? {};
 
     Object.keys(config.options).forEach((key) => {
       const k = key as keyof T;


### PR DESCRIPTION
Previously, passing an argument to the createConfigs function was always mandatory, even if the required field was undefined or empty. The problem has been fixed, and using the function without the required field will no longer result in an error.