### PR TITLE
feat: Enhance presetOption in createConfigs

### DIFF
--- a/app/_lib/utils/configs.utils.ts
+++ b/app/_lib/utils/configs.utils.ts
@@ -14,7 +14,7 @@ type NestedOptions<T> = { [Property in keyof T]: DisallowFurtherNesting<ValueTyp
 type RootOptions<T> = { [Key in keyof T]: NestedOptions<T[Key]> };
 type RequiredProps<T, R> = R extends (keyof T)[] ? { [K in R[number] & keyof T]: keyof T[K] } : {};
 type CommonKeyType<T> = { [K in keyof T]: keyof T[K] | null | undefined };
-type PresetOptions<T> = Partial<CommonKeyType<T>>;
+type PresetOptions<T> = Partial<CommonKeyType<T> | null | undefined>;
 
 export const createConfigs = <
   T extends RootOptions<T>,
@@ -25,7 +25,9 @@ export const createConfigs = <
   defaultOptions: Partial<CommonKeyType<T>>;
   required?: R;
   presetOptions?: P & {
-    [K in keyof P]: { [L in keyof P[K]]: L extends keyof T ? keyof T[L] : CommonKeyType<T> };
+    [K in keyof P]: {
+      [L in keyof P[K]]: L extends keyof T ? keyof T[L] | null | undefined : CommonKeyType<T> | null | undefined;
+    };
   };
 }) => {
   type PropsType = Partial<CommonKeyType<T>> & RequiredProps<T, R> & { preset?: P extends undefined ? never : keyof P };


### PR DESCRIPTION
Allow passing undefined or null to presetOptions within createConfigs util function. When undefined or null are passed, nothing is returned when the preset is used. Enhancing the handling of these values enables exemption of preset values from the object's output.