### PR TITLE
feat: Add the NextAuth API in appRouter

### DIFF
--- a/app/api/auth/[...nextauth]/authOptions.ts
+++ b/app/api/auth/[...nextauth]/authOptions.ts
@@ -1,0 +1,67 @@
+import EmailProvider from 'next-auth/providers/email';
+import GoogleProvider from 'next-auth/providers/google';
+import GitHubProvider from 'next-auth/providers/github';
+import clientPromise from '@lib/dataConnections/mongodb';
+import { MongoDBAdapter } from '@next-auth/mongodb-adapter';
+import { NextAuthOptions } from 'next-auth';
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    EmailProvider({
+      server: {
+        host: process.env.GCR_EMAIL_SERVER_HOST,
+        port: process.env.GCR_EMAIL_SERVER_PORT,
+        auth: {
+          user: process.env.EMAIL_SERVER_USER,
+          pass: process.env.EMAIL_SERVER_PASSWORD,
+        },
+      },
+      from: process.env.GCR_EMAIL_FROM,
+    }),
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID as string,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
+    }),
+    GitHubProvider({
+      clientId: process.env.GITHUB_CLIENT_ID as string,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET as string,
+    }),
+  ],
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.user = {
+          _id: user.id,
+          email: user.email,
+          name: user.name,
+          image: user.image,
+        };
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (session)
+        session.user = {
+          _id: token.user._id,
+          email: token.user.email,
+          name: token.user.name,
+          image: token.user.image,
+        };
+      return session;
+    },
+  },
+  pages: {
+    signIn: '/auth',
+    signOut: '/',
+    error: '/auth',
+  },
+  adapter: MongoDBAdapter(clientPromise),
+  session: {
+    strategy: 'jwt',
+  },
+  debug: process.env.NODE_ENV === 'development',
+  jwt: {
+    secret: process.env.NEXTAUTH_JWT_SECRET,
+  },
+  secret: process.env.NEXTAUTH_SECRET,
+};

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,6 @@
+import NextAuth from 'next-auth';
+import { authOptions } from './authOptions';
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };


### PR DESCRIPTION
Add the API route of NextAuth within appRouter. This is the only simple migration from the pageRouter.