### PR TITLE
feat: Add Logo component to appRouter

### DIFF
--- a/app/_components/layout/logo/__test__/logo.test.tsx
+++ b/app/_components/layout/logo/__test__/logo.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { Logo } from '..';
+import { renderAsync } from '@/_lib/utils/test.utils';
+import mockRouter from 'next-router-mock';
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn().mockReturnValue(Promise.resolve(false)),
+}));
+
+describe('Logo', () => {
+  const renderWithLogo = async () => await renderAsync(<Logo />, { nextLink: true });
+
+  it('should render logoFull', async () => {
+    renderWithLogo();
+    const descLogoFull = await screen.findByText('Main logo full');
+
+    expect(descLogoFull).toBeInTheDocument();
+  });
+
+  it('should route to the root when link is clicked', async () => {
+    mockRouter.push('/test');
+    renderWithLogo();
+
+    const logoLink = await screen.findByLabelText('Logo to route to index page.');
+
+    expect(logoLink).toBeInTheDocument();
+    expect(mockRouter).toMatchObject({ pathname: '/test' });
+
+    fireEvent.click(logoLink);
+
+    expect(mockRouter).toMatchObject({ pathname: '/' });
+  });
+});

--- a/app/_components/layout/logo/index.tsx
+++ b/app/_components/layout/logo/index.tsx
@@ -1,0 +1,25 @@
+import { authOptions } from '@/api/auth/[...nextauth]/authOptions';
+import { SvgIcon } from '@/icon/svgIcon';
+import { configsSvgIconLogo } from '@/icon/svgIcon/svgIcon.configs';
+import { getServerSession } from 'next-auth';
+import Link from 'next/link';
+
+export const Logo = async () => {
+  const session = await getServerSession(authOptions);
+  const route = !!session ? '' : '/';
+  const routeClassName = !!session ? 'cursor-pointer' : 'pointer-events-none';
+
+  return (
+    <nav className='flex h-0 flex-row items-center'>
+      <Link
+        href={route}
+        className={routeClassName}
+        aria-label='Logo to route to index page.'
+      >
+        <span className='flex w-full flex-row items-center justify-center'>
+          <SvgIcon configs={configsSvgIconLogo({ preset: 'logoFull' })} />
+        </span>
+      </Link>
+    </nav>
+  );
+};

--- a/app/_components/section/sectionHero/__test__/sectionHero.test.tsx
+++ b/app/_components/section/sectionHero/__test__/sectionHero.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { SectionHero } from '..';
 import { ReactNode } from 'react';
-import { getResolvedComponent } from '@/_lib/utils/test.utils';
 import { configsSignInButton } from '@/button/button.configs';
 import { sectionContents } from '@/section/section.consts';
+import { renderAsync } from '@/_lib/utils/test.utils';
 
 jest.mock('@/transition/smoothTransitionWithDivRef', () => ({
   SmoothTransitionWithDivRef: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -18,13 +18,10 @@ jest.mock('@/_lib/utils/base64Converter.utils', () => jest.fn());
 const signInButtonConfigs = configsSignInButton({ preset: 'getStarted' });
 
 describe('SectionHero', () => {
-  const renderAsyncComponent = async () => {
-    const ResolvedSectionHero = await getResolvedComponent(SectionHero);
-    render(<ResolvedSectionHero />);
-  };
+  const renderWithSectionHero = async () => renderAsync(<SectionHero />);
 
   it('should render the text contents', async () => {
-    await renderAsyncComponent();
+    await renderWithSectionHero();
 
     const titleText = await screen.findByText(sectionContents.hero.title);
     const subTitleText = await screen.findByText(sectionContents.hero.subTitle);
@@ -36,7 +33,7 @@ describe('SectionHero', () => {
   });
 
   it('should render the signInButton and link button', async () => {
-    await renderAsyncComponent();
+    await renderWithSectionHero();
 
     const signInButton = await screen.findByText(signInButtonConfigs.buttonName);
     const linkButton = await screen.findByText('Learn more');
@@ -46,7 +43,7 @@ describe('SectionHero', () => {
   });
 
   it('should render the gradient element and mockImage', async () => {
-    await renderAsyncComponent();
+    await renderWithSectionHero();
 
     const gradientElement = await screen.findByTestId('gradient-testid');
     const mockImage = await screen.findByTestId('mockImage-testid');

--- a/app/_components/section/sectionHero/index.tsx
+++ b/app/_components/section/sectionHero/index.tsx
@@ -3,7 +3,7 @@ import { SmoothTransition } from '@/transition/smoothTransition';
 import Link from 'next/link';
 import { SignInButton } from '@/button/signInButton';
 import { SmoothTransitionWithDivRef } from '@/transition/smoothTransitionWithDivRef';
-import { PATH_HOME } from '@/_lib/consts/assertion.consts';
+import { PATH_ROUTE } from '@/_lib/consts/assertion.consts';
 import { STYLE_BLUR_GRADIENT_R_LG } from '@/_lib/consts/style.consts';
 import { ImageWithRemotePlaceholder } from '@/_components/next/imageWithRemotePlaceholder';
 import { configsSignInButton } from '@/button/button.configs';
@@ -46,7 +46,7 @@ export const SectionHero = async () => {
                 <SignInButton configs={configsSignInButton({ preset: 'getStarted' })} />
                 <Link
                   className='text-sm font-semibold leading-6 text-gray-900'
-                  href={PATH_HOME['features']}
+                  href={PATH_ROUTE['features']}
                 >
                   Learn more <span aria-hidden='true'>→</span>
                 </Link>

--- a/app/_components/ui/icon/icon.types.ts
+++ b/app/_components/ui/icon/icon.types.ts
@@ -1,12 +1,4 @@
 import { ConfigsProps } from '@/_lib/utils/configs.utils';
-import { configsSvgIcon } from './svgIcon/svgIcon.configs';
-import { TypesStyles } from '@/_components/components.types';
+import { configsSvgIcon, configsSvgIconLogo } from './svgIcon/svgIcon.configs';
 
-export interface TypesSvgAttributes {
-  path: string;
-  desc: string;
-}
-
-type ExtendedSvgAttributes = ConfigsProps<typeof configsSvgIcon> & TypesSvgAttributes & Pick<TypesStyles, 'className'>;
-
-export type PropsSvgIcon = { configs: Partial<ExtendedSvgAttributes> };
+export type PropsSvgIcon = { configs: ConfigsProps<typeof configsSvgIcon & typeof configsSvgIconLogo> };

--- a/app/_components/ui/icon/svgIcon/__test__/svgIcon.test.tsx
+++ b/app/_components/ui/icon/svgIcon/__test__/svgIcon.test.tsx
@@ -1,10 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import { SvgIcon } from '..';
+import { configsSvgIconLogo } from '../svgIcon.configs';
 
 describe('SvgIcon', () => {
   it('should render the svgIcon component', () => {
-    render(<SvgIcon configs={{ desc: 'svgIcon-title' }} />);
-    const svgIconWithTestId = screen.getByText('svgIcon-title');
+    render(<SvgIcon configs={configsSvgIconLogo({ preset: 'logoFull' })} />);
+    const svgIconWithTestId = screen.getByText('Main logo full');
 
     expect(svgIconWithTestId).toBeInTheDocument();
   });

--- a/app/_lib/consts/assertion.consts.ts
+++ b/app/_lib/consts/assertion.consts.ts
@@ -1,5 +1,5 @@
-export type PATH_HOME = (typeof PATH_HOME)[keyof typeof PATH_HOME];
-export const PATH_HOME = {
+export type PATH_ROUTE = (typeof PATH_ROUTE)[keyof typeof PATH_ROUTE];
+export const PATH_ROUTE = {
   home: '/',
   demo: '/app',
   features: '/features',

--- a/app/_lib/utils/test.utils.ts
+++ b/app/_lib/utils/test.utils.ts
@@ -1,6 +1,0 @@
-import { ReactNode } from 'react';
-
-export const getResolvedComponent = async (Component: (props: unknown) => Promise<ReactNode>, props = {}) => {
-  const ComponentResolved = await Component(props);
-  return () => ComponentResolved;
-};

--- a/app/_lib/utils/test.utils.tsx
+++ b/app/_lib/utils/test.utils.tsx
@@ -1,0 +1,14 @@
+import { render } from '@testing-library/react';
+import { MemoryRouterProvider } from 'next-router-mock/MemoryRouterProvider';
+import React from 'react';
+
+export const renderAsync = async (
+  element: React.ReactElement,
+  { nextLink }: { nextLink?: boolean } = { nextLink: false },
+) => {
+  const componentType = element.type as (props: unknown) => Promise<React.ReactNode>;
+  const wrapper = !!nextLink ? { wrapper: MemoryRouterProvider } : undefined;
+
+  const ResolvedComponent = await componentType(element.props);
+  render(<>{ResolvedComponent}</>, wrapper);
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,8 +1,16 @@
 // NOTE: If you delete this file, remove `setupFilesAfterEnv` from `jest.config.js`
-
-// Used for __tests__/testing-library.js
+// sed for __tests__/testing-library.js
 // Learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Next Auth
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn().mockReturnValue(Promise.resolve(true)),
+}));
+
+jest.mock('@/api/auth/[...nextauth]/authOptions', () => ({
+  authOptions: {},
+}));
 
 // Next.js router mock
 jest.mock('next/router', () => require('next-router-mock'));


### PR DESCRIPTION
Introduces Logo component in appRouter, transitioning from pageRouter. Leverages NextAuth's getServerSession for server-side session access, eliminating the need for client-side hooks. Renames PATH_HOME to PATH_ROUTES and refactors renderAsyncComponent to renderAsync, adding nextLink option for compatibility with Link component.