### PR TITLE
refactor: Transition client components to server

### DIFF
--- a/app/_components/ui/button/buttonWithTooltip/index.tsx
+++ b/app/_components/ui/button/buttonWithTooltip/index.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { forwardRef, useState } from 'react';
 import { PropsButtonWithTooltip } from '../button.types';
 import { Button } from '..';

--- a/app/_components/ui/button/index.tsx
+++ b/app/_components/ui/button/index.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { forwardRef } from 'react';
 import { PropsButton } from './button.types';
 

--- a/app/_components/ui/tooltip/index.tsx
+++ b/app/_components/ui/tooltip/index.tsx
@@ -1,13 +1,10 @@
-'use client';
-
 import { Portal } from '@headlessui/react';
-import { memo } from 'react';
 import { isMobile } from 'react-device-detect';
 import { usePopperTooltip } from 'react-popper-tooltip';
 import { PropsTooltip } from './tooltip.types';
 import { cx } from 'class-variance-authority';
 
-export const Tooltip = memo(({ configs = {}, children }: PropsTooltip) => {
+export const Tooltip = ({ configs = {}, children }: PropsTooltip) => {
   const { getTooltipProps, setTooltipRef, setTriggerRef, visible } = usePopperTooltip({
     trigger: configs.trigger ?? 'hover',
     delayShow: configs.delayShow ?? 50,
@@ -50,6 +47,4 @@ export const Tooltip = memo(({ configs = {}, children }: PropsTooltip) => {
       )}
     </>
   );
-});
-
-Tooltip.displayName = 'Tooltip';
+};


### PR DESCRIPTION
Eliminates 'use client' directive to transition certain components to server-side. Such as Button component serving as root to server-side, retaining client-side scope for versions requiring onClick handlers.