### PR TITLE
refactor: Revise PropsSvgIcon type definitions

### DIFF
--- a/app/_components/ui/icon/icon.types.ts
+++ b/app/_components/ui/icon/icon.types.ts
@@ -1,4 +1,13 @@
-import { ConfigsProps } from '@/_lib/utils/configs.utils';
-import { configsSvgIcon, configsSvgIconLogo } from './svgIcon/svgIcon.configs';
+import { ReactNode } from 'react';
 
-export type PropsSvgIcon = { configs: ConfigsProps<typeof configsSvgIcon & typeof configsSvgIconLogo> };
+interface TypesSvgIcon {
+  height: number | string;
+  width: number | string;
+  viewBox: string;
+  className: string;
+  path: string | ReactNode;
+  desc: string;
+}
+
+// export type PropsSvgIcon = { configs: ConfigsProps<typeof configsSvgIcon & typeof configsSvgIconLogo> };
+export type PropsSvgIcon = { configs: Partial<TypesSvgIcon> };


### PR DESCRIPTION
Previously, PropsSvgIcon utilized types inferred from configSvgIcon, resulting in restricted string literal types. Modified type definitions to allow widened string types, enhancing reusability and maintainability for primitive components like SvgIcon and Button.