### PR TITLE
refactor: Update className and button.configs

### DIFF
--- a/app/_components/section/sectionHero/__test__/sectionHero.test.tsx
+++ b/app/_components/section/sectionHero/__test__/sectionHero.test.tsx
@@ -1,9 +1,9 @@
 import { screen } from '@testing-library/react';
 import { SectionHero } from '..';
 import { ReactNode } from 'react';
-import { configsSignInButton } from '@/button/button.configs';
 import { sectionContents } from '@/section/section.consts';
 import { renderAsync } from '@/_lib/utils/test.utils';
+import { configsSignInButton } from '@/button/signInButton/signInButton.configs';
 
 jest.mock('@/transition/smoothTransitionWithDivRef', () => ({
   SmoothTransitionWithDivRef: ({ children }: { children: ReactNode }) => <div>{children}</div>,

--- a/app/_components/section/sectionHero/index.tsx
+++ b/app/_components/section/sectionHero/index.tsx
@@ -6,12 +6,12 @@ import { SmoothTransitionWithDivRef } from '@/transition/smoothTransitionWithDiv
 import { PATH_ROUTE } from '@/_lib/consts/assertion.consts';
 import { STYLE_BLUR_GRADIENT_R_LG } from '@/_lib/consts/style.consts';
 import { ImageWithRemotePlaceholder } from '@/_components/next/imageWithRemotePlaceholder';
-import { configsSignInButton } from '@/button/button.configs';
 import { sectionContents } from '../section.consts';
 import { cx } from 'class-variance-authority';
 import { configsTransition } from '@/transition/transition.configs';
 import { SmoothTransitionWithDefaultConfigs } from '@/transition/smoothTransitionWithDefaultConfigs';
 import { configsImageWithRemotePlaceholder } from '@/next/imageWithRemotePlaceholder/imageWithRemotePlaceholder.configs';
+import { configsSignInButton } from '@/button/signInButton/signInButton.configs';
 
 export const SectionHero = async () => {
   const divContainer_id = 'sectionHero';

--- a/app/_components/section/sectionStartToday/__test__/sectionStartToday.test.tsx
+++ b/app/_components/section/sectionStartToday/__test__/sectionStartToday.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { SectionStartToday } from '..';
 import { ReactNode } from 'react';
-import { configsSignInButton } from '@/button/button.configs';
 import { sectionContents } from '@/section/section.consts';
+import { configsSignInButton } from '@/button/signInButton/signInButton.configs';
 
 jest.mock('@/transition/smoothTransitionWithDivRef', () => ({
   SmoothTransitionWithDivRef: ({ children }: { children: ReactNode }) => <div>{children}</div>,

--- a/app/_components/section/sectionStartToday/index.tsx
+++ b/app/_components/section/sectionStartToday/index.tsx
@@ -3,11 +3,11 @@ import { STYLE_BLUR_GRADIENT_R_LG } from '@/_lib/consts/style.consts';
 import { SmoothTransition } from '@/transition/smoothTransition';
 import { SmoothTransitionWithDivRef } from '@/transition/smoothTransitionWithDivRef';
 import { SignInButton } from '@/button/signInButton';
-import { configsSignInButton } from '@/button/button.configs';
 import { sectionContents } from '../section.consts';
 import { cx } from 'class-variance-authority';
 import { configsTransition } from '@/transition/transition.configs';
 import { SmoothTransitionWithDefaultConfigs } from '@/transition/smoothTransitionWithDefaultConfigs';
+import { configsSignInButton } from '@/button/signInButton/signInButton.configs';
 
 export const SectionStartToday = () => {
   const divContainer_id = 'sectionStartToday';

--- a/app/_components/ui/button/button.types.ts
+++ b/app/_components/ui/button/button.types.ts
@@ -2,7 +2,7 @@ import { TypesAttributes, TypesEvents, TypesStyles } from '@/_components/compone
 import { ConfigsProps } from '@/_lib/utils/configs.utils';
 import { TypesTooltips } from '@/tooltip/tooltip.types';
 import { ReactNode } from 'react';
-import { configsSignInButton } from './button.configs';
+import { configsSignInButton } from './signInButton/signInButton.configs';
 
 export interface TypesButtons {
   isDisabled: boolean;
@@ -11,16 +11,13 @@ export interface TypesButtons {
   signInButtonName: 'Sign in' | 'Get started';
 }
 
-type TypesOptionsButton = TypesButtons & TypesAttributes & Pick<TypesStyles, 'className'>;
+type TypesOptionsButton = TypesButtons & TypesAttributes;
 
 export type TypesConfigsButtonWithTooltip = TypesOptionsButton &
   Pick<TypesTooltips, 'tooltip' | 'kbd' | 'offset' | 'placement' | 'isVisible'>;
 
 type TypesButtonBase<T> = Partial<
-  {
-    configs: Partial<T>;
-    children: ReactNode;
-  } & TypesEvents
+  { configs: Partial<T>; children: ReactNode } & TypesEvents & Pick<TypesStyles, 'className'>
 >;
 
 export type PropsButton = TypesButtonBase<TypesOptionsButton>;

--- a/app/_components/ui/button/buttonWithTooltip/index.tsx
+++ b/app/_components/ui/button/buttonWithTooltip/index.tsx
@@ -4,7 +4,7 @@ import { Button } from '..';
 import { Tooltip } from '@/tooltip/index';
 
 export const ButtonWithTooltip = forwardRef<HTMLButtonElement, PropsButtonWithTooltip>(
-  ({ configs = {}, onClick, onKeyDown, onDoubleClick, children }: PropsButtonWithTooltip, ref) => {
+  ({ configs = {}, onClick, onKeyDown, onDoubleClick, children, className }: PropsButtonWithTooltip, ref) => {
     const [hasTooltip, setTooltip] = useState(false);
     const { isDisabled, placement, offset, tooltip, kbd, isVisible } = configs;
     const configsTooltip = {
@@ -19,6 +19,7 @@ export const ButtonWithTooltip = forwardRef<HTMLButtonElement, PropsButtonWithTo
       <Tooltip configs={configsTooltip}>
         <Button
           configs={configs}
+          className={className}
           onMouseDown={() => !isDisabled && setTooltip(true)}
           onMouseEnter={() => !isDisabled && setTooltip(false)}
           onMouseLeave={() => !isDisabled && setTooltip(true)}

--- a/app/_components/ui/button/index.tsx
+++ b/app/_components/ui/button/index.tsx
@@ -11,6 +11,7 @@ export const Button = forwardRef<HTMLButtonElement, PropsButton>(
     {
       configs = {},
       children,
+      className,
       onClick,
       onKeyDown,
       onDoubleClick,
@@ -21,7 +22,7 @@ export const Button = forwardRef<HTMLButtonElement, PropsButton>(
     }: PropsButton,
     ref,
   ) => {
-    const { ariaLabel, type = 'button', isDisabled, className } = configs;
+    const { ariaLabel, type = 'button', isDisabled } = configs;
     return (
       <button
         aria-label={ariaLabel}

--- a/app/_components/ui/button/signInButton/__test__/signInButton.test.tsx
+++ b/app/_components/ui/button/signInButton/__test__/signInButton.test.tsx
@@ -2,13 +2,12 @@ import { render } from '@testing-library/react';
 import { SignInButton } from '..';
 import { PropsSignInButton } from '@/button/button.types';
 import { screen } from '@testing-library/react';
-import { configsSignInButton } from '@/button/button.configs';
+import { configsSignInButton } from '../signInButton.configs';
 
 const signInButton = configsSignInButton({ preset: 'getStarted' });
 
 describe('SignInButton', () => {
-  const renderWithSignInButton = ({ configs }: PropsSignInButton) =>
-    render(<SignInButton configs={configs} />);
+  const renderWithSignInButton = ({ configs }: PropsSignInButton) => render(<SignInButton configs={configs} />);
 
   it('should render the default signInButtonName', () => {
     const { container } = renderWithSignInButton({ configs: configsSignInButton() });

--- a/app/_components/ui/button/signInButton/index.tsx
+++ b/app/_components/ui/button/signInButton/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { styleButton } from '../button.styles';
 import { PropsSignInButton } from '../button.types';
 import { ButtonWithTooltip } from '../buttonWithTooltip';
 import { signIn } from 'next-auth/react';
@@ -10,6 +11,7 @@ export const SignInButton = ({ configs = {} }: PropsSignInButton) => {
   return (
     <ButtonWithTooltip
       configs={configs}
+      className={styleButton({ className: 'max-ml:mb-3' })}
       onClick={() => signIn()}
     >
       {buttonName}

--- a/app/_components/ui/button/signInButton/signInButton.configs.ts
+++ b/app/_components/ui/button/signInButton/signInButton.configs.ts
@@ -1,14 +1,10 @@
 import { createConfigs } from '@/_lib/utils/configs.utils';
-import { styleButton } from './button.styles';
 
 export const configsSignInButton = createConfigs({
   options: {
     buttonName: {
       signIn: 'Sign in',
       getStarted: 'Get started',
-    },
-    className: {
-      signIn: styleButton({ className: 'max-ml:mb-3' }),
     },
     tooltip: {
       signIn: 'Sign in',
@@ -22,13 +18,11 @@ export const configsSignInButton = createConfigs({
   presetOptions: {
     getStarted: {
       buttonName: 'getStarted',
-      className: 'signIn',
       tooltip: 'getStarted',
     },
   },
   defaultOptions: {
     buttonName: 'signIn',
-    className: 'signIn',
     tooltip: 'signIn',
   },
 });

--- a/app/_components/ui/icon/icon.types.ts
+++ b/app/_components/ui/icon/icon.types.ts
@@ -1,6 +1,11 @@
+import { TypesStyles } from '@/_components/components.types';
 import { ReactNode } from 'react';
 
-interface TypesSvgIcon {
+type TypesSvgIconBase<T> = {
+  configs: Partial<T>;
+} & Partial<Pick<TypesStyles, 'className'>>;
+
+export interface TypesSvgIcon {
   height: number | string;
   width: number | string;
   viewBox: string;
@@ -9,5 +14,4 @@ interface TypesSvgIcon {
   desc: string;
 }
 
-// export type PropsSvgIcon = { configs: ConfigsProps<typeof configsSvgIcon & typeof configsSvgIconLogo> };
-export type PropsSvgIcon = { configs: Partial<TypesSvgIcon> };
+export type PropsSvgIcon = TypesSvgIconBase<TypesSvgIcon>;

--- a/app/_components/ui/icon/svgIcon/index.tsx
+++ b/app/_components/ui/icon/svgIcon/index.tsx
@@ -1,7 +1,7 @@
 import { PropsSvgIcon } from '../icon.types';
 
-export const SvgIcon = ({ configs }: PropsSvgIcon) => {
-  const { height, width, viewBox, className, path, desc } = configs;
+export const SvgIcon = ({ className, configs }: PropsSvgIcon) => {
+  const { height, width, viewBox, path, desc } = configs;
 
   return (
     <svg


### PR DESCRIPTION
Separate className from object props in configs for enhanced efficiency. Rename button.configs to signInButton.configs for clarity.