### PR TITLE
feat: Eliminate extendOptions in createConfigs

### DIFF
--- a/app/_lib/utils/configs.utils.ts
+++ b/app/_lib/utils/configs.utils.ts
@@ -1,70 +1,37 @@
-type ObjectOnlyMessage = 'Only non-array object types are permitted as values within the initial object.';
-type DisallowArray<T, K extends keyof T, S> = T[K] extends Array<unknown>
-  ? ObjectOnlyMessage
+type TypesObjectOnlyMessage = 'Only non-array object types are permitted as values within the initial object.';
+type TypesDisallowArray<T, K extends keyof T, S> = T[K] extends Array<unknown>
+  ? TypesObjectOnlyMessage
   : { [P in keyof T[K]]: S | T[K][P] | [] | Array<string> | Array<number> };
 type TypesOptions<T, S extends string> = {
-  [K in keyof T]: T[K] extends object ? DisallowArray<T, K, S> : ObjectOnlyMessage;
+  [K in keyof T]: T[K] extends object ? TypesDisallowArray<T, K, S> : TypesObjectOnlyMessage;
 };
-type Options<T, U> = { [K in keyof Merge<T, U>]: keyof Merge<T, U>[K] | null | undefined };
-type Merge<T, U> = T & U;
-type Configs<T, U, P extends string> = {
+type TypesConfigs<T, P extends string> = {
   options: T;
-  defaultOptions: Partial<Options<T, U>>;
-  presetOptions?: Partial<Record<P, Partial<Options<T, U>>>>;
-  extendOptions?: { options: U }[];
+  defaultOptions: Partial<{ [K in keyof T]: keyof T[K] | null | undefined }>;
+  presetOptions?: Partial<Record<P, Partial<{ [K in keyof T]: keyof T[K] | null | undefined }>>>;
 };
 
-export const createConfigs = <
-  T extends TypesOptions<T, S>,
-  U extends TypesOptions<U, S>,
-  S extends string,
-  P extends string = never,
->(
-  config: Configs<T, U, P>,
-): ((props?: Partial<{ [K in keyof Merge<T, U>]: keyof Merge<T, U>[K] } & { preset?: P }>) => {
-  [K in keyof Merge<T, U>]: Merge<T, U>[K][keyof Merge<T, U>[K]];
-}) & { options: T } => {
-  const extendOptions: { [key: string]: unknown } = {};
+export const createConfigs = <T extends TypesOptions<T, S>, S extends string, P extends string = never>(
+  config: TypesConfigs<T, P>,
+): ((props?: Partial<{ [K in keyof T]: keyof T[K] } & { preset?: P }>) => {
+  [K in keyof T]: T[K][keyof T[K]];
+}) => {
+  return (props?: Partial<{ [K in keyof T]: keyof T[K] } & { preset?: P }>): { [K in keyof T]: T[K][keyof T[K]] } => {
+    const { defaultOptions, options, presetOptions } = config;
 
-  if (config.extendOptions) {
-    for (const extendOption of config.extendOptions) {
-      if (extendOption && 'options' in extendOption) {
-        for (const key in extendOption.options) {
-          extendOptions[key] = extendOption.options[key];
-        }
-      }
-    }
-  }
-
-  const options = {} as typeof config.options;
-
-  const configOptions = config.options;
-  for (const key in configOptions) {
-    options[key as keyof typeof configOptions] = configOptions[key];
-  }
-  for (const key in extendOptions) {
-    options[key as keyof typeof config.options] = extendOptions[key] as T[keyof T];
-  }
-
-  const callable = (
-    props?: Partial<{ [K in keyof Merge<T, U>]: keyof Merge<T, U>[K] } & { preset?: P }>,
-  ): { [K in keyof Merge<T, U>]: Merge<T, U>[K][keyof Merge<T, U>[K]] } => {
-    const defaultOptions = config.defaultOptions;
-    const presetOptions = config.presetOptions;
     const result: { [K in keyof T]?: T[K][keyof T[K]] | null } = {};
-    const presetProp = props?.preset;
-    const preset = presetProp ? presetOptions?.[presetProp] : undefined;
+    const preset = props?.preset ? presetOptions?.[props.preset] : undefined;
 
     for (const key in options) {
       const k = key as keyof T;
       const getVariant = (k: keyof T) => {
-        if (props && k in props) return props[k];
-        if (preset && k in preset) return preset[k] !== undefined ? preset[k] : defaultOptions[k];
+        if (props?.hasOwnProperty(k)) return props[k];
+        if (preset?.hasOwnProperty(k)) return preset[k] !== undefined ? preset[k] : defaultOptions[k];
         return defaultOptions[k];
       };
       const variant = getVariant(k);
 
-      if (!!variant && variant in (options[k] as object)) {
+      if (variant !== undefined && options[k].hasOwnProperty(variant as PropertyKey)) {
         result[k] = options[k][variant as keyof T[keyof T]];
       }
       if (variant === null) {
@@ -72,12 +39,8 @@ export const createConfigs = <
       }
     }
 
-    return result as { [K in keyof Merge<T, U>]: Merge<T, U>[K][keyof Merge<T, U>[K]] };
+    return result as { [K in keyof T]: T[K][keyof T[K]] };
   };
-
-  callable.options = options;
-
-  return callable;
 };
 
 /**


### PR DESCRIPTION
Eliminate extendOptions parameter from createConfigs function to reduce complexity and enhance visibility of available selection options.