### PR TITLE
feat: Revert extendOptions in createConfigs

### DIFF
--- a/app/_components/ui/button/button.configs.ts
+++ b/app/_components/ui/button/button.configs.ts
@@ -1,5 +1,6 @@
 import { createConfigs } from '@/_lib/utils/configs.utils';
 import { styleButton } from './button.styles';
+import { configsTooltip } from '@/tooltip/tooltip.configs';
 
 export const configsButton = createConfigs({
   options: {
@@ -21,6 +22,7 @@ export const configsButton = createConfigs({
       off: false,
     },
   },
+  extendOptions: [configsTooltip({ delayHide: '500' })],
   presetOptions: {
     signInGetStarted: {
       buttonName: 'getStarted',

--- a/app/_lib/utils/configs.utils.ts
+++ b/app/_lib/utils/configs.utils.ts
@@ -9,6 +9,7 @@ type TypesConfigs<T, P extends string> = {
   options: T;
   defaultOptions: Partial<{ [K in keyof T]: keyof T[K] | null | undefined }>;
   presetOptions?: Partial<Record<P, Partial<{ [K in keyof T]: keyof T[K] | null | undefined }>>>;
+  extendOptions?: object[];
 };
 
 export const createConfigs = <T extends TypesOptions<T, S>, S extends string, P extends string = never>(
@@ -17,7 +18,7 @@ export const createConfigs = <T extends TypesOptions<T, S>, S extends string, P 
   [K in keyof T]: T[K][keyof T[K]];
 }) => {
   return (props?: Partial<{ [K in keyof T]: keyof T[K] } & { preset?: P }>): { [K in keyof T]: T[K][keyof T[K]] } => {
-    const { defaultOptions, options, presetOptions } = config;
+    const { defaultOptions, options, presetOptions, extendOptions } = config;
 
     const result: { [K in keyof T]?: T[K][keyof T[K]] | null } = {};
     const preset = props?.preset ? presetOptions?.[props.preset] : undefined;
@@ -36,6 +37,15 @@ export const createConfigs = <T extends TypesOptions<T, S>, S extends string, P 
       }
       if (variant === null) {
         result[k] = null;
+      }
+    }
+
+    if (extendOptions) {
+      for (const options of extendOptions) {
+        for (const key in options) {
+          const k = key as keyof typeof options;
+          result[k] = options[k];
+        }
       }
     }
 


### PR DESCRIPTION
Revert extendOptions merge in createConfigs utility function to mitigate complexity concerns. While extendOptions merge offered some maintenance advantages, its potential for infinite complexity outweighs the benefits.