### PR TITLE
refactor: Update Tooltip types for flexibility

### DIFF
--- a/app/_components/ui/button/button.configs.ts
+++ b/app/_components/ui/button/button.configs.ts
@@ -1,6 +1,5 @@
 import { createConfigs } from '@/_lib/utils/configs.utils';
 import { styleButton } from './button.styles';
-import { configsTooltip } from '@/tooltip/tooltip.configs';
 
 export const configsButton = createConfigs({
   options: {
@@ -22,7 +21,6 @@ export const configsButton = createConfigs({
       off: false,
     },
   },
-  extendOptions: [configsTooltip({ delayHide: '500' })],
   presetOptions: {
     signInGetStarted: {
       buttonName: 'getStarted',

--- a/app/_components/ui/tooltip/index.tsx
+++ b/app/_components/ui/tooltip/index.tsx
@@ -7,7 +7,7 @@ import { PropsTooltip } from './tooltip.types';
 
 export const Tooltip = ({ configs = {}, children }: PropsTooltip) => {
   const { getTooltipProps, setTooltipRef, setTriggerRef, visible } = usePopperTooltip({ ...configs });
-  const { kbd, tooltip, classNameTooltip, classNameKbd } = configs;
+  const { kbd, tooltip, className } = configs;
 
   return (
     <>
@@ -19,10 +19,10 @@ export const Tooltip = ({ configs = {}, children }: PropsTooltip) => {
               <div
                 ref={setTooltipRef}
                 {...getTooltipProps()}
-                className={!!tooltip ? classNameTooltip : undefined}
+                className={!!tooltip ? className?.tooltip : undefined}
               >
                 <span>{tooltip}</span>
-                <kbd className={!!kbd ? classNameKbd : undefined}>{kbd}</kbd>
+                <kbd className={!!kbd ? className?.kbd : undefined}>{kbd}</kbd>
               </div>
             </Portal>
           )}

--- a/app/_components/ui/tooltip/tooltip.types.ts
+++ b/app/_components/ui/tooltip/tooltip.types.ts
@@ -1,7 +1,28 @@
-import { ReactNode } from 'react';
-import { ConfigsProps } from '@/_lib/utils/configs.utils';
-import { configsTooltip } from './tooltip.configs';
+import { ReactElement, ReactNode } from 'react';
+import { TriggerType } from 'react-popper-tooltip';
+import { Placement } from '@popperjs/core';
+
+interface TypesTooltipAttributes {
+  tooltip: string | ReactElement | null;
+  kbd: string;
+  delayShow: number;
+  delayHide: number;
+  trigger: TriggerType | TriggerType[] | null;
+  offset: [number, number];
+  placement: Placement;
+  visible: boolean;
+  closeOnOutsideClick: boolean;
+  defaultVisible: boolean;
+  followCursor: boolean;
+}
 
 type TypesTooltipBase<T> = Partial<{ configs: Partial<T> }> & { children: ReactNode };
 
-export type PropsTooltip = TypesTooltipBase<ConfigsProps<typeof configsTooltip>>;
+export type TypesTooltip = TypesTooltipAttributes & {
+  className: {
+    tooltip: HTMLElement['className'];
+    kbd: HTMLElement['className'];
+  };
+};
+
+export type PropsTooltip = TypesTooltipBase<TypesTooltip>;


### PR DESCRIPTION
Rewrite Tooltip types to expand flexibility by moving away from createConfigs function's custom types. Shift from literal string types allows for more flexible usage.