### PR TITLE
feat: Implement appRouter NavigationButton

### DIFF
--- a/app/_components/ui/button/button.states.ts
+++ b/app/_components/ui/button/button.states.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const atomNavigationOpen = atom(false);

--- a/app/_components/ui/button/iconButton/navigationButton/__test__/navigationButton.test.tsx
+++ b/app/_components/ui/button/iconButton/navigationButton/__test__/navigationButton.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, renderHook, fireEvent } from '@testing-library/react';
+import { PropsButtonWithTooltip } from '@/button/button.types';
+import { NavigationButton } from '..';
+import { useAtomValue } from 'jotai';
+import { atomNavigationOpen } from '@/button/button.states';
+
+describe('NavigationButton', () => {
+  const renderWithNavigationButton = ({ children, configs }: PropsButtonWithTooltip) =>
+    render(<NavigationButton configs={configs}>{children}</NavigationButton>);
+  const testElement = 'test text';
+
+  it('should onClick update the state', async () => {
+    renderWithNavigationButton({ children: testElement });
+    const childElement = screen.getByText(testElement);
+
+    const { result } = renderHook(() => useAtomValue(atomNavigationOpen));
+
+    expect(childElement).toBeInTheDocument();
+    expect(result.current).toBe(false);
+
+    fireEvent.click(childElement);
+    expect(result.current).toBe(true);
+  });
+
+  it('should render the object props of configs', () => {
+    renderWithNavigationButton({ configs: { 'aria-label': testElement } });
+    const ariaLabel = screen.getByLabelText(testElement);
+
+    expect(ariaLabel).toBeInTheDocument();
+  });
+});

--- a/app/_components/ui/button/iconButton/navigationButton/index.tsx
+++ b/app/_components/ui/button/iconButton/navigationButton/index.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { atomNavigationOpen } from '@/button/button.states';
+import { PropsButtonWithTooltip } from '@/button/button.types';
+import { ButtonWithTooltip } from '@/button/buttonWithTooltip';
+import { useSetAtom } from 'jotai';
+
+export const NavigationButton = ({ configs, children }: PropsButtonWithTooltip) => {
+  const setNavigationOpen = useSetAtom(atomNavigationOpen);
+
+  return (
+    <ButtonWithTooltip
+      configs={configs}
+      onClick={() => setNavigationOpen((event) => !event)}
+    >
+      {children}
+    </ButtonWithTooltip>
+  );
+};


### PR DESCRIPTION
Replace previous pageRouter NavigationButton with new appRouter component. Diverges in behavior by accepting server component, such as svgIcon, via children props. Includes corresponding unit tests.