### PR TITLE
feat: Migrate DividerX and DividerY to appRouter

### DIFF
--- a/app/_components/ui/divider/divider.styles.ts
+++ b/app/_components/ui/divider/divider.styles.ts
@@ -1,0 +1,28 @@
+import { cva } from 'class-variance-authority';
+
+export const styleDividerY = cva('grid w-4 grid-cols-2', {
+  variants: {
+    type: {
+      primary: 'h-8/10 divide-x-2',
+    },
+    color: {
+      primary: 'divide-slate-800/10',
+    },
+  },
+  defaultVariants: {
+    type: 'primary',
+    color: 'primary',
+  },
+});
+
+export const styleDividerX = cva('border-t border-gray-300', {
+  variants: {
+    width: {
+      full: 'w-full',
+      half: 'w-1/2',
+    },
+  },
+  defaultVariants: {
+    width: 'full',
+  },
+});

--- a/app/_components/ui/divider/divider.types.ts
+++ b/app/_components/ui/divider/divider.types.ts
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react';
+
+export interface PropsDividerX {
+  children?: ReactNode;
+  style: HTMLElement['className'];
+}
+
+export interface PropsDividerY {
+  style: HTMLElement['className'];
+}

--- a/app/_components/ui/divider/dividerX/__test__/dividerX.test.tsx
+++ b/app/_components/ui/divider/dividerX/__test__/dividerX.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { DividerX } from '..';
+import { styleDividerX } from '../../divider.styles';
+import { PropsDividerX } from '../../divider.types';
+
+describe('DividerX', () => {
+  const renderWithDividerX = ({ children, style }: PropsDividerX) =>
+    render(<DividerX style={style}>{children}</DividerX>);
+  const childElement = 'test-childElement';
+
+  it('should render the props correctly when the value of props have been passed into', () => {
+    renderWithDividerX({ children: childElement, style: styleDividerX({ width: 'full' }) });
+
+    const dividerWithChildElement = screen.getByText(childElement);
+    const dividerXComponent = screen.getByTestId('dividerX-testid');
+
+    expect(dividerWithChildElement).toBeInTheDocument();
+    expect(dividerXComponent).toHaveClass(styleDividerX({ width: 'full' }));
+  });
+});

--- a/app/_components/ui/divider/dividerX/index.tsx
+++ b/app/_components/ui/divider/dividerX/index.tsx
@@ -1,0 +1,22 @@
+import { PropsDividerX } from '../divider.types';
+
+export const DividerX = ({ children, style }: PropsDividerX) => {
+  return (
+    <div className='relative'>
+      <div
+        className='absolute inset-0 flex items-center justify-center'
+        aria-hidden='true'
+      >
+        <div
+          className={style}
+          data-testid='dividerX-testid'
+        />
+      </div>
+      {!!children && (
+        <div className='relative flex justify-center'>
+          <span className='bg-slate-50 px-2 text-sm text-gray-500'>{children}</span>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/app/_components/ui/divider/dividerY/__test__/dividerY.test.tsx
+++ b/app/_components/ui/divider/dividerY/__test__/dividerY.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { DividerY } from '..';
+import { PropsDividerY } from '../../divider.types';
+import { styleDividerY } from '../../divider.styles';
+
+describe('DividerY', () => {
+  const renderWithDividerY = ({ style }: PropsDividerY) => render(<DividerY style={style} />);
+
+  it('should render the style props properly', () => {
+    renderWithDividerY({ style: styleDividerY({ type: 'primary', color: 'primary' }) });
+
+    const dividerYComponent = screen.getByTestId('dividerY-testid');
+
+    expect(dividerYComponent).toBeInTheDocument();
+    expect(dividerYComponent).toHaveClass(styleDividerY({ type: 'primary', color: 'primary' }));
+  });
+});

--- a/app/_components/ui/divider/dividerY/index.tsx
+++ b/app/_components/ui/divider/dividerY/index.tsx
@@ -1,0 +1,13 @@
+import { PropsDividerY } from '../divider.types';
+
+export const DividerY = ({ style }: PropsDividerY) => {
+  return (
+    <div
+      className={style}
+      data-testid='dividerY-testid'
+    >
+      <div className='w-1' />
+      <div className='w-1' />
+    </div>
+  );
+};

--- a/app/v2/page.tsx
+++ b/app/v2/page.tsx
@@ -2,6 +2,8 @@ import { SectionContent } from '@/section/sectionContent';
 import { SectionHeader } from '@/section/sectionHeader';
 import { SectionHero } from '@/section/sectionHero';
 import { SectionStartToday } from '@/section/sectionStartToday';
+import { styleDividerY } from '@/ui/divider/divider.styles';
+import { DividerY } from '@/ui/divider/dividerY';
 
 const Home = () => {
   return (
@@ -10,6 +12,7 @@ const Home = () => {
       <SectionHeader />
       <SectionContent />
       <SectionStartToday />
+      <DividerY style={styleDividerY()} />
     </>
   );
 };


### PR DESCRIPTION
Move DividerX and DividerY components from pageRouter to appRouter. Apply minor modifications and include unit tests for each component.