### PR TITLE
feat: Remove the options 'all'

### DIFF
--- a/app/_components/ui/button/signInButton/signInButton.configs.ts
+++ b/app/_components/ui/button/signInButton/signInButton.configs.ts
@@ -14,7 +14,7 @@ export const configsSignInButton = createConfigs({
       getStarted: 'Go to sign in',
     },
     className: {
-      default: {
+      all: {
         button: styleButton({ className: 'max-ml:mb-3' }),
       },
     },
@@ -36,6 +36,6 @@ export const configsSignInButton = createConfigs({
   },
   defaultOptions: {
     buttonName: 'signIn',
-    className: 'default',
+    className: 'all',
   },
 });

--- a/app/_components/ui/tooltip/tooltip.configs.ts
+++ b/app/_components/ui/tooltip/tooltip.configs.ts
@@ -10,7 +10,7 @@ const delayProperty = {
 export const configsTooltip = createConfigs({
   options: {
     className: {
-      default: {
+      all: {
         tooltip:
           'z-50 max-w-[15rem] truncate whitespace-nowrap rounded-lg bg-gray-700 p-2 text-xs text-white opacity-90',
         kbd: 'ml-2 h-6 rounded border-x border-y py-px px-1.5 font-sans tracking-normal subpixel-antialiased',
@@ -71,6 +71,6 @@ export const configsTooltip = createConfigs({
     offset: 'base',
     delayShow: '50',
     delayHide: '50',
-    className: 'default',
+    className: 'all',
   },
 });

--- a/app/_lib/utils/configs.utils.ts
+++ b/app/_lib/utils/configs.utils.ts
@@ -7,19 +7,17 @@ type TypesOptions<T, S extends string> = {
 };
 type TypesConfigs<T, P extends string> = {
   options: T;
-  defaultOptions: Partial<{ [K in keyof T]: keyof T[K] | 'all' | null | undefined }>;
-  presetOptions?: Partial<Record<P, Partial<{ [K in keyof T]: keyof T[K] | 'all' | null | undefined }>>>;
+  defaultOptions: Partial<{ [K in keyof T]: keyof T[K] | null | undefined }>;
+  presetOptions?: Partial<Record<P, Partial<{ [K in keyof T]: keyof T[K] | null | undefined }>>>;
   extendOptions?: object[];
 };
 
 export const createConfigs = <T extends TypesOptions<T, S>, S extends string, P extends string = never>(
   config: TypesConfigs<T, P>,
-): ((props?: Partial<{ [K in keyof T]: keyof T[K] | 'all' } & { preset?: P }>) => {
+): ((props?: Partial<{ [K in keyof T]: keyof T[K] } & { preset?: P }>) => {
   [K in keyof T]: T[K][keyof T[K]];
 }) => {
-  return (
-    props?: Partial<{ [K in keyof T]: keyof T[K] | 'all' } & { preset?: P }>,
-  ): { [K in keyof T]: T[K][keyof T[K]] } => {
+  return (props?: Partial<{ [K in keyof T]: keyof T[K] } & { preset?: P }>): { [K in keyof T]: T[K][keyof T[K]] } => {
     const { defaultOptions, options, presetOptions, extendOptions } = config;
 
     const result: { [K in keyof T]?: T[K][keyof T[K]] | null } = {};
@@ -28,16 +26,13 @@ export const createConfigs = <T extends TypesOptions<T, S>, S extends string, P 
     for (const key in options) {
       const k = key as keyof T;
       const getVariant = (k: keyof T) => {
-        if (props?.hasOwnProperty(k)) return props[k] === 'all' ? 'all' : props[k];
-        if (preset?.hasOwnProperty(k))
-          return preset[k] === 'all' ? 'all' : preset[k] !== undefined ? preset[k] : defaultOptions[k];
-        return defaultOptions[k] === 'all' ? 'all' : defaultOptions[k];
+        if (props?.hasOwnProperty(k)) return props[k];
+        if (preset?.hasOwnProperty(k)) return preset[k] !== undefined ? preset[k] : defaultOptions[k];
+        return defaultOptions[k];
       };
       const variant = getVariant(k);
 
-      if (variant === 'all') {
-        result[k] = options[k] as unknown as T[keyof T][keyof T[keyof T]] | null | undefined;
-      } else if (variant !== undefined && options[k].hasOwnProperty(variant as PropertyKey)) {
+      if (variant !== undefined && options[k].hasOwnProperty(variant as PropertyKey)) {
         result[k] = options[k][variant as keyof T[keyof T]];
       }
       if (variant === null) {


### PR DESCRIPTION
Remove the option 'all' from the createConfigs util function due to the limitation of typescript inferring types dynamically.